### PR TITLE
Fix tvloader parsing Relationships and Annotations

### DIFF
--- a/docs/tvloader-assumptions.md
+++ b/docs/tvloader-assumptions.md
@@ -26,22 +26,9 @@ Other License Info
 * Any Other License section, if present, will come later than the Document
   Creation Info section and after any Package, File and Snippet sections.
 
-* Additionally, any Other License section will not have Relationship or
-  Annotation sections.
-
-* An implication of the preceding two points is that the Other License sections
-  should be the final sections in a v2.1 tag-value document, unless it is
-  followed by a (deprecated as of v2.1) Review Information section.
-
 Review
 ------
 * Review sections will begin with the "Reviewer" tag.
 
 * Any Review section, if present, will come later than the Document Creation
   Info section and after any Package, File, Snippet, and Other License sections.
-
-* Additionally, any Review section will not have Relationship or
-  Annotation sections.
-
-* An implication of the preceding two points is that the Review sections
-  should be the final sections in a v2.1 tag-value document.

--- a/v0/tvloader/parser2v1/parse_other_license.go
+++ b/v0/tvloader/parser2v1/parse_other_license.go
@@ -23,6 +23,26 @@ func (parser *tvParser2_1) parsePairFromOtherLicense2_1(tag string, value string
 		parser.otherLic.LicenseCrossReferences = append(parser.otherLic.LicenseCrossReferences, value)
 	case "LicenseComment":
 		parser.otherLic.LicenseComment = value
+	// for relationship tags, pass along but don't change state
+	case "Relationship":
+		parser.rln = &spdx.Relationship2_1{}
+		parser.doc.Relationships = append(parser.doc.Relationships, parser.rln)
+		return parser.parsePairForRelationship2_1(tag, value)
+	case "RelationshipComment":
+		return parser.parsePairForRelationship2_1(tag, value)
+	// for annotation tags, pass along but don't change state
+	case "Annotator":
+		parser.ann = &spdx.Annotation2_1{}
+		parser.doc.Annotations = append(parser.doc.Annotations, parser.ann)
+		return parser.parsePairForAnnotation2_1(tag, value)
+	case "AnnotationDate":
+		return parser.parsePairForAnnotation2_1(tag, value)
+	case "AnnotationType":
+		return parser.parsePairForAnnotation2_1(tag, value)
+	case "SPDXREF":
+		return parser.parsePairForAnnotation2_1(tag, value)
+	case "AnnotationComment":
+		return parser.parsePairForAnnotation2_1(tag, value)
 	// tag for going on to review section (DEPRECATED)
 	case "Reviewer":
 		parser.st = psReview2_1

--- a/v0/tvloader/parser2v1/parse_review.go
+++ b/v0/tvloader/parser2v1/parse_review.go
@@ -35,6 +35,26 @@ func (parser *tvParser2_1) parsePairFromReview2_1(tag string, value string) erro
 		parser.rev.ReviewDate = value
 	case "ReviewComment":
 		parser.rev.ReviewComment = value
+	// for relationship tags, pass along but don't change state
+	case "Relationship":
+		parser.rln = &spdx.Relationship2_1{}
+		parser.doc.Relationships = append(parser.doc.Relationships, parser.rln)
+		return parser.parsePairForRelationship2_1(tag, value)
+	case "RelationshipComment":
+		return parser.parsePairForRelationship2_1(tag, value)
+	// for annotation tags, pass along but don't change state
+	case "Annotator":
+		parser.ann = &spdx.Annotation2_1{}
+		parser.doc.Annotations = append(parser.doc.Annotations, parser.ann)
+		return parser.parsePairForAnnotation2_1(tag, value)
+	case "AnnotationDate":
+		return parser.parsePairForAnnotation2_1(tag, value)
+	case "AnnotationType":
+		return parser.parsePairForAnnotation2_1(tag, value)
+	case "SPDXREF":
+		return parser.parsePairForAnnotation2_1(tag, value)
+	case "AnnotationComment":
+		return parser.parsePairForAnnotation2_1(tag, value)
 	default:
 		return fmt.Errorf("received unknown tag %v in Review section", tag)
 	}

--- a/v0/tvloader/parser2v1/parse_review_test.go
+++ b/v0/tvloader/parser2v1/parse_review_test.go
@@ -80,6 +80,121 @@ func TestParser2_1ReviewStartsNewReviewAfterParsingReviewerTag(t *testing.T) {
 
 }
 
