### PR TITLE
Updated imports and docs for spdx/tools-golang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ before_install:
   - go get github.com/mattn/goveralls
 
 script:
-  - go test -coverprofile=spdx-go.cov ./v0/...
-  - $GOPATH/bin/goveralls -coverprofile=spdx-go.cov -service=travis-ci
+  - go test -coverprofile=tools-golang.cov ./v0/...
+  - $GOPATH/bin/goveralls -coverprofile=tools-golang.cov -service=travis-ci

--- a/LICENSE-code.txt
+++ b/LICENSE-code.txt
@@ -1,4 +1,4 @@
-The spdx-go source code is provided and may be used, at your option,
+The tools-golang source code is provided and may be used, at your option,
 under either:
 * Apache License, version 2.0 (Apache-2.0), OR
 * GNU General Public License, version 2.0 or later (GPL-2.0-or-later).

--- a/LICENSE-docs.txt
+++ b/LICENSE-docs.txt
@@ -1,4 +1,4 @@
-The spdx-go documentation is provided under the Creative Commons Attribution
+The tools-golang documentation is provided under the Creative Commons Attribution
 4.0 International license (CC-BY-4.0), a copy of which is provided below.
 
 Attribution 4.0 International

--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
-[![Build Status](https://travis-ci.org/swinslow/spdx-go.svg?branch=master)](https://travis-ci.org/swinslow/spdx-go)
-[![Coverage Status](https://coveralls.io/repos/github/swinslow/spdx-go/badge.svg)](https://coveralls.io/github/swinslow/spdx-go)
+[![Build Status](https://travis-ci.org/spdx/tools-golang.svg?branch=master)](https://travis-ci.org/spdx/tools-golang)
+[![Coverage Status](https://coveralls.io/repos/github/spdx/tools-golang/badge.svg)](https://coveralls.io/github/spdx/tools-golang)
 
-SPDX-License-Identifier: CC-BY-4.0
+# tools-golang
 
-# spdx-go
+tools-golang is a collection of Go packages intended to make it easier for
+Go programs to work with [SPDX®](https://spdx.org/) files.
 
-spdx-go is a collection of Go packages intended to make it easier for Go
-programs to work with [SPDX®](https://spdx.org/) files.
-
-This software is in an early state, and its API may change significantly (hence the "v0/" directory).
+This software is in an early state, and its API may change significantly
+(hence the "v0/" directory).
 
 ## What it does
 
-spdx-go currently works with files conformant to version 2.1 of the SPDX
-specification, available at: https://spdx.org/specifications
+tools-golang currently works with files conformant to version 2.1 of the
+SPDX specification, available at: https://spdx.org/specifications
 
-spdx-go provides the following packages:
+tools-golang provides the following packages:
 
 * *v0/spdx* - in-memory data model for the sections of an SPDX document
 * *v0/tvloader* - tag-value file loader
@@ -24,13 +23,14 @@ spdx-go provides the following packages:
 * *v0/idsearcher* - searches for [SPDX short-form IDs](https://spdx.org/ids/) and builds SPDX document
 * *v0/licensediff* - compares concluded licenses between files in two packages
 * *v0/reporter* - generates basic license count report from SPDX document
-* *v0/utils* - various utility functions that support the other spdx-go packages
+* *v0/utils* - various utility functions that support the other tools-golang packages
 
-Examples for how to use these packages can be found in the `examples/` directory.
+Examples for how to use these packages can be found in the `examples/`
+directory.
 
 ## What it doesn't do
 
-spdx-go doesn't currently do any of the following:
+tools-golang doesn't currently do any of the following:
 
 * work with files under any version of the SPDX spec *other than* v2.1
 * work with RDF files
@@ -38,23 +38,25 @@ spdx-go doesn't currently do any of the following:
 * enable applications to interact with SPDX files without needing to care
   (too much) about the particular SPDX file version
 
-As a long-term goal, I am hoping to enable each of these. Code contributions
+We are working towards adding functionality for all of these. Code contributions
 are welcome!
 
 ## Requirements
 
-At present, spdx-go does not require anything outside the Go standard library.
+At present, tools-golang does not require anything outside the Go standard
+library.
 
 ## Licenses
 
-As indicated in `LICENSE-code.txt`, spdx-go **source code files** are provided
-and may be used, at your option, under *either*:
+As indicated in `LICENSE-code.txt`, tools-golang **source code files** are
+provided and may be used, at your option, under *either*:
 * Apache License, version 2.0 (**Apache-2.0**), **OR**
 * GNU General Public License, version 2.0 or later (**GPL-2.0-or-later**).
 
-As indicated in `LICENSE-docs.txt`, spdx-go **documentation files** are
+As indicated in `LICENSE-docs.txt`, tools-golang **documentation files** are
 provided and may be used under the Creative Commons Attribution
 4.0 International license (**CC-BY-4.0**).
 
-This `README.md` file is documentation, hence the CC-BY-4.0 license ID at
-the top of the file.
+This `README.md` file is documentation:
+
+`SPDX-License-Identifier: CC-BY-4.0`

--- a/examples/1-load/example_load.go
+++ b/examples/1-load/example_load.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/swinslow/spdx-go/v0/tvloader"
+	"github.com/spdx/tools-golang/v0/tvloader"
 )
 
 func main() {

--- a/examples/2-load-save/example_load_save.go
+++ b/examples/2-load-save/example_load_save.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/swinslow/spdx-go/v0/tvloader"
-	"github.com/swinslow/spdx-go/v0/tvsaver"
+	"github.com/spdx/tools-golang/v0/tvloader"
+	"github.com/spdx/tools-golang/v0/tvsaver"
 )
 
 func main() {

--- a/examples/3-build/example_build.go
+++ b/examples/3-build/example_build.go
@@ -12,8 +12,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/swinslow/spdx-go/v0/builder"
-	"github.com/swinslow/spdx-go/v0/tvsaver"
+	"github.com/spdx/tools-golang/v0/builder"
+	"github.com/spdx/tools-golang/v0/tvsaver"
 )
 
 func main() {
@@ -56,7 +56,7 @@ func main() {
 
 		// note that builder will also add the following, in addition to the
 		// Creator defined above:
-		// Creator: Tool: github.com/swinslow/spdx-go/v0/builder
+		// Creator: Tool: github.com/spdx/tools-golang/v0/builder
 
 		// Finally, you can define one or more paths that should be ignored
 		// when walking through the directory. This is intended to omit files

--- a/examples/4-search/example_search.go
+++ b/examples/4-search/example_search.go
@@ -14,9 +14,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/swinslow/spdx-go/v0/idsearcher"
+	"github.com/spdx/tools-golang/v0/idsearcher"
 
-	"github.com/swinslow/spdx-go/v0/tvsaver"
+	"github.com/spdx/tools-golang/v0/tvsaver"
 )
 
 func main() {
@@ -52,8 +52,8 @@ func main() {
 		// CreatorType and Creator, from builder.Config2_1, are not needed for
 		// idsearcher.Config. Because it is automated and doesn't assume
 		// further review, the following two Creator fields are filled in:
-		// Creator: Tool: github.com/swinslow/spdx-go/v0/builder
-		// Creator: Tool: github.com/swinslow/spdx-go/v0/idsearcher
+		// Creator: Tool: github.com/spdx/tools-golang/v0/builder
+		// Creator: Tool: github.com/spdx/tools-golang/v0/idsearcher
 
 		// You can define one or more paths that should be ignored
 		// when walking through the directory. This is intended to omit files

--- a/examples/5-report/example_report.go
+++ b/examples/5-report/example_report.go
@@ -12,8 +12,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/swinslow/spdx-go/v0/reporter"
-	"github.com/swinslow/spdx-go/v0/tvloader"
+	"github.com/spdx/tools-golang/v0/reporter"
+	"github.com/spdx/tools-golang/v0/tvloader"
 )
 
 func main() {

--- a/examples/6-licensediff/example_licensediff.go
+++ b/examples/6-licensediff/example_licensediff.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/swinslow/spdx-go/v0/licensediff"
-	"github.com/swinslow/spdx-go/v0/tvloader"
+	"github.com/spdx/tools-golang/v0/licensediff"
+	"github.com/spdx/tools-golang/v0/tvloader"
 )
 
 func main() {

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,9 @@
 SPDX-License-Identifier: CC-BY-4.0
 
-# spdx-go Examples
+# tools-golang Examples
 
-The `examples/` directory contains examples for how to use the various spdx-go sub-packages.
+The `examples/` directory contains examples for how to use the various
+tools-golang sub-packages.
 
 ## 1-load/
 

--- a/v0/builder/build.go
+++ b/v0/builder/build.go
@@ -1,12 +1,12 @@
-// Package builder is used to create spdx-go data structures for a given
+// Package builder is used to create tools-golang data structures for a given
 // directory path's contents, with hashes, etc. filled in and with empty
 // license data.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 package builder
 
 import (
-	"github.com/swinslow/spdx-go/v0/builder/builder2v1"
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/builder/builder2v1"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // Config2_1 is a collection of configuration settings for builder

--- a/v0/builder/build_test.go
+++ b/v0/builder/build_test.go
@@ -58,8 +58,8 @@ func TestBuild2_1CreatesDocument(t *testing.T) {
 	if len(doc.CreationInfo.CreatorTools) != 1 {
 		t.Fatalf("expected %d, got %d", 1, len(doc.CreationInfo.CreatorTools))
 	}
-	if doc.CreationInfo.CreatorTools[0] != "github.com/swinslow/spdx-go/v0/builder" {
-		t.Errorf("expected %s, got %s", "github.com/swinslow/spdx-go/v0/builder", doc.CreationInfo.CreatorTools[0])
+	if doc.CreationInfo.CreatorTools[0] != "github.com/spdx/tools-golang/v0/builder" {
+		t.Errorf("expected %s, got %s", "github.com/spdx/tools-golang/v0/builder", doc.CreationInfo.CreatorTools[0])
 	}
 	if doc.CreationInfo.Created != "2018-10-19T04:38:00Z" {
 		t.Errorf("expected %s, got %s", "2018-10-19T04:38:00Z", doc.CreationInfo.Created)

--- a/v0/builder/builder2v1/build_creation_info.go
+++ b/v0/builder/builder2v1/build_creation_info.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // BuildCreationInfoSection2_1 creates an SPDX Package (version 2.1), returning that
@@ -23,7 +23,7 @@ func BuildCreationInfoSection2_1(packageName string, code string, namespacePrefi
 	cOrganizations := []string{}
 	cTools := []string{}
 	// add builder as a tool
-	cTools = append(cTools, "github.com/swinslow/spdx-go/v0/builder")
+	cTools = append(cTools, "github.com/spdx/tools-golang/v0/builder")
 
 	switch creatorType {
 	case "Person":

--- a/v0/builder/builder2v1/build_creation_info_test.go
+++ b/v0/builder/builder2v1/build_creation_info_test.go
@@ -54,8 +54,8 @@ func TestBuilder2_1CanBuildCreationInfoSection(t *testing.T) {
 	if len(ci.CreatorTools) != 1 {
 		t.Fatalf("expected %d, got %d", 1, len(ci.CreatorTools))
 	}
-	if ci.CreatorTools[0] != "github.com/swinslow/spdx-go/v0/builder" {
-		t.Errorf("expected %s, got %s", "github.com/swinslow/spdx-go/v0/builder", ci.CreatorTools[0])
+	if ci.CreatorTools[0] != "github.com/spdx/tools-golang/v0/builder" {
+		t.Errorf("expected %s, got %s", "github.com/spdx/tools-golang/v0/builder", ci.CreatorTools[0])
 	}
 	if ci.Created != "2018-10-20T16:48:00Z" {
 		t.Errorf("expected %s, got %s", "2018-10-20T16:48:00Z", ci.Created)
@@ -91,8 +91,8 @@ func TestBuilder2_1CanBuildCreationInfoSectionWithCreatorPerson(t *testing.T) {
 	if len(ci.CreatorTools) != 1 {
 		t.Fatalf("expected %d, got %d", 1, len(ci.CreatorTools))
 	}
-	if ci.CreatorTools[0] != "github.com/swinslow/spdx-go/v0/builder" {
-		t.Errorf("expected %s, got %s", "github.com/swinslow/spdx-go/v0/builder", ci.CreatorTools[0])
+	if ci.CreatorTools[0] != "github.com/spdx/tools-golang/v0/builder" {
+		t.Errorf("expected %s, got %s", "github.com/spdx/tools-golang/v0/builder", ci.CreatorTools[0])
 	}
 }
 
@@ -122,8 +122,8 @@ func TestBuilder2_1CanBuildCreationInfoSectionWithCreatorTool(t *testing.T) {
 	if len(ci.CreatorTools) != 2 {
 		t.Fatalf("expected %d, got %d", 2, len(ci.CreatorTools))
 	}
-	if ci.CreatorTools[0] != "github.com/swinslow/spdx-go/v0/builder" {
-		t.Errorf("expected %s, got %s", "github.com/swinslow/spdx-go/v0/builder", ci.CreatorTools[0])
+	if ci.CreatorTools[0] != "github.com/spdx/tools-golang/v0/builder" {
+		t.Errorf("expected %s, got %s", "github.com/spdx/tools-golang/v0/builder", ci.CreatorTools[0])
 	}
 	if ci.CreatorTools[1] != "some-other-tool-2.1" {
 		t.Errorf("expected %s, got %s", "some-other-tool-2.1", ci.CreatorTools[1])
@@ -159,7 +159,7 @@ func TestBuilder2_1CanBuildCreationInfoSectionWithInvalidPerson(t *testing.T) {
 	if len(ci.CreatorTools) != 1 {
 		t.Fatalf("expected %d, got %d", 1, len(ci.CreatorTools))
 	}
-	if ci.CreatorTools[0] != "github.com/swinslow/spdx-go/v0/builder" {
-		t.Errorf("expected %s, got %s", "github.com/swinslow/spdx-go/v0/builder", ci.CreatorTools[0])
+	if ci.CreatorTools[0] != "github.com/spdx/tools-golang/v0/builder" {
+		t.Errorf("expected %s, got %s", "github.com/spdx/tools-golang/v0/builder", ci.CreatorTools[0])
 	}
 }

--- a/v0/builder/builder2v1/build_file.go
+++ b/v0/builder/builder2v1/build_file.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
-	"github.com/swinslow/spdx-go/v0/utils"
+	"github.com/spdx/tools-golang/v0/spdx"
+	"github.com/spdx/tools-golang/v0/utils"
 )
 
 // BuildFileSection2_1 creates an SPDX File (version 2.1), returning that

--- a/v0/builder/builder2v1/build_package.go
+++ b/v0/builder/builder2v1/build_package.go
@@ -5,8 +5,8 @@ package builder2v1
 import (
 	"fmt"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
-	"github.com/swinslow/spdx-go/v0/utils"
+	"github.com/spdx/tools-golang/v0/spdx"
+	"github.com/spdx/tools-golang/v0/utils"
 )
 
 // BuildPackageSection2_1 creates an SPDX Package (version 2.1), returning

--- a/v0/builder/builder2v1/build_relationship.go
+++ b/v0/builder/builder2v1/build_relationship.go
@@ -5,7 +5,7 @@ package builder2v1
 import (
 	"fmt"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // BuildRelationshipSection2_1 creates an SPDX Relationship (version 2.1)

--- a/v0/idsearcher/idsearcher.go
+++ b/v0/idsearcher/idsearcher.go
@@ -13,9 +13,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/swinslow/spdx-go/v0/builder"
-	"github.com/swinslow/spdx-go/v0/spdx"
-	"github.com/swinslow/spdx-go/v0/utils"
+	"github.com/spdx/tools-golang/v0/builder"
+	"github.com/spdx/tools-golang/v0/spdx"
+	"github.com/spdx/tools-golang/v0/utils"
 )
 
 // Config is a collection of configuration settings for docbuilder
@@ -53,7 +53,7 @@ func BuildIDsDocument(packageName string, dirRoot string, idconfig *Config) (*sp
 	bconfig := &builder.Config2_1{
 		NamespacePrefix: idconfig.NamespacePrefix,
 		CreatorType:     "Tool",
-		Creator:         "github.com/swinslow/spdx-go/v0/idsearcher",
+		Creator:         "github.com/spdx/tools-golang/v0/idsearcher",
 		PathsIgnored:    idconfig.BuilderPathsIgnored,
 	}
 	doc, err := builder.Build2_1(packageName, dirRoot, bconfig)

--- a/v0/licensediff/licensediff.go
+++ b/v0/licensediff/licensediff.go
@@ -4,7 +4,7 @@
 package licensediff
 
 import (
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // LicensePair is a result set where we are talking about two license strings,

--- a/v0/licensediff/licensediff_test.go
+++ b/v0/licensediff/licensediff_test.go
@@ -5,7 +5,7 @@ package licensediff
 import (
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== License diff top-level function tests =====

--- a/v0/reporter/reporter.go
+++ b/v0/reporter/reporter.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"text/tabwriter"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // Generate takes a Package whose Files have been analyzed and an

--- a/v0/reporter/reporter_test.go
+++ b/v0/reporter/reporter_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Reporter top-level function tests =====

--- a/v0/tvloader/parser2v1/parse_annotation_test.go
+++ b/v0/tvloader/parser2v1/parse_annotation_test.go
@@ -4,7 +4,7 @@ package parser2v1
 import (
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Annotation section tests =====

--- a/v0/tvloader/parser2v1/parse_creation_info.go
+++ b/v0/tvloader/parser2v1/parse_creation_info.go
@@ -5,7 +5,7 @@ package parser2v1
 import (
 	"fmt"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func (parser *tvParser2_1) parsePairFromCreationInfo2_1(tag string, value string) error {

--- a/v0/tvloader/parser2v1/parse_creation_info_test.go
+++ b/v0/tvloader/parser2v1/parse_creation_info_test.go
@@ -4,7 +4,7 @@ package parser2v1
 import (
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Parser creation info state change tests =====

--- a/v0/tvloader/parser2v1/parse_file.go
+++ b/v0/tvloader/parser2v1/parse_file.go
@@ -5,7 +5,7 @@ package parser2v1
 import (
 	"fmt"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func (parser *tvParser2_1) parsePairFromFile2_1(tag string, value string) error {

--- a/v0/tvloader/parser2v1/parse_file_test.go
+++ b/v0/tvloader/parser2v1/parse_file_test.go
@@ -4,7 +4,7 @@ package parser2v1
 import (
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Parser file section state change tests =====

--- a/v0/tvloader/parser2v1/parse_other_license.go
+++ b/v0/tvloader/parser2v1/parse_other_license.go
@@ -5,7 +5,7 @@ package parser2v1
 import (
 	"fmt"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func (parser *tvParser2_1) parsePairFromOtherLicense2_1(tag string, value string) error {

--- a/v0/tvloader/parser2v1/parse_other_license_test.go
+++ b/v0/tvloader/parser2v1/parse_other_license_test.go
@@ -4,7 +4,7 @@ package parser2v1
 import (
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Parser other license section state change tests =====

--- a/v0/tvloader/parser2v1/parse_package.go
+++ b/v0/tvloader/parser2v1/parse_package.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func (parser *tvParser2_1) parsePairFromPackage2_1(tag string, value string) error {

--- a/v0/tvloader/parser2v1/parse_package_test.go
+++ b/v0/tvloader/parser2v1/parse_package_test.go
@@ -4,7 +4,7 @@ package parser2v1
 import (
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Parser package section state change tests =====

--- a/v0/tvloader/parser2v1/parse_relationship_test.go
+++ b/v0/tvloader/parser2v1/parse_relationship_test.go
@@ -4,7 +4,7 @@ package parser2v1
 import (
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Relationship section tests =====

--- a/v0/tvloader/parser2v1/parse_review.go
+++ b/v0/tvloader/parser2v1/parse_review.go
@@ -5,7 +5,7 @@ package parser2v1
 import (
 	"fmt"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func (parser *tvParser2_1) parsePairFromReview2_1(tag string, value string) error {

--- a/v0/tvloader/parser2v1/parse_review_test.go
+++ b/v0/tvloader/parser2v1/parse_review_test.go
@@ -4,7 +4,7 @@ package parser2v1
 import (
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Parser review section state change tests =====

--- a/v0/tvloader/parser2v1/parse_snippet.go
+++ b/v0/tvloader/parser2v1/parse_snippet.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func (parser *tvParser2_1) parsePairFromSnippet2_1(tag string, value string) error {

--- a/v0/tvloader/parser2v1/parse_snippet_test.go
+++ b/v0/tvloader/parser2v1/parse_snippet_test.go
@@ -4,7 +4,7 @@ package parser2v1
 import (
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Parser snippet section state change tests =====

--- a/v0/tvloader/parser2v1/parser.go
+++ b/v0/tvloader/parser2v1/parser.go
@@ -6,8 +6,8 @@ package parser2v1
 import (
 	"fmt"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
-	"github.com/swinslow/spdx-go/v0/tvloader/reader"
+	"github.com/spdx/tools-golang/v0/spdx"
+	"github.com/spdx/tools-golang/v0/tvloader/reader"
 )
 
 // ParseTagValues takes a list of (tag, value) pairs, parses it and returns

--- a/v0/tvloader/parser2v1/parser_test.go
+++ b/v0/tvloader/parser2v1/parser_test.go
@@ -4,7 +4,7 @@ package parser2v1
 import (
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/tvloader/reader"
+	"github.com/spdx/tools-golang/v0/tvloader/reader"
 )
 
 // ===== Parser exported entry point tests =====

--- a/v0/tvloader/parser2v1/types.go
+++ b/v0/tvloader/parser2v1/types.go
@@ -3,7 +3,7 @@
 package parser2v1
 
 import (
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 type tvParser2_1 struct {

--- a/v0/tvloader/tvloader.go
+++ b/v0/tvloader/tvloader.go
@@ -1,14 +1,14 @@
 // Package tvloader is used to load and parse SPDX tag-value documents
-// into spdx-go data structures.
+// into tools-golang data structures.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 package tvloader
 
 import (
 	"io"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
-	"github.com/swinslow/spdx-go/v0/tvloader/parser2v1"
-	"github.com/swinslow/spdx-go/v0/tvloader/reader"
+	"github.com/spdx/tools-golang/v0/spdx"
+	"github.com/spdx/tools-golang/v0/tvloader/parser2v1"
+	"github.com/spdx/tools-golang/v0/tvloader/reader"
 )
 
 // Load2_1 takes an io.Reader and returns a fully-parsed SPDX Document

--- a/v0/tvsaver/saver2v1/save_annotation.go
+++ b/v0/tvsaver/saver2v1/save_annotation.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func renderAnnotation2_1(ann *spdx.Annotation2_1, w io.Writer) error {

--- a/v0/tvsaver/saver2v1/save_annotation_test.go
+++ b/v0/tvsaver/saver2v1/save_annotation_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Annotation section Saver tests =====

--- a/v0/tvsaver/saver2v1/save_creation_info.go
+++ b/v0/tvsaver/saver2v1/save_creation_info.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func renderCreationInfo2_1(ci *spdx.CreationInfo2_1, w io.Writer) error {

--- a/v0/tvsaver/saver2v1/save_creation_info_test.go
+++ b/v0/tvsaver/saver2v1/save_creation_info_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Creation Info section Saver tests =====

--- a/v0/tvsaver/saver2v1/save_document.go
+++ b/v0/tvsaver/saver2v1/save_document.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // RenderDocument2_1 is the main entry point to take an SPDX in-memory

--- a/v0/tvsaver/saver2v1/save_document_test.go
+++ b/v0/tvsaver/saver2v1/save_document_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== entire Document Saver tests =====

--- a/v0/tvsaver/saver2v1/save_file.go
+++ b/v0/tvsaver/saver2v1/save_file.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func renderFile2_1(f *spdx.File2_1, w io.Writer) error {

--- a/v0/tvsaver/saver2v1/save_file_test.go
+++ b/v0/tvsaver/saver2v1/save_file_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== File section Saver tests =====

--- a/v0/tvsaver/saver2v1/save_other_license.go
+++ b/v0/tvsaver/saver2v1/save_other_license.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func renderOtherLicense2_1(ol *spdx.OtherLicense2_1, w io.Writer) error {

--- a/v0/tvsaver/saver2v1/save_other_license_test.go
+++ b/v0/tvsaver/saver2v1/save_other_license_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Other License section Saver tests =====

--- a/v0/tvsaver/saver2v1/save_package.go
+++ b/v0/tvsaver/saver2v1/save_package.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func renderPackage2_1(pkg *spdx.Package2_1, w io.Writer) error {

--- a/v0/tvsaver/saver2v1/save_package_test.go
+++ b/v0/tvsaver/saver2v1/save_package_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Package section Saver tests =====

--- a/v0/tvsaver/saver2v1/save_relationship.go
+++ b/v0/tvsaver/saver2v1/save_relationship.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func renderRelationship2_1(rln *spdx.Relationship2_1, w io.Writer) error {

--- a/v0/tvsaver/saver2v1/save_relationship_test.go
+++ b/v0/tvsaver/saver2v1/save_relationship_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Relationship section Saver tests =====

--- a/v0/tvsaver/saver2v1/save_review.go
+++ b/v0/tvsaver/saver2v1/save_review.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func renderReview2_1(rev *spdx.Review2_1, w io.Writer) error {

--- a/v0/tvsaver/saver2v1/save_review_test.go
+++ b/v0/tvsaver/saver2v1/save_review_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Review section Saver tests =====

--- a/v0/tvsaver/saver2v1/save_snippet.go
+++ b/v0/tvsaver/saver2v1/save_snippet.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 func renderSnippet2_1(sn *spdx.Snippet2_1, w io.Writer) error {

--- a/v0/tvsaver/saver2v1/save_snippet_test.go
+++ b/v0/tvsaver/saver2v1/save_snippet_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Snippet section Saver tests =====

--- a/v0/tvsaver/tvsaver.go
+++ b/v0/tvsaver/tvsaver.go
@@ -1,4 +1,4 @@
-// Package tvsaver is used to save spdx-go data structures
+// Package tvsaver is used to save tools-golang data structures
 // as SPDX tag-value documents.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 package tvsaver
@@ -6,8 +6,8 @@ package tvsaver
 import (
 	"io"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
-	"github.com/swinslow/spdx-go/v0/tvsaver/saver2v1"
+	"github.com/spdx/tools-golang/v0/spdx"
+	"github.com/spdx/tools-golang/v0/tvsaver/saver2v1"
 )
 
 // Save2_1 takes an io.Writer and an SPDX Document (version 2.1),

--- a/v0/utils/filesystem.go
+++ b/v0/utils/filesystem.go
@@ -1,5 +1,5 @@
 // Package utils contains various utility functions to support the
-// main spdx-go packages.
+// main tools-golang packages.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 package utils
 

--- a/v0/utils/verification.go
+++ b/v0/utils/verification.go
@@ -1,5 +1,5 @@
 // Package utils contains various utility functions to support the
-// main spdx-go packages.
+// main tools-golang packages.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 package utils
 
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // GetVerificationCode2_1 takes a slice of files and an optional filename

--- a/v0/utils/verification_test.go
+++ b/v0/utils/verification_test.go
@@ -5,7 +5,7 @@ package utils
 import (
 	"testing"
 
-	"github.com/swinslow/spdx-go/v0/spdx"
+	"github.com/spdx/tools-golang/v0/spdx"
 )
 
 // ===== Verification code functionality tests =====


### PR DESCRIPTION
Changed import paths and documentation to refer to spdx/tools-golang rather than swinslow/spdx-go, and made other related conforming edits.

Fixes #1 

Signed-off-by: Steve Winslow <swinslow@gmail.com>