+func TestParser2_1ReviewStaysAfterParsingRelationshipTags(t *testing.T) {
+	parser := tvParser2_1{
+		doc:  &spdx.Document2_1{},
+		st:   psReview2_1,
+		pkg:  &spdx.Package2_1{PackageName: "test"},
+		file: &spdx.File2_1{FileName: "f1.txt"},
+		otherLic: &spdx.OtherLicense2_1{
+			LicenseIdentifier: "LicenseRef-Lic11",
+			LicenseName:       "License 11",
+		},
+		rev: &spdx.Review2_1{
+			Reviewer:     "Jane Doe",
+			ReviewerType: "Person",
+		},
+	}
+	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
+	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
+	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
+
+	err := parser.parsePair2_1("Relationship", "blah CONTAINS blah-else")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	// state should remain unchanged
+	if parser.st != psReview2_1 {
+		t.Errorf("expected state to be %v, got %v", psReview2_1, parser.st)
+	}
+	// and the relationship should be in the Document's Relationships
+	if len(parser.doc.Relationships) != 1 {
+		t.Fatalf("expected doc.Relationships to have len 1, got %d", len(parser.doc.Relationships))
+	}
+	if parser.doc.Relationships[0].RefA != "blah" {
+		t.Errorf("expected RefA to be %s, got %s", "blah", parser.doc.Relationships[0].RefA)
+	}
+
+	err = parser.parsePair2_1("RelationshipComment", "blah")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	// state should still remain unchanged
+	if parser.st != psReview2_1 {
+		t.Errorf("expected state to be %v, got %v", psReview2_1, parser.st)
+	}
+}
+
+func TestParser2_1ReviewStaysAfterParsingAnnotationTags(t *testing.T) {
+	parser := tvParser2_1{
+		doc:  &spdx.Document2_1{},
+		st:   psReview2_1,
+		pkg:  &spdx.Package2_1{PackageName: "test"},
+		file: &spdx.File2_1{FileName: "f1.txt"},
+		otherLic: &spdx.OtherLicense2_1{
+			LicenseIdentifier: "LicenseRef-Lic11",
+			LicenseName:       "License 11",
+		},
+		rev: &spdx.Review2_1{
+			Reviewer:     "Jane Doe",
+			ReviewerType: "Person",
+		},
+	}
+	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
+	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
+	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
+
+	err := parser.parsePair2_1("Annotator", "Person: John Doe ()")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	if parser.st != psReview2_1 {
+		t.Errorf("parser is in state %v, expected %v", parser.st, psReview2_1)
+	}
+
+	err = parser.parsePair2_1("AnnotationDate", "2018-09-15T00:36:00Z")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	if parser.st != psReview2_1 {
+		t.Errorf("parser is in state %v, expected %v", parser.st, psReview2_1)
+	}
+
+	err = parser.parsePair2_1("AnnotationType", "REVIEW")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	if parser.st != psReview2_1 {
+		t.Errorf("parser is in state %v, expected %v", parser.st, psReview2_1)
+	}
+
+	err = parser.parsePair2_1("SPDXREF", "SPDXRef-45")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	if parser.st != psReview2_1 {
+		t.Errorf("parser is in state %v, expected %v", parser.st, psReview2_1)
+	}
+
+	err = parser.parsePair2_1("AnnotationComment", "i guess i had something to say about this particular file")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	if parser.st != psReview2_1 {
+		t.Errorf("parser is in state %v, expected %v", parser.st, psReview2_1)
+	}
+
+	// and the annotation should be in the Document's Annotations
+	if len(parser.doc.Annotations) != 1 {
+		t.Fatalf("expected doc.Annotations to have len 1, got %d", len(parser.doc.Annotations))
+	}
+	if parser.doc.Annotations[0].Annotator != "John Doe ()" {
+		t.Errorf("expected Annotator to be %s, got %s", "John Doe ()", parser.doc.Annotations[0].Annotator)
+	}
+}
+
 func TestParser2_1ReviewFailsAfterParsingOtherSectionTags(t *testing.T) {
 	parser := tvParser2_1{
 		doc:  &spdx.Document2_1{},
@@ -111,15 +226,6 @@ func TestParser2_1ReviewFailsAfterParsingOtherSectionTags(t *testing.T) {
 		t.Errorf("expected error when calling parsePair2_1, got nil")
 	}
 	err = parser.parsePair2_1("LicenseID", "LicenseRef-Lic22")
-	if err == nil {
-		t.Errorf("expected error when calling parsePair2_1, got nil")
-	}
-	// also can't do relationships or annotations
-	err = parser.parsePair2_1("Relationship", "LicenseRef-Lic11 DESCRIBES SPDXRef-17")
-	if err == nil {
-		t.Errorf("expected error when calling parsePair2_1, got nil")
-	}
-	err = parser.parsePair2_1("Annotator", "steve")
 	if err == nil {
 		t.Errorf("expected error when calling parsePair2_1, got nil")
 	}


### PR DESCRIPTION
Fixes #10 

Also fixes the same problem for Review sections, in addition to OtherLicense sections.

Also removes the (then-true, now-incorrect) section of tvloader-assumptions.md which says that OtherLicense and Review sections will not parse Relationships / Annotations that appear after them.