### PR TITLE
Change data model to use IDs as keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .vscode
 .DS_Store
 scratch/*
+*.swp
+

--- a/builder/build.go
+++ b/builder/build.go
@@ -64,7 +64,7 @@ func Build2_1(packageName string, dirRoot string, config *Config2_1) (*spdx.Docu
 
 	doc := &spdx.Document2_1{
 		CreationInfo:  ci,
-		Packages:      []*spdx.Package2_1{pkg},
+		Packages:      map[spdx.ElementID]*spdx.Package2_1{pkg.PackageSPDXIdentifier: pkg},
 		Relationships: []*spdx.Relationship2_1{rln},
 	}
 

--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -5,6 +5,8 @@ package builder
 import (
 	"fmt"
 	"testing"
+
+	"github.com/spdx/tools-golang/spdx"
 )
 
 // ===== Builder top-level Document test =====
@@ -39,8 +41,8 @@ func TestBuild2_1CreatesDocument(t *testing.T) {
 	if doc.CreationInfo.DataLicense != "CC0-1.0" {
 		t.Errorf("expected %s, got %s", "CC0-1.0", doc.CreationInfo.DataLicense)
 	}
-	if doc.CreationInfo.SPDXIdentifier != "SPDXRef-DOCUMENT" {
-		t.Errorf("expected %s, got %s", "SPDXRef-DOCUMENT", doc.CreationInfo.SPDXIdentifier)
+	if doc.CreationInfo.SPDXIdentifier != spdx.ElementID("DOCUMENT") {
+		t.Errorf("expected %s, got %v", "DOCUMENT", doc.CreationInfo.SPDXIdentifier)
 	}
 	if doc.CreationInfo.DocumentName != "project1" {
 		t.Errorf("expected %s, got %s", "project1", doc.CreationInfo.DocumentName)
@@ -72,12 +74,15 @@ func TestBuild2_1CreatesDocument(t *testing.T) {
 	if len(doc.Packages) != 1 {
 		t.Fatalf("expected %d, got %d", 1, len(doc.Packages))
 	}
-	pkg := doc.Packages[0]
+	pkg := doc.Packages[spdx.ElementID("Package-project1")]
+	if pkg == nil {
+		t.Fatalf("expected non-nil pkg, got nil")
+	}
 	if pkg.PackageName != "project1" {
 		t.Errorf("expected %v, got %v", "project1", pkg.PackageName)
 	}
-	if pkg.PackageSPDXIdentifier != "SPDXRef-Package-project1" {
-		t.Errorf("expected %v, got %v", "SPDXRef-Package-project1", pkg.PackageSPDXIdentifier)
+	if pkg.PackageSPDXIdentifier != spdx.ElementID("Package-project1") {
+		t.Errorf("expected %v, got %v", "Package-project1", pkg.PackageSPDXIdentifier)
 	}
 	if pkg.PackageDownloadLocation != "NOASSERTION" {
 		t.Errorf("expected %v, got %v", "NOASSERTION", pkg.PackageDownloadLocation)
@@ -109,19 +114,20 @@ func TestBuild2_1CreatesDocument(t *testing.T) {
 		t.Fatalf("expected %d, got %d", 5, len(pkg.Files))
 	}
 
-	// files should be in alphabetical order:
+	// files should be in order of identifier, which is numeric,
+	// created based on alphabetical order of files:
 	// emptyfile, file1, file3, folder/file4, lastfile
 
 	// check emptyfile.testdata.txt
-	fileEmpty := pkg.Files[0]
+	fileEmpty := pkg.Files[spdx.ElementID("File0")]
 	if fileEmpty == nil {
 		t.Fatalf("expected non-nil file, got nil")
 	}
 	if fileEmpty.FileName != "/emptyfile.testdata.txt" {
 		t.Errorf("expected %v, got %v", "/emptyfile.testdata.txt", fileEmpty.FileName)
 	}
-	if fileEmpty.FileSPDXIdentifier != "SPDXRef-File0" {
-		t.Errorf("expected %v, got %v", "SPDXRef-File0", fileEmpty.FileSPDXIdentifier)
+	if fileEmpty.FileSPDXIdentifier != spdx.ElementID("File0") {
+		t.Errorf("expected %v, got %v", "File0", fileEmpty.FileSPDXIdentifier)
 	}
 	if fileEmpty.FileChecksumSHA1 != "da39a3ee5e6b4b0d3255bfef95601890afd80709" {
 		t.Errorf("expected %v, got %v", "da39a3ee5e6b4b0d3255bfef95601890afd80709", fileEmpty.FileChecksumSHA1)
@@ -143,15 +149,15 @@ func TestBuild2_1CreatesDocument(t *testing.T) {
 	}
 
 	// check file1.testdata.txt
-	file1 := pkg.Files[1]
+	file1 := pkg.Files[spdx.ElementID("File1")]
 	if file1 == nil {
 		t.Fatalf("expected non-nil file, got nil")
 	}
 	if file1.FileName != "/file1.testdata.txt" {
 		t.Errorf("expected %v, got %v", "/file1.testdata.txt", file1.FileName)
 	}
-	if file1.FileSPDXIdentifier != "SPDXRef-File1" {
-		t.Errorf("expected %v, got %v", "SPDXRef-File1", file1.FileSPDXIdentifier)
+	if file1.FileSPDXIdentifier != spdx.ElementID("File1") {
+		t.Errorf("expected %v, got %v", "File1", file1.FileSPDXIdentifier)
 	}
 	if file1.FileChecksumSHA1 != "024f870eb6323f532515f7a09d5646a97083b819" {
 		t.Errorf("expected %v, got %v", "024f870eb6323f532515f7a09d5646a97083b819", file1.FileChecksumSHA1)
@@ -173,15 +179,15 @@ func TestBuild2_1CreatesDocument(t *testing.T) {
 	}
 
 	// check file3.testdata.txt
-	file3 := pkg.Files[2]
+	file3 := pkg.Files[spdx.ElementID("File2")]
 	if file3 == nil {
 		t.Fatalf("expected non-nil file, got nil")
 	}
 	if file3.FileName != "/file3.testdata.txt" {
 		t.Errorf("expected %v, got %v", "/file3.testdata.txt", file3.FileName)
 	}
-	if file3.FileSPDXIdentifier != "SPDXRef-File2" {
-		t.Errorf("expected %v, got %v", "SPDXRef-File2", file3.FileSPDXIdentifier)
+	if file3.FileSPDXIdentifier != spdx.ElementID("File2") {
+		t.Errorf("expected %v, got %v", "File2", file3.FileSPDXIdentifier)
 	}
 	if file3.FileChecksumSHA1 != "a46114b70e163614f01c64adf44cdd438f158fce" {
 		t.Errorf("expected %v, got %v", "a46114b70e163614f01c64adf44cdd438f158fce", file3.FileChecksumSHA1)
@@ -203,15 +209,15 @@ func TestBuild2_1CreatesDocument(t *testing.T) {
 	}
 
 	// check folder1/file4.testdata.txt
-	file4 := pkg.Files[3]
+	file4 := pkg.Files[spdx.ElementID("File3")]
 	if file4 == nil {
 		t.Fatalf("expected non-nil file, got nil")
 	}
 	if file4.FileName != "/folder1/file4.testdata.txt" {
 		t.Errorf("expected %v, got %v", "folder1/file4.testdata.txt", file4.FileName)
 	}
-	if file4.FileSPDXIdentifier != "SPDXRef-File3" {
-		t.Errorf("expected %v, got %v", "SPDXRef-File3", file4.FileSPDXIdentifier)
+	if file4.FileSPDXIdentifier != spdx.ElementID("File3") {
+		t.Errorf("expected %v, got %v", "File3", file4.FileSPDXIdentifier)
 	}
 	if file4.FileChecksumSHA1 != "e623d7d7d782a7c8323c4d436acee4afab34320f" {
 		t.Errorf("expected %v, got %v", "e623d7d7d782a7c8323c4d436acee4afab34320f", file4.FileChecksumSHA1)
@@ -233,15 +239,15 @@ func TestBuild2_1CreatesDocument(t *testing.T) {
 	}
 
 	// check lastfile.testdata.txt
-	lastfile := pkg.Files[4]
+	lastfile := pkg.Files[spdx.ElementID("File4")]
 	if lastfile == nil {
 		t.Fatalf("expected non-nil file, got nil")
 	}
 	if lastfile.FileName != "/lastfile.testdata.txt" {
 		t.Errorf("expected %v, got %v", "/lastfile.testdata.txt", lastfile.FileName)
 	}
-	if lastfile.FileSPDXIdentifier != "SPDXRef-File4" {
-		t.Errorf("expected %v, got %v", "SPDXRef-File4", lastfile.FileSPDXIdentifier)
+	if lastfile.FileSPDXIdentifier != spdx.ElementID("File4") {
+		t.Errorf("expected %v, got %v", "File4", lastfile.FileSPDXIdentifier)
 	}
 	if lastfile.FileChecksumSHA1 != "26d6221d682d9ba59116f9753a701f34271c8ce1" {
 		t.Errorf("expected %v, got %v", "26d6221d682d9ba59116f9753a701f34271c8ce1", lastfile.FileChecksumSHA1)
@@ -273,11 +279,11 @@ func TestBuild2_1CreatesDocument(t *testing.T) {
 	if rln == nil {
 		t.Fatalf("expected non-nil Relationship, got nil")
 	}
-	if rln.RefA != "SPDXRef-DOCUMENT" {
-		t.Errorf("expected %v, got %v", "SPDXRef-DOCUMENT", rln.RefA)
+	if rln.RefA != spdx.MakeDocElementID("", "DOCUMENT") {
+		t.Errorf("expected %v, got %v", "DOCUMENT", rln.RefA)
 	}
-	if rln.RefB != "SPDXRef-Package-project1" {
-		t.Errorf("expected %v, got %v", "SPDXRef-Package-project1", rln.RefB)
+	if rln.RefB != spdx.MakeDocElementID("", "Package-project1") {
+		t.Errorf("expected %v, got %v", "Package-project1", rln.RefB)
 	}
 	if rln.Relationship != "DESCRIBES" {
 		t.Errorf("expected %v, got %v", "DESCRIBES", rln.Relationship)
@@ -317,37 +323,40 @@ func TestBuild2_1CanIgnoreFiles(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
-	pkg := doc.Packages[0]
+	pkg := doc.Packages[spdx.ElementID("Package-project1")]
+	if pkg == nil {
+		t.Fatalf("expected non-nil pkg, got nil")
+	}
 	if len(pkg.Files) != 5 {
 		t.Fatalf("expected len %d, got %d", 5, len(pkg.Files))
 	}
 
 	want := "/dontscan.txt"
-	got := pkg.Files[0].FileName
+	got := pkg.Files[spdx.ElementID("File0")].FileName
 	if want != got {
 		t.Errorf("expected %v, got %v", want, got)
 	}
 
 	want = "/keep/keep.txt"
-	got = pkg.Files[1].FileName
+	got = pkg.Files[spdx.ElementID("File1")].FileName
 	if want != got {
 		t.Errorf("expected %v, got %v", want, got)
 	}
 
 	want = "/keep.txt"
-	got = pkg.Files[2].FileName
+	got = pkg.Files[spdx.ElementID("File2")].FileName
 	if want != got {
 		t.Errorf("expected %v, got %v", want, got)
 	}
 
 	want = "/subdir/keep/dontscan.txt"
-	got = pkg.Files[3].FileName
+	got = pkg.Files[spdx.ElementID("File3")].FileName
 	if want != got {
 		t.Errorf("expected %v, got %v", want, got)
 	}
 
 	want = "/subdir/keep/keep.txt"
-	got = pkg.Files[4].FileName
+	got = pkg.Files[spdx.ElementID("File4")].FileName
 	if want != got {
 		t.Errorf("expected %v, got %v", want, got)
 	}

--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -73,9 +73,6 @@ func TestBuild2_1CreatesDocument(t *testing.T) {
 		t.Fatalf("expected %d, got %d", 1, len(doc.Packages))
 	}
 	pkg := doc.Packages[0]
-	if pkg.IsUnpackaged {
-		t.Errorf("expected %v, got %v", false, pkg.IsUnpackaged)
-	}
 	if pkg.PackageName != "project1" {
 		t.Errorf("expected %v, got %v", "project1", pkg.PackageName)
 	}

--- a/builder/builder2v1/build_creation_info.go
+++ b/builder/builder2v1/build_creation_info.go
@@ -47,7 +47,7 @@ func BuildCreationInfoSection2_1(packageName string, code string, namespacePrefi
 	ci := &spdx.CreationInfo2_1{
 		SPDXVersion:          "SPDX-2.1",
 		DataLicense:          "CC0-1.0",
-		SPDXIdentifier:       "SPDXRef-DOCUMENT",
+		SPDXIdentifier:       spdx.ElementID("DOCUMENT"),
 		DocumentName:         packageName,
 		DocumentNamespace:    fmt.Sprintf("%s%s-%s", namespacePrefix, packageName, code),
 		CreatorPersons:       cPersons,

--- a/builder/builder2v1/build_creation_info_test.go
+++ b/builder/builder2v1/build_creation_info_test.go
@@ -5,6 +5,8 @@ package builder2v1
 import (
 	"fmt"
 	"testing"
+
+	"github.com/spdx/tools-golang/spdx"
 )
 
 // ===== CreationInfo section builder tests =====
@@ -32,8 +34,8 @@ func TestBuilder2_1CanBuildCreationInfoSection(t *testing.T) {
 	if ci.DataLicense != "CC0-1.0" {
 		t.Errorf("expected %s, got %s", "CC0-1.0", ci.DataLicense)
 	}
-	if ci.SPDXIdentifier != "SPDXRef-DOCUMENT" {
-		t.Errorf("expected %s, got %s", "SPDXRef-DOCUMENT", ci.SPDXIdentifier)
+	if ci.SPDXIdentifier != spdx.ElementID("DOCUMENT") {
+		t.Errorf("expected %s, got %v", "DOCUMENT", ci.SPDXIdentifier)
 	}
 	if ci.DocumentName != "project1" {
 		t.Errorf("expected %s, got %s", "project1", ci.DocumentName)

--- a/builder/builder2v1/build_file.go
+++ b/builder/builder2v1/build_file.go
@@ -26,12 +26,12 @@ func BuildFileSection2_1(filePath string, prefix string, fileNumber int) (*spdx.
 	}
 
 	// build the identifier
-	i := fmt.Sprintf("SPDXRef-File%d", fileNumber)
+	i := fmt.Sprintf("File%d", fileNumber)
 
 	// now build the File section
 	f := &spdx.File2_1{
 		FileName:           filePath,
-		FileSPDXIdentifier: i,
+		FileSPDXIdentifier: spdx.ElementID(i),
 		FileChecksumSHA1:   ssha1,
 		FileChecksumSHA256: ssha256,
 		FileChecksumMD5:    smd5,

--- a/builder/builder2v1/build_file_test.go
+++ b/builder/builder2v1/build_file_test.go
@@ -4,6 +4,8 @@ package builder2v1
 
 import (
 	"testing"
+
+	"github.com/spdx/tools-golang/spdx"
 )
 
 // ===== File section builder tests =====
@@ -23,8 +25,8 @@ func TestBuilder2_1CanBuildFileSection(t *testing.T) {
 	if file1.FileName != "/file1.testdata.txt" {
 		t.Errorf("expected %v, got %v", "/file1.testdata.txt", file1.FileName)
 	}
-	if file1.FileSPDXIdentifier != "SPDXRef-File17" {
-		t.Errorf("expected %v, got %v", "SPDXRef-File17", file1.FileSPDXIdentifier)
+	if file1.FileSPDXIdentifier != spdx.ElementID("File17") {
+		t.Errorf("expected %v, got %v", "File17", file1.FileSPDXIdentifier)
 	}
 	if file1.FileChecksumSHA1 != "024f870eb6323f532515f7a09d5646a97083b819" {
 		t.Errorf("expected %v, got %v", "024f870eb6323f532515f7a09d5646a97083b819", file1.FileChecksumSHA1)

--- a/builder/builder2v1/build_package.go
+++ b/builder/builder2v1/build_package.go
@@ -22,14 +22,14 @@ func BuildPackageSection2_1(packageName string, dirRoot string, pathsIgnore []st
 		return nil, err
 	}
 
-	files := []*spdx.File2_1{}
+	files := map[spdx.ElementID]*spdx.File2_1{}
 	fileNumber := 0
 	for _, fp := range filepaths {
 		newFile, err := BuildFileSection2_1(fp, dirRoot, fileNumber)
 		if err != nil {
 			return nil, err
 		}
-		files = append(files, newFile)
+		files[newFile.FileSPDXIdentifier] = newFile
 		fileNumber++
 	}
 
@@ -42,7 +42,7 @@ func BuildPackageSection2_1(packageName string, dirRoot string, pathsIgnore []st
 	// now build the package section
 	pkg := &spdx.Package2_1{
 		PackageName:                 packageName,
-		PackageSPDXIdentifier:       fmt.Sprintf("SPDXRef-Package-%s", packageName),
+		PackageSPDXIdentifier:       spdx.ElementID(fmt.Sprintf("Package-%s", packageName)),
 		PackageDownloadLocation:     "NOASSERTION",
 		FilesAnalyzed:               true,
 		IsFilesAnalyzedTagPresent:   true,

--- a/builder/builder2v1/build_package.go
+++ b/builder/builder2v1/build_package.go
@@ -41,7 +41,6 @@ func BuildPackageSection2_1(packageName string, dirRoot string, pathsIgnore []st
 
 	// now build the package section
 	pkg := &spdx.Package2_1{
-		IsUnpackaged:                false,
 		PackageName:                 packageName,
 		PackageSPDXIdentifier:       fmt.Sprintf("SPDXRef-Package-%s", packageName),
 		PackageDownloadLocation:     "NOASSERTION",

--- a/builder/builder2v1/build_package_test.go
+++ b/builder/builder2v1/build_package_test.go
@@ -4,6 +4,8 @@ package builder2v1
 
 import (
 	"testing"
+
+	"github.com/spdx/tools-golang/spdx"
 )
 
 // ===== Package section builder tests =====
@@ -24,8 +26,8 @@ func TestBuilder2_1CanBuildPackageSection(t *testing.T) {
 	if pkg.PackageName != "project1" {
 		t.Errorf("expected %v, got %v", "project1", pkg.PackageName)
 	}
-	if pkg.PackageSPDXIdentifier != "SPDXRef-Package-project1" {
-		t.Errorf("expected %v, got %v", "SPDXRef-Package-project1", pkg.PackageSPDXIdentifier)
+	if pkg.PackageSPDXIdentifier != spdx.ElementID("Package-project1") {
+		t.Errorf("expected %v, got %v", "Package-project1", pkg.PackageSPDXIdentifier)
 	}
 	if pkg.PackageDownloadLocation != "NOASSERTION" {
 		t.Errorf("expected %v, got %v", "NOASSERTION", pkg.PackageDownloadLocation)
@@ -59,15 +61,15 @@ func TestBuilder2_1CanBuildPackageSection(t *testing.T) {
 	if len(pkg.Files) != 5 {
 		t.Fatalf("expected %d, got %d", 5, len(pkg.Files))
 	}
-	fileEmpty := pkg.Files[0]
+	fileEmpty := pkg.Files[spdx.ElementID("File0")]
 	if fileEmpty == nil {
 		t.Fatalf("expected non-nil file, got nil")
 	}
 	if fileEmpty.FileName != "/emptyfile.testdata.txt" {
 		t.Errorf("expected %v, got %v", "/emptyfile.testdata.txt", fileEmpty.FileName)
 	}
-	if fileEmpty.FileSPDXIdentifier != "SPDXRef-File0" {
-		t.Errorf("expected %v, got %v", "SPDXRef-File0", fileEmpty.FileSPDXIdentifier)
+	if fileEmpty.FileSPDXIdentifier != spdx.ElementID("File0") {
+		t.Errorf("expected %v, got %v", "File0", fileEmpty.FileSPDXIdentifier)
 	}
 	if fileEmpty.FileChecksumSHA1 != "da39a3ee5e6b4b0d3255bfef95601890afd80709" {
 		t.Errorf("expected %v, got %v", "da39a3ee5e6b4b0d3255bfef95601890afd80709", fileEmpty.FileChecksumSHA1)
@@ -112,31 +114,31 @@ func TestBuilder2_1CanIgnoreFiles(t *testing.T) {
 	}
 
 	want := "/dontscan.txt"
-	got := pkg.Files[0].FileName
+	got := pkg.Files[spdx.ElementID("File0")].FileName
 	if want != got {
 		t.Errorf("expected %v, got %v", want, got)
 	}
 
 	want = "/keep/keep.txt"
-	got = pkg.Files[1].FileName
+	got = pkg.Files[spdx.ElementID("File1")].FileName
 	if want != got {
 		t.Errorf("expected %v, got %v", want, got)
 	}
 
 	want = "/keep.txt"
-	got = pkg.Files[2].FileName
+	got = pkg.Files[spdx.ElementID("File2")].FileName
 	if want != got {
 		t.Errorf("expected %v, got %v", want, got)
 	}
 
 	want = "/subdir/keep/dontscan.txt"
-	got = pkg.Files[3].FileName
+	got = pkg.Files[spdx.ElementID("File3")].FileName
 	if want != got {
 		t.Errorf("expected %v, got %v", want, got)
 	}
 
 	want = "/subdir/keep/keep.txt"
-	got = pkg.Files[4].FileName
+	got = pkg.Files[spdx.ElementID("File4")].FileName
 	if want != got {
 		t.Errorf("expected %v, got %v", want, got)
 	}

--- a/builder/builder2v1/build_package_test.go
+++ b/builder/builder2v1/build_package_test.go
@@ -21,9 +21,6 @@ func TestBuilder2_1CanBuildPackageSection(t *testing.T) {
 	if pkg == nil {
 		t.Fatalf("expected non-nil Package, got nil")
 	}
-	if pkg.IsUnpackaged {
-		t.Errorf("expected %v, got %v", false, pkg.IsUnpackaged)
-	}
 	if pkg.PackageName != "project1" {
 		t.Errorf("expected %v, got %v", "project1", pkg.PackageName)
 	}

--- a/builder/builder2v1/build_relationship.go
+++ b/builder/builder2v1/build_relationship.go
@@ -14,8 +14,8 @@ import (
 //   - packageName: name of package / directory
 func BuildRelationshipSection2_1(packageName string) (*spdx.Relationship2_1, error) {
 	rln := &spdx.Relationship2_1{
-		RefA:         "SPDXRef-DOCUMENT",
-		RefB:         fmt.Sprintf("SPDXRef-Package-%s", packageName),
+		RefA:         spdx.MakeDocElementID("", "DOCUMENT"),
+		RefB:         spdx.MakeDocElementID("", fmt.Sprintf("Package-%s", packageName)),
 		Relationship: "DESCRIBES",
 	}
 

--- a/builder/builder2v1/build_relationship_test.go
+++ b/builder/builder2v1/build_relationship_test.go
@@ -4,6 +4,8 @@ package builder2v1
 
 import (
 	"testing"
+
+	"github.com/spdx/tools-golang/spdx"
 )
 
 // ===== Relationship section builder tests =====
@@ -18,11 +20,11 @@ func TestBuilder2_1CanBuildRelationshipSection(t *testing.T) {
 	if rln == nil {
 		t.Fatalf("expected non-nil relationship, got nil")
 	}
-	if rln.RefA != "SPDXRef-DOCUMENT" {
-		t.Errorf("expected %v, got %v", "SPDXRef-DOCUMENT", rln.RefA)
+	if rln.RefA != spdx.MakeDocElementID("", "DOCUMENT") {
+		t.Errorf("expected %v, got %v", "DOCUMENT", rln.RefA)
 	}
-	if rln.RefB != "SPDXRef-Package-project17" {
-		t.Errorf("expected %v, got %v", "SPDXRef-Package-project17", rln.RefB)
+	if rln.RefB != spdx.MakeDocElementID("", "Package-project17") {
+		t.Errorf("expected %v, got %v", "Package-project17", rln.RefB)
 	}
 	if rln.Relationship != "DESCRIBES" {
 		t.Errorf("expected %v, got %v", "DESCRIBES", rln.Relationship)

--- a/examples/1-load/example_load.go
+++ b/examples/1-load/example_load.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spdx/tools-golang/spdxlib"
 	"github.com/spdx/tools-golang/tvloader"
 )
 
@@ -53,40 +54,50 @@ func main() {
 	fmt.Printf("==============\n")
 	fmt.Printf("%#v\n\n", doc.CreationInfo)
 
-	// check whether the SPDX file has at least one package
-	if doc.Packages == nil || len(doc.Packages) < 1 {
-		fmt.Printf("No packages found in SPDX document\n")
+	// check whether the SPDX file has at least one package that it describes
+	pkgIDs, err := spdxlib.GetDescribedPackageIDs2_1(doc)
+	if err != nil {
+		fmt.Printf("Unable to get describe packages from SPDX document: %v\n", err)
 		return
 	}
 
-	// it does, so we'll choose the first one
-	pkg := doc.Packages[0]
+	// it does, so we'll go through each one
+	for _, pkgID := range pkgIDs {
+		pkg, ok := doc.Packages[pkgID]
+		if !ok {
+			fmt.Printf("Package %s has described relationship but ID not found\n", string(pkgID))
+			continue
+		}
 
-	// check whether the package had its files analyzed
-	if !pkg.FilesAnalyzed {
-		fmt.Printf("First Package (%s) had FilesAnalyzed: false\n", pkg.PackageName)
-		return
-	}
+		// check whether the package had its files analyzed
+		if !pkg.FilesAnalyzed {
+			fmt.Printf("Package %s (%s) had FilesAnalyzed: false\n", string(pkgID), pkg.PackageName)
+			continue
+		}
 
-	// also check whether the package has any files present
-	if pkg.Files == nil || len(pkg.Files) < 1 {
-		fmt.Printf("No Files found in first Package (%s)\n", pkg.PackageName)
-		return
-	}
+		// also check whether the package has any files present
+		if pkg.Files == nil || len(pkg.Files) < 1 {
+			fmt.Printf("Package %s (%s) has no Files\n", string(pkgID), pkg.PackageName)
+			continue
+		}
 
-	// if we got here, there's at least one file
-	// print the filename and license info for the first 50
-	fmt.Printf("============================\n")
-	fmt.Printf("Files info (up to first 50):\n")
-	fmt.Printf("============================\n")
-	i := 1
-	for _, f := range pkg.Files {
-		fmt.Printf("File %d: %s\n", i, f.FileName)
-		fmt.Printf("  License from file: %v\n", f.LicenseInfoInFile)
-		fmt.Printf("  License concluded: %v\n", f.LicenseConcluded)
-		i++
-		if i > 50 {
-			break
+		// if we got here, there's at least one file
+		// print the filename and license info for the first 50
+		fmt.Printf("============================\n")
+		fmt.Printf("Package %s (%s)\n", string(pkgID), pkg.PackageName)
+		fmt.Printf("File info (up to first 50):\n")
+		i := 1
+		for _, f := range pkg.Files {
+			// note that these will be in random order, since we're pulling
+			// from a map. if we care about order, we should first pull the
+			// IDs into a slice, sort it, and then print the ordered files.
+			fmt.Printf("- File %d: %s\n", i, f.FileName)
+			fmt.Printf("    License from file: %v\n", f.LicenseInfoInFile)
+			fmt.Printf("    License concluded: %v\n", f.LicenseConcluded)
+			i++
+			if i > 50 {
+				break
+			}
 		}
 	}
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,8 +49,9 @@ files, and printing the report to standard output.
 *licensediff*, *tvloader*
 
 This example demonstrates loading two SPDX tag-value files from disk into
-memory, and generating a diff of the concluded licenses for Files in the
-first-listed Packages in each document.
+memory, and generating a diff of the concluded licenses for Files in Packages
+with matching IDs in each document.
 
 This is generally only useful when run with two SPDX documents that describe
-licenses for subsequent versions of the same set of files.
+licenses for subsequent versions of the same set of files, AND if they have
+the same identifier in both documents.

--- a/idsearcher/idsearcher.go
+++ b/idsearcher/idsearcher.go
@@ -64,14 +64,17 @@ func BuildIDsDocument(packageName string, dirRoot string, idconfig *Config) (*sp
 		return nil, fmt.Errorf("builder returned nil Document")
 	}
 	if doc.Packages == nil {
-		return nil, fmt.Errorf("builder returned nil Package")
+		return nil, fmt.Errorf("builder returned nil Packages map")
 	}
 	if len(doc.Packages) != 1 {
 		return nil, fmt.Errorf("builder returned %d Packages", len(doc.Packages))
 	}
 
 	// now, walk through each file and find its licenses (if any)
-	pkg := doc.Packages[0]
+	pkg := doc.Packages[spdx.ElementID("Package-"+packageName)]
+	if pkg == nil {
+		return nil, fmt.Errorf("builder returned nil Package")
+	}
 	if pkg.Files == nil {
 		return nil, fmt.Errorf("builder returned nil Files in Package")
 	}

--- a/idsearcher/idsearcher_test.go
+++ b/idsearcher/idsearcher_test.go
@@ -4,6 +4,8 @@ package idsearcher
 
 import (
 	"testing"
+
+	"github.com/spdx/tools-golang/spdx"
 )
 
 // ===== Searcher top-level function tests =====
@@ -31,7 +33,10 @@ func TestSearcherCanFillInIDs(t *testing.T) {
 	if len(doc.Packages) != 1 {
 		t.Fatalf("expected Packages len to be 1, got %d", len(doc.Packages))
 	}
-	pkg := doc.Packages[0]
+	pkg := doc.Packages[spdx.ElementID("Package-project2")]
+	if pkg == nil {
+		t.Fatalf("expected non-nil pkg, got nil")
+	}
 
 	if pkg.Files == nil {
 		t.Fatalf("expected non-nil Files, got nil")
@@ -40,7 +45,7 @@ func TestSearcherCanFillInIDs(t *testing.T) {
 		t.Fatalf("expected Files len to be 6, got %d", len(pkg.Files))
 	}
 
-	fileInFolder := pkg.Files[0]
+	fileInFolder := pkg.Files[spdx.ElementID("File0")]
 	if fileInFolder.LicenseInfoInFile == nil {
 		t.Fatalf("expected non-nil LicenseInfoInFile, got nil")
 	}
@@ -54,7 +59,7 @@ func TestSearcherCanFillInIDs(t *testing.T) {
 		t.Errorf("expected %v, got %v", "MIT", fileInFolder.LicenseConcluded)
 	}
 
-	fileTrailingComment := pkg.Files[1]
+	fileTrailingComment := pkg.Files[spdx.ElementID("File1")]
 	if fileTrailingComment.LicenseInfoInFile == nil {
 		t.Fatalf("expected non-nil LicenseInfoInFile, got nil")
 	}
@@ -68,7 +73,7 @@ func TestSearcherCanFillInIDs(t *testing.T) {
 		t.Errorf("expected %v, got %v", "GPL-2.0-or-later", fileTrailingComment.LicenseConcluded)
 	}
 
-	fileHasDuplicateID := pkg.Files[2]
+	fileHasDuplicateID := pkg.Files[spdx.ElementID("File2")]
 	if fileHasDuplicateID.LicenseInfoInFile == nil {
 		t.Fatalf("expected non-nil LicenseInfoInFile, got nil")
 	}
@@ -82,7 +87,7 @@ func TestSearcherCanFillInIDs(t *testing.T) {
 		t.Errorf("expected %v, got %v", "MIT", fileHasDuplicateID.LicenseConcluded)
 	}
 
-	fileHasID := pkg.Files[3]
+	fileHasID := pkg.Files[spdx.ElementID("File3")]
 	if fileHasID.LicenseInfoInFile == nil {
 		t.Fatalf("expected non-nil LicenseInfoInFile, got nil")
 	}
@@ -99,7 +104,7 @@ func TestSearcherCanFillInIDs(t *testing.T) {
 		t.Errorf("expected %v, got %v", "Apache-2.0 OR GPL-2.0-or-later", fileHasID.LicenseConcluded)
 	}
 
-	fileMultipleIDs := pkg.Files[4]
+	fileMultipleIDs := pkg.Files[spdx.ElementID("File4")]
 	if fileMultipleIDs.LicenseInfoInFile == nil {
 		t.Fatalf("expected non-nil LicenseInfoInFile, got nil")
 	}
@@ -126,7 +131,7 @@ func TestSearcherCanFillInIDs(t *testing.T) {
 		t.Errorf("expected %v, got %v", "((MIT AND BSD-3-Clause) OR ISC) AND BSD-2-Clause AND EPL-1.0+", fileMultipleIDs.LicenseConcluded)
 	}
 
-	fileNoID := pkg.Files[5]
+	fileNoID := pkg.Files[spdx.ElementID("File5")]
 	if fileNoID.LicenseInfoInFile == nil {
 		t.Fatalf("expected non-nil LicenseInfoInFile, got nil")
 	}
@@ -200,12 +205,15 @@ func TestSearcherCanFillInIDsAndIgnorePaths(t *testing.T) {
 
 	// get the package and its files, checking licenses for each, and
 	// confirming NOASSERTION for those that are skipped
-	pkg := doc.Packages[0]
+	pkg := doc.Packages[spdx.ElementID("Package-project3")]
+	if pkg == nil {
+		t.Fatalf("expected non-nil pkg, got nil")
+	}
 	if len(pkg.Files) != 5 {
 		t.Fatalf("expected len %d, got %d", 5, len(pkg.Files))
 	}
 
-	f := pkg.Files[0]
+	f := pkg.Files[spdx.ElementID("File0")]
 	if f.FileName != "/dontscan.txt" {
 		t.Errorf("expected %v, got %v", "/dontscan.txt", f.FileName)
 	}
@@ -219,7 +227,7 @@ func TestSearcherCanFillInIDsAndIgnorePaths(t *testing.T) {
 		t.Errorf("expected %s, got %s", "NOASSERTION", f.LicenseConcluded)
 	}
 
-	f = pkg.Files[1]
+	f = pkg.Files[spdx.ElementID("File1")]
 	if f.FileName != "/keep/keep.txt" {
 		t.Errorf("expected %v, got %v", "/keep/keep.txt", f.FileName)
 	}
@@ -233,7 +241,7 @@ func TestSearcherCanFillInIDsAndIgnorePaths(t *testing.T) {
 		t.Errorf("expected %s, got %s", "MIT", f.LicenseConcluded)
 	}
 
-	f = pkg.Files[2]
+	f = pkg.Files[spdx.ElementID("File2")]
 	if f.FileName != "/keep.txt" {
 		t.Errorf("expected %v, got %v", "/keep.txt", f.FileName)
 	}
@@ -247,7 +255,7 @@ func TestSearcherCanFillInIDsAndIgnorePaths(t *testing.T) {
 		t.Errorf("expected %s, got %s", "NOASSERTION", f.LicenseConcluded)
 	}
 
-	f = pkg.Files[3]
+	f = pkg.Files[spdx.ElementID("File3")]
 	if f.FileName != "/subdir/keep/dontscan.txt" {
 		t.Errorf("expected %v, got %v", "/subdir/keep/dontscan.txt", f.FileName)
 	}
@@ -261,7 +269,7 @@ func TestSearcherCanFillInIDsAndIgnorePaths(t *testing.T) {
 		t.Errorf("expected %s, got %s", "NOASSERTION", f.LicenseConcluded)
 	}
 
-	f = pkg.Files[4]
+	f = pkg.Files[spdx.ElementID("File4")]
 	if f.FileName != "/subdir/keep/keep.txt" {
 		t.Errorf("expected %v, got %v", "/subdir/keep/keep.txt", f.FileName)
 	}

--- a/licensediff/licensediff_test.go
+++ b/licensediff/licensediff_test.go
@@ -118,7 +118,6 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 
 	// create Packages
 	p1 := &spdx.Package2_1{
-		IsUnpackaged:              false,
 		PackageName:               "p1",
 		PackageSPDXIdentifier:     "SPDXRef-p1",
 		PackageDownloadLocation:   "NOASSERTION",
@@ -141,7 +140,6 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 		},
 	}
 	p2 := &spdx.Package2_1{
-		IsUnpackaged:              false,
 		PackageName:               "p2",
 		PackageSPDXIdentifier:     "SPDXRef-p2",
 		PackageDownloadLocation:   "NOASSERTION",
@@ -359,7 +357,6 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 
 	// create Packages
 	p1 := &spdx.Package2_1{
-		IsUnpackaged:              false,
 		PackageName:               "p1",
 		PackageSPDXIdentifier:     "SPDXRef-p1",
 		PackageDownloadLocation:   "NOASSERTION",
@@ -382,7 +379,6 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 		},
 	}
 	p2 := &spdx.Package2_1{
-		IsUnpackaged:              false,
 		PackageName:               "p2",
 		PackageSPDXIdentifier:     "SPDXRef-p2",
 		PackageDownloadLocation:   "NOASSERTION",

--- a/licensediff/licensediff_test.go
+++ b/licensediff/licensediff_test.go
@@ -14,7 +14,7 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 	// f1 will be identical in both
 	f1 := &spdx.File2_1{
 		FileName:           "/project/file1.txt",
-		FileSPDXIdentifier: "SPDXRef-File561",
+		FileSPDXIdentifier: spdx.ElementID("File561"),
 		FileChecksumSHA1:   "6c92dc8bc462b6889d9b1c0bc16c54d19a2cbdd3",
 		LicenseConcluded:   "Apache-2.0",
 		LicenseInfoInFile: []string{
@@ -26,7 +26,7 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 	// f2 will only appear in the first Package
 	f2 := &spdx.File2_1{
 		FileName:           "/project/file2.txt",
-		FileSPDXIdentifier: "SPDXRef-File562",
+		FileSPDXIdentifier: spdx.ElementID("File562"),
 		FileChecksumSHA1:   "066c5139bd9a43d15812ec1a1755b08ccf199824",
 		LicenseConcluded:   "GPL-2.0-or-later",
 		LicenseInfoInFile: []string{
@@ -38,7 +38,7 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 	// f3 will only appear in the second Package
 	f3 := &spdx.File2_1{
 		FileName:           "/project/file3.txt",
-		FileSPDXIdentifier: "SPDXRef-File563",
+		FileSPDXIdentifier: spdx.ElementID("File563"),
 		FileChecksumSHA1:   "bd0f4863b15fad2b79b35303af54fcb5baaf7c68",
 		LicenseConcluded:   "MPL-2.0",
 		LicenseInfoInFile: []string{
@@ -51,7 +51,7 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 	// with same name, same hash and different license
 	f4_1 := &spdx.File2_1{
 		FileName:           "/project/file4.txt",
-		FileSPDXIdentifier: "SPDXRef-File564",
+		FileSPDXIdentifier: spdx.ElementID("File564"),
 		FileChecksumSHA1:   "bc417a575ceae93435bcb7bfd382ac28cbdaa8b5",
 		LicenseConcluded:   "MIT",
 		LicenseInfoInFile: []string{
@@ -61,7 +61,7 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 	}
 	f4_2 := &spdx.File2_1{
 		FileName:           "/project/file4.txt",
-		FileSPDXIdentifier: "SPDXRef-File564",
+		FileSPDXIdentifier: spdx.ElementID("File564"),
 		FileChecksumSHA1:   "bc417a575ceae93435bcb7bfd382ac28cbdaa8b5",
 		LicenseConcluded:   "Apache-2.0 AND MIT",
 		LicenseInfoInFile: []string{
@@ -74,7 +74,7 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 	// with same name, different hash and same license
 	f5_1 := &spdx.File2_1{
 		FileName:           "/project/file5.txt",
-		FileSPDXIdentifier: "SPDXRef-File565",
+		FileSPDXIdentifier: spdx.ElementID("File565"),
 		FileChecksumSHA1:   "ba226db943bbbf455da77afab6f16dbab156d000",
 		LicenseConcluded:   "BSD-3-Clause",
 		LicenseInfoInFile: []string{
@@ -84,7 +84,7 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 	}
 	f5_2 := &spdx.File2_1{
 		FileName:           "/project/file5.txt",
-		FileSPDXIdentifier: "SPDXRef-File565",
+		FileSPDXIdentifier: spdx.ElementID("File565"),
 		FileChecksumSHA1:   "b6e0ec7d085c5699b46f6f8d425413702652874d",
 		LicenseConcluded:   "BSD-3-Clause",
 		LicenseInfoInFile: []string{
@@ -97,7 +97,7 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 	// with same name, different hash and different license
 	f6_1 := &spdx.File2_1{
 		FileName:           "/project/file6.txt",
-		FileSPDXIdentifier: "SPDXRef-File566",
+		FileSPDXIdentifier: spdx.ElementID("File566"),
 		FileChecksumSHA1:   "ba226db943bbbf455da77afab6f16dbab156d000",
 		LicenseConcluded:   "CC0-1.0",
 		LicenseInfoInFile: []string{
@@ -107,7 +107,7 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 	}
 	f6_2 := &spdx.File2_1{
 		FileName:           "/project/file6.txt",
-		FileSPDXIdentifier: "SPDXRef-File566",
+		FileSPDXIdentifier: spdx.ElementID("File566"),
 		FileChecksumSHA1:   "b6e0ec7d085c5699b46f6f8d425413702652874d",
 		LicenseConcluded:   "Unlicense",
 		LicenseInfoInFile: []string{
@@ -119,7 +119,7 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 	// create Packages
 	p1 := &spdx.Package2_1{
 		PackageName:               "p1",
-		PackageSPDXIdentifier:     "SPDXRef-p1",
+		PackageSPDXIdentifier:     spdx.ElementID("p1"),
 		PackageDownloadLocation:   "NOASSERTION",
 		FilesAnalyzed:             true,
 		IsFilesAnalyzedTagPresent: true,
@@ -131,17 +131,17 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 		},
 		PackageLicenseDeclared: "NOASSERTION",
 		PackageCopyrightText:   "NOASSERTION",
-		Files: []*spdx.File2_1{
-			f1,
-			f2,
-			f4_1,
-			f5_1,
-			f6_1,
+		Files: map[spdx.ElementID]*spdx.File2_1{
+			spdx.ElementID(f1.FileSPDXIdentifier):   f1,
+			spdx.ElementID(f2.FileSPDXIdentifier):   f2,
+			spdx.ElementID(f4_1.FileSPDXIdentifier): f4_1,
+			spdx.ElementID(f5_1.FileSPDXIdentifier): f5_1,
+			spdx.ElementID(f6_1.FileSPDXIdentifier): f6_1,
 		},
 	}
 	p2 := &spdx.Package2_1{
 		PackageName:               "p2",
-		PackageSPDXIdentifier:     "SPDXRef-p2",
+		PackageSPDXIdentifier:     spdx.ElementID("p2"),
 		PackageDownloadLocation:   "NOASSERTION",
 		FilesAnalyzed:             true,
 		IsFilesAnalyzedTagPresent: true,
@@ -153,12 +153,12 @@ func TestDifferCanCreateDiffPairs(t *testing.T) {
 		},
 		PackageLicenseDeclared: "NOASSERTION",
 		PackageCopyrightText:   "NOASSERTION",
-		Files: []*spdx.File2_1{
-			f1,
-			f3,
-			f4_2,
-			f5_2,
-			f6_2,
+		Files: map[spdx.ElementID]*spdx.File2_1{
+			spdx.ElementID(f1.FileSPDXIdentifier):   f1,
+			spdx.ElementID(f3.FileSPDXIdentifier):   f3,
+			spdx.ElementID(f4_2.FileSPDXIdentifier): f4_2,
+			spdx.ElementID(f5_2.FileSPDXIdentifier): f5_2,
+			spdx.ElementID(f6_2.FileSPDXIdentifier): f6_2,
 		},
 	}
 
@@ -253,7 +253,7 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 	// f1 will be identical in both
 	f1 := &spdx.File2_1{
 		FileName:           "/project/file1.txt",
-		FileSPDXIdentifier: "SPDXRef-File561",
+		FileSPDXIdentifier: spdx.ElementID("File561"),
 		FileChecksumSHA1:   "6c92dc8bc462b6889d9b1c0bc16c54d19a2cbdd3",
 		LicenseConcluded:   "Apache-2.0",
 		LicenseInfoInFile: []string{
@@ -265,7 +265,7 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 	// f2 will only appear in the first Package
 	f2 := &spdx.File2_1{
 		FileName:           "/project/file2.txt",
-		FileSPDXIdentifier: "SPDXRef-File562",
+		FileSPDXIdentifier: spdx.ElementID("File562"),
 		FileChecksumSHA1:   "066c5139bd9a43d15812ec1a1755b08ccf199824",
 		LicenseConcluded:   "GPL-2.0-or-later",
 		LicenseInfoInFile: []string{
@@ -277,7 +277,7 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 	// f3 will only appear in the second Package
 	f3 := &spdx.File2_1{
 		FileName:           "/project/file3.txt",
-		FileSPDXIdentifier: "SPDXRef-File563",
+		FileSPDXIdentifier: spdx.ElementID("File563"),
 		FileChecksumSHA1:   "bd0f4863b15fad2b79b35303af54fcb5baaf7c68",
 		LicenseConcluded:   "MPL-2.0",
 		LicenseInfoInFile: []string{
@@ -290,7 +290,7 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 	// with same name, same hash and different license
 	f4_1 := &spdx.File2_1{
 		FileName:           "/project/file4.txt",
-		FileSPDXIdentifier: "SPDXRef-File564",
+		FileSPDXIdentifier: spdx.ElementID("File564"),
 		FileChecksumSHA1:   "bc417a575ceae93435bcb7bfd382ac28cbdaa8b5",
 		LicenseConcluded:   "MIT",
 		LicenseInfoInFile: []string{
@@ -300,7 +300,7 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 	}
 	f4_2 := &spdx.File2_1{
 		FileName:           "/project/file4.txt",
-		FileSPDXIdentifier: "SPDXRef-File564",
+		FileSPDXIdentifier: spdx.ElementID("File564"),
 		FileChecksumSHA1:   "bc417a575ceae93435bcb7bfd382ac28cbdaa8b5",
 		LicenseConcluded:   "Apache-2.0 AND MIT",
 		LicenseInfoInFile: []string{
@@ -313,7 +313,7 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 	// with same name, different hash and same license
 	f5_1 := &spdx.File2_1{
 		FileName:           "/project/file5.txt",
-		FileSPDXIdentifier: "SPDXRef-File565",
+		FileSPDXIdentifier: spdx.ElementID("File565"),
 		FileChecksumSHA1:   "ba226db943bbbf455da77afab6f16dbab156d000",
 		LicenseConcluded:   "BSD-3-Clause",
 		LicenseInfoInFile: []string{
@@ -323,7 +323,7 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 	}
 	f5_2 := &spdx.File2_1{
 		FileName:           "/project/file5.txt",
-		FileSPDXIdentifier: "SPDXRef-File565",
+		FileSPDXIdentifier: spdx.ElementID("File565"),
 		FileChecksumSHA1:   "b6e0ec7d085c5699b46f6f8d425413702652874d",
 		LicenseConcluded:   "BSD-3-Clause",
 		LicenseInfoInFile: []string{
@@ -336,7 +336,7 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 	// with same name, different hash and different license
 	f6_1 := &spdx.File2_1{
 		FileName:           "/project/file6.txt",
-		FileSPDXIdentifier: "SPDXRef-File566",
+		FileSPDXIdentifier: spdx.ElementID("File566"),
 		FileChecksumSHA1:   "ba226db943bbbf455da77afab6f16dbab156d000",
 		LicenseConcluded:   "CC0-1.0",
 		LicenseInfoInFile: []string{
@@ -346,7 +346,7 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 	}
 	f6_2 := &spdx.File2_1{
 		FileName:           "/project/file6.txt",
-		FileSPDXIdentifier: "SPDXRef-File566",
+		FileSPDXIdentifier: spdx.ElementID("File566"),
 		FileChecksumSHA1:   "b6e0ec7d085c5699b46f6f8d425413702652874d",
 		LicenseConcluded:   "Unlicense",
 		LicenseInfoInFile: []string{
@@ -358,7 +358,7 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 	// create Packages
 	p1 := &spdx.Package2_1{
 		PackageName:               "p1",
-		PackageSPDXIdentifier:     "SPDXRef-p1",
+		PackageSPDXIdentifier:     spdx.ElementID("p1"),
 		PackageDownloadLocation:   "NOASSERTION",
 		FilesAnalyzed:             true,
 		IsFilesAnalyzedTagPresent: true,
@@ -370,17 +370,17 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 		},
 		PackageLicenseDeclared: "NOASSERTION",
 		PackageCopyrightText:   "NOASSERTION",
-		Files: []*spdx.File2_1{
-			f1,
-			f2,
-			f4_1,
-			f5_1,
-			f6_1,
+		Files: map[spdx.ElementID]*spdx.File2_1{
+			spdx.ElementID(f1.FileSPDXIdentifier):   f1,
+			spdx.ElementID(f2.FileSPDXIdentifier):   f2,
+			spdx.ElementID(f4_1.FileSPDXIdentifier): f4_1,
+			spdx.ElementID(f5_1.FileSPDXIdentifier): f5_1,
+			spdx.ElementID(f6_1.FileSPDXIdentifier): f6_1,
 		},
 	}
 	p2 := &spdx.Package2_1{
 		PackageName:               "p2",
-		PackageSPDXIdentifier:     "SPDXRef-p2",
+		PackageSPDXIdentifier:     spdx.ElementID("p2"),
 		PackageDownloadLocation:   "NOASSERTION",
 		FilesAnalyzed:             true,
 		IsFilesAnalyzedTagPresent: true,
@@ -392,12 +392,12 @@ func TestDifferCanCreateDiffStructuredResults(t *testing.T) {
 		},
 		PackageLicenseDeclared: "NOASSERTION",
 		PackageCopyrightText:   "NOASSERTION",
-		Files: []*spdx.File2_1{
-			f1,
-			f3,
-			f4_2,
-			f5_2,
-			f6_2,
+		Files: map[spdx.ElementID]*spdx.File2_1{
+			spdx.ElementID(f1.FileSPDXIdentifier):   f1,
+			spdx.ElementID(f3.FileSPDXIdentifier):   f3,
+			spdx.ElementID(f4_2.FileSPDXIdentifier): f4_2,
+			spdx.ElementID(f5_2.FileSPDXIdentifier): f5_2,
+			spdx.ElementID(f6_2.FileSPDXIdentifier): f6_2,
 		},
 	}
 

--- a/reporter/reporter_test.go
+++ b/reporter/reporter_test.go
@@ -13,19 +13,19 @@ import (
 func TestReporterCanMakeReportFromPackage(t *testing.T) {
 	pkg := &spdx.Package2_1{
 		FilesAnalyzed: true,
-		Files: []*spdx.File2_1{
-			&spdx.File2_1{LicenseConcluded: "MIT"},
-			&spdx.File2_1{LicenseConcluded: "NOASSERTION"},
-			&spdx.File2_1{LicenseConcluded: "MIT"},
-			&spdx.File2_1{LicenseConcluded: "MIT"},
-			&spdx.File2_1{LicenseConcluded: "GPL-2.0-only"},
-			&spdx.File2_1{LicenseConcluded: "NOASSERTION"},
-			&spdx.File2_1{LicenseConcluded: "GPL-2.0-only"},
-			&spdx.File2_1{LicenseConcluded: "GPL-2.0-only"},
-			&spdx.File2_1{LicenseConcluded: "MIT"},
-			&spdx.File2_1{LicenseConcluded: "GPL-2.0-only"},
-			&spdx.File2_1{LicenseConcluded: "GPL-2.0-only"},
-			&spdx.File2_1{LicenseConcluded: "NOASSERTION"},
+		Files: map[spdx.ElementID]*spdx.File2_1{
+			spdx.ElementID("File0"):  &spdx.File2_1{FileSPDXIdentifier: "File0", LicenseConcluded: "MIT"},
+			spdx.ElementID("File1"):  &spdx.File2_1{FileSPDXIdentifier: "File1", LicenseConcluded: "NOASSERTION"},
+			spdx.ElementID("File2"):  &spdx.File2_1{FileSPDXIdentifier: "File2", LicenseConcluded: "MIT"},
+			spdx.ElementID("File3"):  &spdx.File2_1{FileSPDXIdentifier: "File3", LicenseConcluded: "MIT"},
+			spdx.ElementID("File4"):  &spdx.File2_1{FileSPDXIdentifier: "File4", LicenseConcluded: "GPL-2.0-only"},
+			spdx.ElementID("File5"):  &spdx.File2_1{FileSPDXIdentifier: "File5", LicenseConcluded: "NOASSERTION"},
+			spdx.ElementID("File6"):  &spdx.File2_1{FileSPDXIdentifier: "File6", LicenseConcluded: "GPL-2.0-only"},
+			spdx.ElementID("File7"):  &spdx.File2_1{FileSPDXIdentifier: "File7", LicenseConcluded: "GPL-2.0-only"},
+			spdx.ElementID("File8"):  &spdx.File2_1{FileSPDXIdentifier: "File8", LicenseConcluded: "MIT"},
+			spdx.ElementID("File9"):  &spdx.File2_1{FileSPDXIdentifier: "File9", LicenseConcluded: "GPL-2.0-only"},
+			spdx.ElementID("File10"): &spdx.File2_1{FileSPDXIdentifier: "File10", LicenseConcluded: "GPL-2.0-only"},
+			spdx.ElementID("File11"): &spdx.File2_1{FileSPDXIdentifier: "File11", LicenseConcluded: "NOASSERTION"},
 		},
 	}
 
@@ -71,19 +71,19 @@ func TestReporterReturnsErrorIfPackageFilesNotAnalyzed(t *testing.T) {
 func TestCanGetCountsOfLicenses(t *testing.T) {
 	pkg := &spdx.Package2_1{
 		FilesAnalyzed: true,
-		Files: []*spdx.File2_1{
-			&spdx.File2_1{LicenseConcluded: "MIT"},
-			&spdx.File2_1{LicenseConcluded: "NOASSERTION"},
-			&spdx.File2_1{LicenseConcluded: "MIT"},
-			&spdx.File2_1{LicenseConcluded: "MIT"},
-			&spdx.File2_1{LicenseConcluded: "GPL-2.0-only"},
-			&spdx.File2_1{LicenseConcluded: "NOASSERTION"},
-			&spdx.File2_1{LicenseConcluded: "GPL-2.0-only"},
-			&spdx.File2_1{LicenseConcluded: "GPL-2.0-only"},
-			&spdx.File2_1{LicenseConcluded: "MIT"},
-			&spdx.File2_1{LicenseConcluded: "GPL-2.0-only"},
-			&spdx.File2_1{LicenseConcluded: "GPL-2.0-only"},
-			&spdx.File2_1{LicenseConcluded: "NOASSERTION"},
+		Files: map[spdx.ElementID]*spdx.File2_1{
+			spdx.ElementID("File0"):  &spdx.File2_1{FileSPDXIdentifier: "File0", LicenseConcluded: "MIT"},
+			spdx.ElementID("File1"):  &spdx.File2_1{FileSPDXIdentifier: "File1", LicenseConcluded: "NOASSERTION"},
+			spdx.ElementID("File2"):  &spdx.File2_1{FileSPDXIdentifier: "File2", LicenseConcluded: "MIT"},
+			spdx.ElementID("File3"):  &spdx.File2_1{FileSPDXIdentifier: "File3", LicenseConcluded: "MIT"},
+			spdx.ElementID("File4"):  &spdx.File2_1{FileSPDXIdentifier: "File4", LicenseConcluded: "GPL-2.0-only"},
+			spdx.ElementID("File5"):  &spdx.File2_1{FileSPDXIdentifier: "File5", LicenseConcluded: "NOASSERTION"},
+			spdx.ElementID("File6"):  &spdx.File2_1{FileSPDXIdentifier: "File6", LicenseConcluded: "GPL-2.0-only"},
+			spdx.ElementID("File7"):  &spdx.File2_1{FileSPDXIdentifier: "File7", LicenseConcluded: "GPL-2.0-only"},
+			spdx.ElementID("File8"):  &spdx.File2_1{FileSPDXIdentifier: "File8", LicenseConcluded: "MIT"},
+			spdx.ElementID("File9"):  &spdx.File2_1{FileSPDXIdentifier: "File9", LicenseConcluded: "GPL-2.0-only"},
+			spdx.ElementID("File10"): &spdx.File2_1{FileSPDXIdentifier: "File10", LicenseConcluded: "GPL-2.0-only"},
+			spdx.ElementID("File11"): &spdx.File2_1{FileSPDXIdentifier: "File11", LicenseConcluded: "NOASSERTION"},
 		},
 	}
 

--- a/spdx/annotation.go
+++ b/spdx/annotation.go
@@ -21,7 +21,7 @@ type Annotation2_1 struct {
 
 	// 8.4: SPDX Identifier Reference
 	// Cardinality: conditional (mandatory, one) if there is an Annotation
-	AnnotationSPDXIdentifier string
+	AnnotationSPDXIdentifier DocElementID
 
 	// 8.5: Annotation Comment
 	// Cardinality: conditional (mandatory, one) if there is an Annotation

--- a/spdx/creation_info.go
+++ b/spdx/creation_info.go
@@ -16,7 +16,7 @@ type CreationInfo2_1 struct {
 
 	// 2.3: SPDX Identifier; should be "SPDXRef-DOCUMENT"
 	// Cardinality: mandatory, one
-	SPDXIdentifier string
+	SPDXIdentifier ElementID
 
 	// 2.4: Document Name
 	// Cardinality: mandatory, one

--- a/spdx/document.go
+++ b/spdx/document.go
@@ -7,7 +7,7 @@ package spdx
 // See https://spdx.org/sites/cpstandard/files/pages/files/spdxversion2.1.pdf
 type Document2_1 struct {
 	CreationInfo  *CreationInfo2_1
-	Packages      []*Package2_1
+	Packages      map[ElementID]*Package2_1
 	OtherLicenses []*OtherLicense2_1
 	Relationships []*Relationship2_1
 	Annotations   []*Annotation2_1

--- a/spdx/document.go
+++ b/spdx/document.go
@@ -6,11 +6,12 @@ package spdx
 // Document2_1 is an SPDX Document for version 2.1 of the spec.
 // See https://spdx.org/sites/cpstandard/files/pages/files/spdxversion2.1.pdf
 type Document2_1 struct {
-	CreationInfo  *CreationInfo2_1
-	Packages      map[ElementID]*Package2_1
-	OtherLicenses []*OtherLicense2_1
-	Relationships []*Relationship2_1
-	Annotations   []*Annotation2_1
+	CreationInfo    *CreationInfo2_1
+	Packages        map[ElementID]*Package2_1
+	UnpackagedFiles map[ElementID]*File2_1
+	OtherLicenses   []*OtherLicense2_1
+	Relationships   []*Relationship2_1
+	Annotations     []*Annotation2_1
 
 	// DEPRECATED in version 2.0 of spec
 	Reviews []*Review2_1

--- a/spdx/file.go
+++ b/spdx/file.go
@@ -11,7 +11,7 @@ type File2_1 struct {
 
 	// 4.2: File SPDX Identifier: "SPDXRef-[idstring]"
 	// Cardinality: mandatory, one
-	FileSPDXIdentifier string
+	FileSPDXIdentifier ElementID
 
 	// 4.3: File Type
 	// Cardinality: optional, multiple
@@ -62,7 +62,8 @@ type File2_1 struct {
 	FileDependencies []string
 
 	// Snippets contained in this File
-	Snippets []*Snippet2_1
+	// Note that Snippets could be defined in a different Document!
+	Snippets map[DocElementID]*Snippet2_1
 }
 
 // ArtifactOfProject2_1 is a DEPRECATED collection of data regarding

--- a/spdx/file.go
+++ b/spdx/file.go
@@ -62,8 +62,10 @@ type File2_1 struct {
 	FileDependencies []string
 
 	// Snippets contained in this File
-	// Note that Snippets could be defined in a different Document!
-	Snippets map[DocElementID]*Snippet2_1
+	// Note that Snippets could be defined in a different Document! However,
+	// the only ones that _THIS_ document can contain are this ones that are
+	// defined here -- so this should just be an ElementID.
+	Snippets map[ElementID]*Snippet2_1
 }
 
 // ArtifactOfProject2_1 is a DEPRECATED collection of data regarding

--- a/spdx/identifier.go
+++ b/spdx/identifier.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+package spdx
+
+// ElementID represents the identifier string portion of an SPDX element
+// identifier. DocElementID should be used for any attributes which can
+// contain identifiers defined in a different SPDX document.
+// ElementIDs should NOT contain the mandatory 'SPDXRef-' portion.
+type ElementID string
+
+// DocElementID represents an SPDX element identifier that could be defined
+// in a different SPDX document, and therefore could have a "DocumentRef-"
+// portion, such as Relationships and Annotations.
+// ElementID is used for attributes in which a "DocumentRef-" portion cannot
+// appear, such as a Package or File definition (since it is necessarily
+// being defined in the present document).
+// DocumentRefID will be the empty string for elements defined in the
+// present document.
+// DocElementIDs should NOT contain the mandatory 'DocumentRef-' or
+// 'SPDXRef-' portions.
+type DocElementID struct {
+	DocumentRefID string
+	ElementRefID  ElementID
+}
+
+// TODO: add equivalents for LicenseRef- identifiers

--- a/spdx/identifier.go
+++ b/spdx/identifier.go
@@ -24,3 +24,31 @@ type DocElementID struct {
 }
 
 // TODO: add equivalents for LicenseRef- identifiers
+
+// MakeDocElementID takes strings (without prefixes) for the DocumentRef-
+// and SPDXRef- identifiers, and returns a DocElementID. An empty string
+// should be used for the DocumentRef- portion if it is referring to the
+// present document.
+func MakeDocElementID(docRef string, eltRef string) DocElementID {
+	return DocElementID{
+		DocumentRefID: docRef,
+		ElementRefID:  ElementID(eltRef),
+	}
+}
+
+// RenderElementID takes an ElementID and returns the string equivalent,
+// with the SPDXRef- prefix reinserted.
+func RenderElementID(eID ElementID) string {
+	return "SPDXRef-" + string(eID)
+}
+
+// RenderDocElementID takes a DocElementID and returns the string equivalent,
+// with the SPDXRef- prefix (and, if applicable, the DocumentRef- prefix)
+// reinserted.
+func RenderDocElementID(deID DocElementID) string {
+	prefix := ""
+	if deID.DocumentRefID != "" {
+		prefix = "DocumentRef-" + deID.DocumentRefID + ":"
+	}
+	return prefix + "SPDXRef-" + string(deID.ElementRefID)
+}

--- a/spdx/package.go
+++ b/spdx/package.go
@@ -5,11 +5,6 @@ package spdx
 // Package2_1 is a Package section of an SPDX Document for version 2.1 of the spec.
 type Package2_1 struct {
 
-	// NOT PART OF SPEC
-	// flag: does this "package" contain files that were in fact "unpackaged",
-	// e.g. included directly in the Document without being in a Package?
-	IsUnpackaged bool
-
 	// 3.1: Package Name
 	// Cardinality: mandatory, one
 	PackageName string

--- a/spdx/package.go
+++ b/spdx/package.go
@@ -16,7 +16,7 @@ type Package2_1 struct {
 
 	// 3.2: Package SPDX Identifier: "SPDXRef-[idstring]"
 	// Cardinality: mandatory, one
-	PackageSPDXIdentifier string
+	PackageSPDXIdentifier ElementID
 
 	// 3.3: Package Version
 	// Cardinality: optional, one
@@ -115,7 +115,7 @@ type Package2_1 struct {
 	// contained within PackageExternalReference2_1 struct, if present
 
 	// Files contained in this Package
-	Files []*File2_1
+	Files map[ElementID]*File2_1
 }
 
 // PackageExternalReference2_1 is an External Reference to additional info

--- a/spdx/relationship.go
+++ b/spdx/relationship.go
@@ -11,8 +11,8 @@ type Relationship2_1 struct {
 	//              one mandatory for SPDX Document with multiple packages
 	// RefA and RefB are first and second item
 	// Relationship is type from 7.1.1
-	RefA         string
-	RefB         string
+	RefA         DocElementID
+	RefB         DocElementID
 	Relationship string
 
 	// 7.2: Relationship Comment

--- a/spdx/snippet.go
+++ b/spdx/snippet.go
@@ -7,11 +7,11 @@ type Snippet2_1 struct {
 
 	// 5.1: Snippet SPDX Identifier: "SPDXRef-[idstring]"
 	// Cardinality: mandatory, one
-	SnippetSPDXIdentifier string
+	SnippetSPDXIdentifier ElementID
 
 	// 5.2: Snippet from File SPDX Identifier
 	// Cardinality: mandatory, one
-	SnippetFromFileSPDXIdentifier string
+	SnippetFromFileSPDXIdentifier DocElementID
 
 	// 5.3: Snippet Byte Range: [start byte]:[end byte]
 	// Cardinality: mandatory, one

--- a/spdxlib/described_elements.go
+++ b/spdxlib/described_elements.go
@@ -1,0 +1,75 @@
+// Package spdxlib contains convenience and utility functions for working
+// with an SPDX document that has already been created in memory.
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+package spdxlib
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spdx/tools-golang/spdx"
+)
+
+// GetDescribedPackageIDs2_1 returns a slice of ElementIDs for all Packages
+// in this Document that it "describes," according to SPDX rules:
+// - If the document has only one Package, its ID is returned.
+// - If the document has 2+ Packages, it returns the IDs of those that have
+//   a DESCRIBES (or DESCRIBED_BY) relationship to this DOCUMENT. If no
+// -
+func GetDescribedPackageIDs2_1(doc *spdx.Document2_1) ([]spdx.ElementID, error) {
+	// if nil Packages map or zero packages in it, return empty slice
+	if doc.Packages == nil {
+		return nil, fmt.Errorf("Packages map is nil")
+	}
+	if len(doc.Packages) == 0 {
+		return nil, fmt.Errorf("no Packages in Document")
+	}
+	if len(doc.Packages) == 1 {
+		// get first (only) one and return its ID
+		for i := range doc.Packages {
+			return []spdx.ElementID{i}, nil
+		}
+	}
+
+	// two or more packages, so we need to go through the relationships,
+	// find DESCRIBES or DESCRIBED_BY for this DOCUMENT, verify they are
+	// valid IDs in this document's packages, and return them
+	if doc.Relationships == nil {
+		return nil, fmt.Errorf("multiple Packages in Document but Relationships slice is nil")
+	}
+	// collect IDs as strings so we can sort them easily
+	eIDStrs := []string{}
+	for _, rln := range doc.Relationships {
+		if rln.Relationship == "DESCRIBES" && rln.RefA == spdx.MakeDocElementID("", "DOCUMENT") {
+			// confirm RefB is actually a package in this document
+			if _, ok := doc.Packages[rln.RefB.ElementRefID]; !ok {
+				// if it's an unpackaged file, that's valid (no error) but don't return it
+				if _, ok2 := doc.UnpackagedFiles[rln.RefB.ElementRefID]; !ok2 {
+					return nil, fmt.Errorf("Document DESCRIBES %s but no such Package or unpackaged File", string(rln.RefB.ElementRefID))
+				}
+			}
+			eIDStrs = append(eIDStrs, string(rln.RefB.ElementRefID))
+		}
+		if rln.Relationship == "DESCRIBED_BY" && rln.RefB == spdx.MakeDocElementID("", "DOCUMENT") {
+			// confirm RefA is actually a package in this document
+			// if it's an unpackaged file, that's valid (no error) but don't return it
+			if _, ok := doc.Packages[rln.RefA.ElementRefID]; !ok {
+				// if it's an unpackaged file, that's valid (no error) but don't return it
+				if _, ok2 := doc.UnpackagedFiles[rln.RefA.ElementRefID]; !ok2 {
+					return nil, fmt.Errorf("%s DESCRIBED_BY Document but no such Package or unpackaged File", string(rln.RefA.ElementRefID))
+				}
+			}
+			eIDStrs = append(eIDStrs, string(rln.RefA.ElementRefID))
+		}
+	}
+	if len(eIDStrs) == 0 {
+		return nil, fmt.Errorf("no DESCRIBES or DESCRIBED_BY relationships found for this Document")
+	}
+	// sort them, convert back to ElementIDs and return
+	sort.Strings(eIDStrs)
+	eIDs := []spdx.ElementID{}
+	for _, eIDStr := range eIDStrs {
+		eIDs = append(eIDs, spdx.ElementID(eIDStr))
+	}
+	return eIDs, nil
+}

--- a/spdxlib/described_elements_test.go
+++ b/spdxlib/described_elements_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+package spdxlib
+
+import (
+	"testing"
+
+	"github.com/spdx/tools-golang/spdx"
+)
+
+func TestCanGetIDsOfDescribedPackages(t *testing.T) {
+	// set up document and some packages and relationships
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+		Packages: map[spdx.ElementID]*spdx.Package2_1{
+			spdx.ElementID("p1"): &spdx.Package2_1{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+			spdx.ElementID("p2"): &spdx.Package2_1{PackageName: "pkg2", PackageSPDXIdentifier: "p2"},
+			spdx.ElementID("p3"): &spdx.Package2_1{PackageName: "pkg3", PackageSPDXIdentifier: "p3"},
+			spdx.ElementID("p4"): &spdx.Package2_1{PackageName: "pkg4", PackageSPDXIdentifier: "p4"},
+			spdx.ElementID("p5"): &spdx.Package2_1{PackageName: "pkg5", PackageSPDXIdentifier: "p5"},
+		},
+		Relationships: []*spdx.Relationship2_1{
+			&spdx.Relationship2_1{
+				RefA:         spdx.MakeDocElementID("", "DOCUMENT"),
+				RefB:         spdx.MakeDocElementID("", "p1"),
+				Relationship: "DESCRIBES",
+			},
+			&spdx.Relationship2_1{
+				RefA:         spdx.MakeDocElementID("", "DOCUMENT"),
+				RefB:         spdx.MakeDocElementID("", "p5"),
+				Relationship: "DESCRIBES",
+			},
+			// inverse relationship -- should also get detected
+			&spdx.Relationship2_1{
+				RefA:         spdx.MakeDocElementID("", "p4"),
+				RefB:         spdx.MakeDocElementID("", "DOCUMENT"),
+				Relationship: "DESCRIBED_BY",
+			},
+			// different relationship
+			&spdx.Relationship2_1{
+				RefA:         spdx.MakeDocElementID("", "p1"),
+				RefB:         spdx.MakeDocElementID("", "p2"),
+				Relationship: "DEPENDS_ON",
+			},
+		},
+	}
+
+	// request IDs for DESCRIBES / DESCRIBED_BY relationships
+	describedPkgIDs, err := GetDescribedPackageIDs2_1(doc)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	// should be three of the five IDs, returned in alphabetical order
+	if len(describedPkgIDs) != 3 {
+		t.Fatalf("expected %d packages, got %d", 3, len(describedPkgIDs))
+	}
+	if describedPkgIDs[0] != spdx.ElementID("p1") {
+		t.Errorf("expected %v, got %v", spdx.ElementID("p1"), describedPkgIDs[0])
+	}
+	if describedPkgIDs[1] != spdx.ElementID("p4") {
+		t.Errorf("expected %v, got %v", spdx.ElementID("p4"), describedPkgIDs[1])
+	}
+	if describedPkgIDs[2] != spdx.ElementID("p5") {
+		t.Errorf("expected %v, got %v", spdx.ElementID("p5"), describedPkgIDs[2])
+	}
+}
+
+func TestGetDescribedPackagesReturnsSinglePackageIfOnlyOne(t *testing.T) {
+	// set up document and one package, but no relationships
+	// b/c only one package
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+		Packages: map[spdx.ElementID]*spdx.Package2_1{
+			spdx.ElementID("p1"): &spdx.Package2_1{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+		},
+	}
+
+	// request IDs for DESCRIBES / DESCRIBED_BY relationships
+	describedPkgIDs, err := GetDescribedPackageIDs2_1(doc)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	// should return the single package
+	if len(describedPkgIDs) != 1 {
+		t.Fatalf("expected %d package, got %d", 1, len(describedPkgIDs))
+	}
+	if describedPkgIDs[0] != spdx.ElementID("p1") {
+		t.Errorf("expected %v, got %v", spdx.ElementID("p1"), describedPkgIDs[0])
+	}
+}
+
+func TestFailsToGetDescribedPackagesIfMoreThanOneWithoutDescribesRelationship(t *testing.T) {
+	// set up document and multiple packages, but no DESCRIBES relationships
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+		Packages: map[spdx.ElementID]*spdx.Package2_1{
+			spdx.ElementID("p1"): &spdx.Package2_1{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+			spdx.ElementID("p2"): &spdx.Package2_1{PackageName: "pkg2", PackageSPDXIdentifier: "p2"},
+			spdx.ElementID("p3"): &spdx.Package2_1{PackageName: "pkg3", PackageSPDXIdentifier: "p3"},
+			spdx.ElementID("p4"): &spdx.Package2_1{PackageName: "pkg4", PackageSPDXIdentifier: "p4"},
+			spdx.ElementID("p5"): &spdx.Package2_1{PackageName: "pkg5", PackageSPDXIdentifier: "p5"},
+		},
+		Relationships: []*spdx.Relationship2_1{
+			// different relationship
+			&spdx.Relationship2_1{
+				RefA:         spdx.MakeDocElementID("", "p1"),
+				RefB:         spdx.MakeDocElementID("", "p2"),
+				Relationship: "DEPENDS_ON",
+			},
+		},
+	}
+
+	_, err := GetDescribedPackageIDs2_1(doc)
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}
+
+func TestFailsToGetDescribedPackagesIfMoreThanOneWithNilRelationships(t *testing.T) {
+	// set up document and multiple packages, but no relationships slice
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+		Packages: map[spdx.ElementID]*spdx.Package2_1{
+			spdx.ElementID("p1"): &spdx.Package2_1{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+			spdx.ElementID("p2"): &spdx.Package2_1{PackageName: "pkg2", PackageSPDXIdentifier: "p2"},
+		},
+	}
+
+	_, err := GetDescribedPackageIDs2_1(doc)
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}
+
+func TestFailsToGetDescribedPackagesIfZeroPackagesInMap(t *testing.T) {
+	// set up document but no packages
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+		Packages: map[spdx.ElementID]*spdx.Package2_1{},
+	}
+
+	_, err := GetDescribedPackageIDs2_1(doc)
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}
+
+func TestFailsToGetDescribedPackagesIfNilMap(t *testing.T) {
+	// set up document but no packages
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+	}
+
+	_, err := GetDescribedPackageIDs2_1(doc)
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}
+
+func TestFailsToGetDescribedPackagesIfRelationshipForNonexistantPackageID(t *testing.T) {
+	// set up document and multiple packages, but no DESCRIBES relationships
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+		Packages: map[spdx.ElementID]*spdx.Package2_1{
+			spdx.ElementID("p1"): &spdx.Package2_1{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+			spdx.ElementID("p2"): &spdx.Package2_1{PackageName: "pkg2", PackageSPDXIdentifier: "p2"},
+		},
+		Relationships: []*spdx.Relationship2_1{
+			// different relationship
+			&spdx.Relationship2_1{
+				RefA:         spdx.MakeDocElementID("", "DOCUMENT"),
+				RefB:         spdx.MakeDocElementID("", "p17"),
+				Relationship: "DESCRIBES",
+			},
+		},
+	}
+
+	_, err := GetDescribedPackageIDs2_1(doc)
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}

--- a/tvloader/parser2v1/parse_annotation.go
+++ b/tvloader/parser2v1/parse_annotation.go
@@ -28,7 +28,11 @@ func (parser *tvParser2_1) parsePairForAnnotation2_1(tag string, value string) e
 	case "AnnotationType":
 		parser.ann.AnnotationType = value
 	case "SPDXREF":
-		parser.ann.AnnotationSPDXIdentifier = value
+		deID, err := extractDocElementID(value)
+		if err != nil {
+			return err
+		}
+		parser.ann.AnnotationSPDXIdentifier = deID
 	case "AnnotationComment":
 		parser.ann.AnnotationComment = value
 	default:

--- a/tvloader/parser2v1/parse_annotation_test.go
+++ b/tvloader/parser2v1/parse_annotation_test.go
@@ -19,6 +19,23 @@ func TestParser2_1FailsIfAnnotationNotSet(t *testing.T) {
 	}
 }
 
+func TestParser2_1FailsIfAnnotationTagUnknown(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{},
+		st:  psCreationInfo2_1,
+	}
+	// start with valid annotator
+	err := parser.parsePair2_1("Annotator", "Person: John Doe (jdoe@example.com)")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// parse invalid tag, using parsePairForAnnotation2_1(
+	err = parser.parsePairForAnnotation2_1("blah", "oops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
 func TestParser2_1FailsIfAnnotationFieldsWithoutAnnotation(t *testing.T) {
 	parser := tvParser2_1{
 		doc: &spdx.Document2_1{},
@@ -101,3 +118,42 @@ func TestParser2_1CanParseAnnotationTags(t *testing.T) {
 		t.Errorf("got %v for AnnotationComment, expected %v", parser.ann.AnnotationComment, cmt)
 	}
 }
+
+func TestParser2_1FailsIfAnnotatorInvalid(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{},
+		st:  psCreationInfo2_1,
+	}
+	err := parser.parsePair2_1("Annotator", "John Doe (jdoe@example.com)")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfAnnotatorTypeInvalid(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{},
+		st:  psCreationInfo2_1,
+	}
+	err := parser.parsePair2_1("Annotator", "Human: John Doe (jdoe@example.com)")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfAnnotationRefInvalid(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{},
+		st:  psCreationInfo2_1,
+	}
+	// start with valid annotator
+	err := parser.parsePair2_1("Annotator", "Person: John Doe (jdoe@example.com)")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	err = parser.parsePair2_1("SPDXREF", "blah:other")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+

--- a/tvloader/parser2v1/parse_annotation_test.go
+++ b/tvloader/parser2v1/parse_annotation_test.go
@@ -86,8 +86,9 @@ func TestParser2_1CanParseAnnotationTags(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
-	if parser.ann.AnnotationSPDXIdentifier != ref {
-		t.Errorf("got %v for SPDXREF, expected %v", parser.ann.AnnotationSPDXIdentifier, ref)
+	deID := parser.ann.AnnotationSPDXIdentifier
+	if deID.DocumentRefID != "" || deID.ElementRefID != "30" {
+		t.Errorf("got %v for SPDXREF, expected %v", parser.ann.AnnotationSPDXIdentifier, "30")
 	}
 
 	// Annotation Comment

--- a/tvloader/parser2v1/parse_creation_info.go
+++ b/tvloader/parser2v1/parse_creation_info.go
@@ -26,7 +26,7 @@ func (parser *tvParser2_1) parsePairFromCreationInfo2_1(tag string, value string
 	case "DataLicense":
 		ci.DataLicense = value
 	case "SPDXID":
-		ci.SPDXIdentifier = value
+		ci.SPDXIdentifier = spdx.ElementID(value)
 	case "DocumentName":
 		ci.DocumentName = value
 	case "DocumentNamespace":
@@ -61,22 +61,15 @@ func (parser *tvParser2_1) parsePairFromCreationInfo2_1(tag string, value string
 	case "PackageName":
 		parser.st = psPackage2_1
 		parser.pkg = &spdx.Package2_1{
-			IsUnpackaged:              false,
 			FilesAnalyzed:             true,
 			IsFilesAnalyzedTagPresent: false,
 		}
-		parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
 		return parser.parsePairFromPackage2_1(tag, value)
 	// tag for going on to _unpackaged_ file section
 	case "FileName":
-		// create an "unpackaged" Package structure
+		// leave pkg as nil, so that packages will be placed in UnpackagedFiles
 		parser.st = psFile2_1
-		parser.pkg = &spdx.Package2_1{
-			IsUnpackaged:              true,
-			FilesAnalyzed:             true,
-			IsFilesAnalyzedTagPresent: false,
-		}
-		parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
+		parser.pkg = nil
 		return parser.parsePairFromFile2_1(tag, value)
 	// tag for going on to other license section
 	case "LicenseID":

--- a/tvloader/parser2v1/parse_creation_info_test.go
+++ b/tvloader/parser2v1/parse_creation_info_test.go
@@ -162,6 +162,17 @@ func TestParser2_1CIStaysAfterParsingAnnotationTags(t *testing.T) {
 	}
 }
 
+func TestParser2_1FailsParsingCreationInfoWithInvalidState(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{},
+		st:  psPackage2_1,
+	}
+	err := parser.parsePairFromCreationInfo2_1("SPDXVersion", "SPDX-2.1")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
 // ===== Creation Info section tests =====
 func TestParser2_1HasCreationInfoAfterCallToParseFirstTag(t *testing.T) {
 	parser := tvParser2_1{

--- a/tvloader/parser2v1/parse_file.go
+++ b/tvloader/parser2v1/parse_file.go
@@ -19,7 +19,6 @@ func (parser *tvParser2_1) parsePairFromFile2_1(tag string, value string) error 
 	// tag for creating new file section
 	case "FileName":
 		parser.file = &spdx.File2_1{}
-		parser.pkg.Files = append(parser.pkg.Files, parser.file)
 		parser.file.FileName = value
 	// tag for creating new package section and going back to parsing Package
 	case "PackageName":
@@ -36,7 +35,22 @@ func (parser *tvParser2_1) parsePairFromFile2_1(tag string, value string) error 
 		return parser.parsePairFromOtherLicense2_1(tag, value)
 	// tags for file data
 	case "SPDXID":
-		parser.file.FileSPDXIdentifier = value
+		eID, err := extractElementID(value)
+		if err != nil {
+			return err
+		}
+		parser.file.FileSPDXIdentifier = eID
+		if parser.pkg == nil {
+			if parser.doc.UnpackagedFiles == nil {
+				parser.doc.UnpackagedFiles = map[spdx.ElementID]*spdx.File2_1{}
+			}
+			parser.doc.UnpackagedFiles[eID] = parser.file
+		} else {
+			if parser.pkg.Files == nil {
+				parser.pkg.Files = map[spdx.ElementID]*spdx.File2_1{}
+			}
+			parser.pkg.Files[eID] = parser.file
+		}
 	case "FileType":
 		parser.file.FileType = append(parser.file.FileType, value)
 	case "FileChecksum":

--- a/tvloader/parser2v1/parse_file_test.go
+++ b/tvloader/parser2v1/parse_file_test.go
@@ -784,3 +784,105 @@ func TestFileAOPPointerChangesAfterTags(t *testing.T) {
 		t.Errorf("expected nil AOP pointer, got %v", parser.fileAOP)
 	}
 }
+
+func TestParser2_1FailsIfInvalidSPDXIDInFileSection(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psFile2_1,
+		pkg: &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+	}
+	parser.doc.Packages["test"] = parser.pkg
+
+	// start with File Name
+	err := parser.parsePairFromFile2_1("FileName", "f1.txt")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid SPDX Identifier
+	err = parser.parsePairFromFile2_1("SPDXID", "whoops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfInvalidChecksumFormatInFileSection(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psFile2_1,
+		pkg: &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+	}
+	parser.doc.Packages["test"] = parser.pkg
+
+	// start with File Name
+	err := parser.parsePairFromFile2_1("FileName", "f1.txt")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid format for checksum line, missing colon
+	err = parser.parsePairFromFile2_1("FileChecksum", "SHA1 85ed0817af83a24ad8da68c2b5094de69833983c")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfUnknownChecksumTypeInFileSection(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psFile2_1,
+		pkg: &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+	}
+	parser.doc.Packages["test"] = parser.pkg
+
+	// start with File Name
+	err := parser.parsePairFromFile2_1("FileName", "f1.txt")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// unknown checksum type
+	err = parser.parsePairFromFile2_1("FileChecksum", "Special: 85ed0817af83a24ad8da68c2b5094de69833983c")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfArtifactHomePageBeforeArtifactName(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psFile2_1,
+		pkg: &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+	}
+	parser.doc.Packages["test"] = parser.pkg
+
+	// start with File Name
+	err := parser.parsePairFromFile2_1("FileName", "f1.txt")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// artifact home page appears before artifact name
+	err = parser.parsePairFromFile2_1("ArtifactOfProjectHomePage", "https://example.com")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfArtifactURIBeforeArtifactName(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psFile2_1,
+		pkg: &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+	}
+	parser.doc.Packages["test"] = parser.pkg
+
+	// start with File Name
+	err := parser.parsePairFromFile2_1("FileName", "f1.txt")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// artifact home page appears before artifact name
+	err = parser.parsePairFromFile2_1("ArtifactOfProjectURI", "https://example.com")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+

--- a/tvloader/parser2v1/parse_file_test.go
+++ b/tvloader/parser2v1/parse_file_test.go
@@ -13,20 +13,23 @@ func TestParser2_1FileStartsNewFileAfterParsingFileNameTag(t *testing.T) {
 	fileOldName := "f1.txt"
 
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psFile2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: fileOldName},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: fileOldName, FileSPDXIdentifier: "f1"},
 	}
 	fileOld := parser.file
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, fileOld)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = fileOld
 	// the Package's Files should have this one only
-	if parser.pkg.Files[0] != fileOld {
-		t.Errorf("Expected file %v in Files[0], got %v", fileOld, parser.pkg.Files[0])
+	if len(parser.pkg.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(parser.pkg.Files))
 	}
-	if parser.pkg.Files[0].FileName != fileOldName {
-		t.Errorf("expected file name %s in Files[0], got %s", fileOldName, parser.pkg.Files[0].FileName)
+	if parser.pkg.Files["f1"] != fileOld {
+		t.Errorf("expected file %v in Files[f1], got %v", fileOld, parser.pkg.Files["f1"])
+	}
+	if parser.pkg.Files["f1"].FileName != fileOldName {
+		t.Errorf("expected file name %s in Files[f1], got %s", fileOldName, parser.pkg.Files["f1"].FileName)
 	}
 
 	// now add a new file
@@ -47,18 +50,96 @@ func TestParser2_1FileStartsNewFileAfterParsingFileNameTag(t *testing.T) {
 	if parser.file.FileName != fileName {
 		t.Errorf("expected file name %s, got %s", fileName, parser.file.FileName)
 	}
-	// and the Package's Files should be of size 2 and have these two
-	if parser.pkg.Files[0] != fileOld {
-		t.Errorf("Expected file %v in Files[0], got %v", fileOld, parser.pkg.Files[0])
+	// and the Package's Files should still be of size 1 and not have this new
+	// one yet, since it hasn't seen an SPDX identifier
+	if len(parser.pkg.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(parser.pkg.Files))
 	}
-	if parser.pkg.Files[0].FileName != fileOldName {
-		t.Errorf("expected file name %s in Files[0], got %s", fileOldName, parser.pkg.Files[0].FileName)
+	if parser.pkg.Files["f1"] != fileOld {
+		t.Errorf("expected file %v in Files[f1], got %v", fileOld, parser.pkg.Files["f1"])
 	}
-	if parser.pkg.Files[1] != parser.file {
-		t.Errorf("Expected file %v in Files[1], got %v", parser.file, parser.pkg.Files[1])
+	if parser.pkg.Files["f1"].FileName != fileOldName {
+		t.Errorf("expected file name %s in Files[f1], got %s", fileOldName, parser.pkg.Files["f1"].FileName)
 	}
-	if parser.pkg.Files[1].FileName != fileName {
-		t.Errorf("expected file name %s in Files[1], got %s", fileName, parser.pkg.Files[1].FileName)
+
+	// now parse an SPDX identifier tag
+	err = parser.parsePair2_1("SPDXID", "SPDXRef-f2ID")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	// and the Package's Files should now be of size 2 and have this new one
+	if len(parser.pkg.Files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(parser.pkg.Files))
+	}
+	if parser.pkg.Files["f1"] != fileOld {
+		t.Errorf("expected file %v in Files[f1], got %v", fileOld, parser.pkg.Files["f1"])
+	}
+	if parser.pkg.Files["f1"].FileName != fileOldName {
+		t.Errorf("expected file name %s in Files[f1], got %s", fileOldName, parser.pkg.Files["f1"].FileName)
+	}
+	if parser.pkg.Files["f2ID"] != parser.file {
+		t.Errorf("expected file %v in Files[f2ID], got %v", parser.file, parser.pkg.Files["f2ID"])
+	}
+	if parser.pkg.Files["f2ID"].FileName != fileName {
+		t.Errorf("expected file name %s in Files[f2ID], got %s", fileName, parser.pkg.Files["f2ID"].FileName)
+	}
+}
+
+func TestParser2_1FileAddsToPackageOrUnpackagedFiles(t *testing.T) {
+	// start with no packages
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{},
+		st:  psCreationInfo2_1,
+	}
+
+	// add a file and SPDX identifier
+	fileName := "f2.txt"
+	err := parser.parsePair2_1("FileName", fileName)
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	err = parser.parsePair2_1("SPDXID", "SPDXRef-f2ID")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	fileOld := parser.file
+	// should have been added to UnpackagedFiles
+	if len(parser.doc.UnpackagedFiles) != 1 {
+		t.Fatalf("expected 1 file in UnpackagedFiles, got %d", len(parser.doc.UnpackagedFiles))
+	}
+	if parser.doc.UnpackagedFiles["f2ID"] != fileOld {
+		t.Errorf("expected file %v in UnpackagedFiles[f2ID], got %v", fileOld, parser.doc.UnpackagedFiles["f2ID"])
+	}
+	// now create a package and a new file
+	err = parser.parsePair2_1("PackageName", "package1")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	err = parser.parsePair2_1("SPDXID", "SPDXRef-pkg1")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	err = parser.parsePair2_1("FileName", "f3.txt")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	err = parser.parsePair2_1("SPDXID", "SPDXRef-f3ID")
+	if err != nil {
+		t.Errorf("got error when calling parsePair2_1: %v", err)
+	}
+	// UnpackagedFiles should still be size 1 and have old file only
+	if len(parser.doc.UnpackagedFiles) != 1 {
+		t.Fatalf("expected 1 file in UnpackagedFiles, got %d", len(parser.doc.UnpackagedFiles))
+	}
+	if parser.doc.UnpackagedFiles["f2ID"] != fileOld {
+		t.Errorf("expected file %v in UnpackagedFiles[f2ID], got %v", fileOld, parser.doc.UnpackagedFiles["f2ID"])
+	}
+	// and new package should have gotten the new file
+	if len(parser.pkg.Files) != 1 {
+		t.Fatalf("expected 1 file in Files, got %d", len(parser.pkg.Files))
+	}
+	if parser.pkg.Files["f3ID"] != parser.file {
+		t.Errorf("expected file %v in Files[f3ID], got %v", parser.file, parser.pkg.Files["f3ID"])
 	}
 }
 
@@ -68,15 +149,15 @@ func TestParser2_1FileStartsNewPackageAfterParsingPackageNameTag(t *testing.T) {
 	f1Name := "f1.txt"
 
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psFile2_1,
-		pkg:  &spdx.Package2_1{PackageName: p1Name},
-		file: &spdx.File2_1{FileName: f1Name},
+		pkg:  &spdx.Package2_1{PackageName: p1Name, PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: f1Name, FileSPDXIdentifier: "f1"},
 	}
 	p1 := parser.pkg
 	f1 := parser.file
-	parser.doc.Packages = append(parser.doc.Packages, p1)
-	parser.pkg.Files = append(parser.pkg.Files, f1)
+	parser.doc.Packages["package1"] = p1
+	parser.pkg.Files["f1"] = f1
 
 	// now add a new package
 	p2Name := "package2"
@@ -103,36 +184,30 @@ func TestParser2_1FileStartsNewPackageAfterParsingPackageNameTag(t *testing.T) {
 	if parser.pkg.IsFilesAnalyzedTagPresent != false {
 		t.Errorf("expected IsFilesAnalyzedTagPresent to default to false, got true")
 	}
-	// and the package should _not_ be an "unpackaged" placeholder
-	if parser.pkg.IsUnpackaged == true {
-		t.Errorf("package incorrectly has IsUnpackaged flag set")
+	// and the new Package should have no files
+	if len(parser.pkg.Files) != 0 {
+		t.Errorf("Expected no files in pkg.Files, got %d", len(parser.pkg.Files))
 	}
-	// and the Document's Packages should be of size 2 and have these two
-	if parser.doc.Packages[0] != p1 {
-		t.Errorf("Expected package %v in Packages[0], got %v", p1, parser.doc.Packages[0])
+	// and the Document's Packages should still be of size 1 and not have this
+	// new one, because no SPDX identifier has been seen yet
+	if len(parser.doc.Packages) != 1 {
+		t.Fatalf("expected 1 package, got %d", len(parser.doc.Packages))
 	}
-	if parser.doc.Packages[0].PackageName != p1Name {
-		t.Errorf("expected package name %s in Packages[0], got %s", p1Name, parser.doc.Packages[0].PackageName)
+	if parser.doc.Packages["package1"] != p1 {
+		t.Errorf("Expected package %v in Packages[package1], got %v", p1, parser.doc.Packages["package1"])
 	}
-	if parser.doc.Packages[1] != parser.pkg {
-		t.Errorf("Expected package %v in Packages[1], got %v", parser.pkg, parser.doc.Packages[1])
-	}
-	if parser.doc.Packages[1].PackageName != p2Name {
-		t.Errorf("expected package name %s in Packages[1], got %s", p2Name, parser.doc.Packages[1].PackageName)
+	if parser.doc.Packages["package1"].PackageName != p1Name {
+		t.Errorf("expected package name %s in Packages[package1], got %s", p1Name, parser.doc.Packages["package1"].PackageName)
 	}
 	// and the first Package's Files should be of size 1 and have f1 only
-	if len(parser.doc.Packages[0].Files) != 1 {
-		t.Errorf("Expected 1 file in Packages[0].Files, got %d", len(parser.doc.Packages[0].Files))
+	if len(parser.doc.Packages["package1"].Files) != 1 {
+		t.Errorf("Expected 1 file in Packages[package1].Files, got %d", len(parser.doc.Packages["package1"].Files))
 	}
-	if parser.doc.Packages[0].Files[0] != f1 {
-		t.Errorf("Expected file %v in Files[0], got %v", f1, parser.doc.Packages[0].Files[0])
+	if parser.doc.Packages["package1"].Files["f1"] != f1 {
+		t.Errorf("Expected file %v in Files[f1], got %v", f1, parser.doc.Packages["package1"].Files["f1"])
 	}
-	if parser.doc.Packages[0].Files[0].FileName != f1Name {
-		t.Errorf("expected file name %s in Files[0], got %s", f1Name, parser.doc.Packages[0].Files[0].FileName)
-	}
-	// and the second Package should have no files
-	if len(parser.doc.Packages[1].Files) != 0 {
-		t.Errorf("Expected no files in Packages[1].Files, got %d", len(parser.doc.Packages[1].Files))
+	if parser.doc.Packages["package1"].Files["f1"].FileName != f1Name {
+		t.Errorf("expected file name %s in Files[f1], got %s", f1Name, parser.doc.Packages["package1"].Files["f1"].FileName)
 	}
 	// and the current file should be nil
 	if parser.file != nil {
@@ -142,13 +217,13 @@ func TestParser2_1FileStartsNewPackageAfterParsingPackageNameTag(t *testing.T) {
 
 func TestParser2_1FileMovesToSnippetAfterParsingSnippetSPDXIDTag(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psFile2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	fileCurrent := parser.file
 
 	err := parser.parsePair2_1("SnippetSPDXID", "SPDXRef-Test1")
@@ -167,13 +242,13 @@ func TestParser2_1FileMovesToSnippetAfterParsingSnippetSPDXIDTag(t *testing.T) {
 
 func TestParser2_1FileMovesToOtherLicenseAfterParsingLicenseIDTag(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psFile2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 
 	err := parser.parsePair2_1("LicenseID", "LicenseRef-TestLic")
 	if err != nil {
@@ -186,13 +261,13 @@ func TestParser2_1FileMovesToOtherLicenseAfterParsingLicenseIDTag(t *testing.T) 
 
 func TestParser2_1FileMovesToReviewAfterParsingReviewerTag(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psFile2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 
 	err := parser.parsePair2_1("Reviewer", "Person: John Doe")
 	if err != nil {
@@ -205,15 +280,15 @@ func TestParser2_1FileMovesToReviewAfterParsingReviewerTag(t *testing.T) {
 
 func TestParser2_1FileStaysAfterParsingRelationshipTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psFile2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 
-	err := parser.parsePair2_1("Relationship", "blah CONTAINS blah-else")
+	err := parser.parsePair2_1("Relationship", "SPDXRef-blah CONTAINS SPDXRef-blah-else")
 	if err != nil {
 		t.Errorf("got error when calling parsePair2_1: %v", err)
 	}
@@ -234,13 +309,13 @@ func TestParser2_1FileStaysAfterParsingRelationshipTags(t *testing.T) {
 
 func TestParser2_1FileStaysAfterParsingAnnotationTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psFile2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 
 	err := parser.parsePair2_1("Annotator", "Person: John Doe ()")
 	if err != nil {
@@ -286,12 +361,11 @@ func TestParser2_1FileStaysAfterParsingAnnotationTags(t *testing.T) {
 // ===== File data section tests =====
 func TestParser2_1CanParseFileTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc: &spdx.Document2_1{},
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:  psFile2_1,
-		pkg: &spdx.Package2_1{PackageName: "test"},
+		pkg: &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
 
 	// File Name
 	err := parser.parsePairFromFile2_1("FileName", "f1.txt")
@@ -301,14 +375,26 @@ func TestParser2_1CanParseFileTags(t *testing.T) {
 	if parser.file.FileName != "f1.txt" {
 		t.Errorf("got %v for FileName", parser.file.FileName)
 	}
+	// should not yet be added to the Packages file list, because we haven't
+	// seen an SPDX identifier yet
+	if len(parser.pkg.Files) != 0 {
+		t.Errorf("expected 0 files, got %d", len(parser.pkg.Files))
+	}
 
 	// File SPDX Identifier
 	err = parser.parsePairFromFile2_1("SPDXID", "SPDXRef-f1")
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
-	if parser.file.FileSPDXIdentifier != "SPDXRef-f1" {
+	if parser.file.FileSPDXIdentifier != "f1" {
 		t.Errorf("got %v for FileSPDXIdentifier", parser.file.FileSPDXIdentifier)
+	}
+	// should now be added to the Packages file list
+	if len(parser.pkg.Files) != 1 {
+		t.Errorf("expected 1 file, got %d", len(parser.pkg.Files))
+	}
+	if parser.pkg.Files["f1"] != parser.file {
+		t.Errorf("expected Files[f1] to be %v, got %v", parser.file, parser.pkg.Files["f1"])
 	}
 
 	// File Type
@@ -584,15 +670,15 @@ func TestParser2_1CanParseFileTags(t *testing.T) {
 
 func TestParser2_1FileCreatesRelationshipInDocument(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psFile2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 
-	err := parser.parsePair2_1("Relationship", "blah CONTAINS blah-whatever")
+	err := parser.parsePair2_1("Relationship", "SPDXRef-blah CONTAINS SPDXRef-blah-whatever")
 	if err != nil {
 		t.Errorf("got error when calling parsePair2_1: %v", err)
 	}
@@ -606,13 +692,13 @@ func TestParser2_1FileCreatesRelationshipInDocument(t *testing.T) {
 
 func TestParser2_1FileCreatesAnnotationInDocument(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psFile2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 
 	err := parser.parsePair2_1("Annotator", "Person: John Doe ()")
 	if err != nil {
@@ -628,13 +714,13 @@ func TestParser2_1FileCreatesAnnotationInDocument(t *testing.T) {
 
 func TestParser2_1FileUnknownTagFails(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psFile2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 
 	err := parser.parsePairFromFile2_1("blah", "something")
 	if err == nil {
@@ -644,13 +730,13 @@ func TestParser2_1FileUnknownTagFails(t *testing.T) {
 
 func TestFileAOPPointerChangesAfterTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psFile2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 
 	err := parser.parsePairFromFile2_1("ArtifactOfProjectName", "project1")
 	if err != nil {

--- a/tvloader/parser2v1/parse_other_license_test.go
+++ b/tvloader/parser2v1/parse_other_license_test.go
@@ -14,18 +14,18 @@ func TestParser2_1OLStartsNewOtherLicenseAfterParsingLicenseIDTag(t *testing.T) 
 	olname1 := "License 11"
 
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psOtherLicense2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: olid1,
 			LicenseName:       olname1,
 		},
 	}
 	olic1 := parser.otherLic
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 
 	// the Document's OtherLicenses should have this one only
@@ -90,13 +90,13 @@ func TestParser2_1OLStartsNewOtherLicenseAfterParsingLicenseIDTag(t *testing.T) 
 
 func TestParser2_1OLMovesToReviewAfterParsingReviewerTag(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psOtherLicense2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 
 	err := parser.parsePair2_1("Reviewer", "Person: John Doe")
@@ -110,20 +110,20 @@ func TestParser2_1OLMovesToReviewAfterParsingReviewerTag(t *testing.T) {
 
 func TestParser2_1OtherLicenseStaysAfterParsingRelationshipTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psOtherLicense2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: "LicenseRef-whatever",
 			LicenseName:       "the whatever license",
 		},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 
-	err := parser.parsePair2_1("Relationship", "blah CONTAINS blah-else")
+	err := parser.parsePair2_1("Relationship", "SPDXRef-blah CONTAINS SPDXRef-blah-else")
 	if err != nil {
 		t.Errorf("got error when calling parsePair2_1: %v", err)
 	}
@@ -135,7 +135,8 @@ func TestParser2_1OtherLicenseStaysAfterParsingRelationshipTags(t *testing.T) {
 	if len(parser.doc.Relationships) != 1 {
 		t.Fatalf("expected doc.Relationships to have len 1, got %d", len(parser.doc.Relationships))
 	}
-	if parser.doc.Relationships[0].RefA != "blah" {
+	deID := parser.doc.Relationships[0].RefA
+	if deID.DocumentRefID != "" || deID.ElementRefID != "blah" {
 		t.Errorf("expected RefA to be %s, got %s", "blah", parser.doc.Relationships[0].RefA)
 	}
 
@@ -151,17 +152,17 @@ func TestParser2_1OtherLicenseStaysAfterParsingRelationshipTags(t *testing.T) {
 
 func TestParser2_1OtherLicenseStaysAfterParsingAnnotationTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psOtherLicense2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: "LicenseRef-whatever",
 			LicenseName:       "the whatever license",
 		},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 
 	err := parser.parsePair2_1("Annotator", "Person: John Doe ()")
@@ -215,17 +216,17 @@ func TestParser2_1OtherLicenseStaysAfterParsingAnnotationTags(t *testing.T) {
 
 func TestParser2_1OLFailsAfterParsingOtherSectionTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psOtherLicense2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: "LicenseRef-Lic11",
 			LicenseName:       "License 11",
 		},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 
 	// can't go back to old sections
@@ -246,13 +247,13 @@ func TestParser2_1OLFailsAfterParsingOtherSectionTags(t *testing.T) {
 // ===== Other License data section tests =====
 func TestParser2_1CanParseOtherLicenseTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psOtherLicense2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 
 	// License Identifier
@@ -322,13 +323,13 @@ func TestParser2_1CanParseOtherLicenseTags(t *testing.T) {
 
 func TestParser2_1OLUnknownTagFails(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psOtherLicense2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 
 	err := parser.parsePairFromOtherLicense2_1("blah", "something")

--- a/tvloader/parser2v1/parse_package.go
+++ b/tvloader/parser2v1/parse_package.go
@@ -19,13 +19,11 @@ func (parser *tvParser2_1) parsePairFromPackage2_1(tag string, value string) err
 	switch tag {
 	case "PackageName":
 		// if package already has a name, create and go on to a new package
-		if parser.pkg.PackageName != "" || parser.pkg.IsUnpackaged == true {
+		if parser.pkg == nil || parser.pkg.PackageName != "" {
 			parser.pkg = &spdx.Package2_1{
-				IsUnpackaged:              false,
 				FilesAnalyzed:             true,
 				IsFilesAnalyzedTagPresent: false,
 			}
-			parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
 		}
 		parser.pkg.PackageName = value
 	// tag for going on to file section
@@ -37,7 +35,15 @@ func (parser *tvParser2_1) parsePairFromPackage2_1(tag string, value string) err
 		parser.st = psOtherLicense2_1
 		return parser.parsePairFromOtherLicense2_1(tag, value)
 	case "SPDXID":
-		parser.pkg.PackageSPDXIdentifier = value
+		eID, err := extractElementID(value)
+		if err != nil {
+			return err
+		}
+		parser.pkg.PackageSPDXIdentifier = eID
+		if parser.doc.Packages == nil {
+			parser.doc.Packages = map[spdx.ElementID]*spdx.Package2_1{}
+		}
+		parser.doc.Packages[eID] = parser.pkg
 	case "PackageVersion":
 		parser.pkg.PackageVersion = value
 	case "PackageFileName":

--- a/tvloader/parser2v1/parse_package.go
+++ b/tvloader/parser2v1/parse_package.go
@@ -80,7 +80,7 @@ func (parser *tvParser2_1) parsePairFromPackage2_1(tag string, value string) err
 		case "Organization":
 			parser.pkg.PackageOriginatorOrganization = subvalue
 		default:
-			return fmt.Errorf("unrecognized PackageSupplier type %v", subkey)
+			return fmt.Errorf("unrecognized PackageOriginator type %v", subkey)
 		}
 	case "PackageDownloadLocation":
 		parser.pkg.PackageDownloadLocation = value

--- a/tvloader/parser2v1/parse_package_test.go
+++ b/tvloader/parser2v1/parse_package_test.go
@@ -808,6 +808,202 @@ func TestParser2_1PackageUnknownTagFails(t *testing.T) {
 	}
 }
 
+func TestParser2_1FailsIfInvalidSPDXIDInPackageSection(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psPackage2_1,
+		pkg: &spdx.Package2_1{},
+	}
+
+	// start with Package Name
+	err := parser.parsePairFromPackage2_1("PackageName", "p1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid ID format
+	err = parser.parsePairFromPackage2_1("SPDXID", "whoops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfInvalidPackageSupplierFormat(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psPackage2_1,
+		pkg: &spdx.Package2_1{},
+	}
+
+	// start with Package Name
+	err := parser.parsePairFromPackage2_1("PackageName", "p1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid supplier format
+	err = parser.parsePairFromPackage2_1("PackageSupplier", "whoops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfUnknownPackageSupplierType(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psPackage2_1,
+		pkg: &spdx.Package2_1{},
+	}
+
+	// start with Package Name
+	err := parser.parsePairFromPackage2_1("PackageName", "p1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid supplier type
+	err = parser.parsePairFromPackage2_1("PackageSupplier", "whoops: John Doe")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfInvalidPackageOriginatorFormat(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psPackage2_1,
+		pkg: &spdx.Package2_1{},
+	}
+
+	// start with Package Name
+	err := parser.parsePairFromPackage2_1("PackageName", "p1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid originator format
+	err = parser.parsePairFromPackage2_1("PackageOriginator", "whoops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfUnknownPackageOriginatorType(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psPackage2_1,
+		pkg: &spdx.Package2_1{},
+	}
+
+	// start with Package Name
+	err := parser.parsePairFromPackage2_1("PackageName", "p1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid originator type
+	err = parser.parsePairFromPackage2_1("PackageOriginator", "whoops: John Doe")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1SetsFilesAnalyzedTagsCorrectly(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psPackage2_1,
+		pkg: &spdx.Package2_1{},
+	}
+
+	// start with Package Name
+	err := parser.parsePairFromPackage2_1("PackageName", "p1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// set tag
+	err = parser.parsePairFromPackage2_1("FilesAnalyzed", "true")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if parser.pkg.FilesAnalyzed != true {
+		t.Errorf("expected %v, got %v", true, parser.pkg.FilesAnalyzed)
+	}
+	if parser.pkg.IsFilesAnalyzedTagPresent != true {
+		t.Errorf("expected %v, got %v", true, parser.pkg.IsFilesAnalyzedTagPresent)
+	}
+}
+
+func TestParser2_1FailsIfInvalidPackageChecksumFormat(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psPackage2_1,
+		pkg: &spdx.Package2_1{},
+	}
+
+	// start with Package Name
+	err := parser.parsePairFromPackage2_1("PackageName", "p1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid checksum format
+	err = parser.parsePairFromPackage2_1("PackageChecksum", "whoops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfInvalidPackageChecksumType(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psPackage2_1,
+		pkg: &spdx.Package2_1{},
+	}
+
+	// start with Package Name
+	err := parser.parsePairFromPackage2_1("PackageName", "p1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid checksum type
+	err = parser.parsePairFromPackage2_1("PackageChecksum", "whoops: blah")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfInvalidExternalRefFormat(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psPackage2_1,
+		pkg: &spdx.Package2_1{},
+	}
+
+	// start with Package Name
+	err := parser.parsePairFromPackage2_1("PackageName", "p1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid external ref format
+	err = parser.parsePairFromPackage2_1("ExternalRef", "whoops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfExternalRefCommentBeforeExternalRef(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:  psPackage2_1,
+		pkg: &spdx.Package2_1{},
+	}
+
+	// start with Package Name
+	err := parser.parsePairFromPackage2_1("PackageName", "p1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// external ref comment before external ref
+	err = parser.parsePairFromPackage2_1("ExternalRefComment", "whoops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
 // ===== Helper function tests =====
 
 func TestCanCheckAndExtractExcludesFilenameAndCode(t *testing.T) {
@@ -865,3 +1061,11 @@ func TestCanExtractPackageExternalReferenceWithExtraWhitespace(t *testing.T) {
 		t.Errorf("expected location %s, got %s", location, gotLocation)
 	}
 }
+
+func TestFailsPackageExternalRefWithInvalidFormat(t *testing.T) {
+	_, _, _, err := extractPackageExternalReference("whoops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+

--- a/tvloader/parser2v1/parse_relationship.go
+++ b/tvloader/parser2v1/parse_relationship.go
@@ -29,9 +29,17 @@ func (parser *tvParser2_1) parsePairForRelationship2_1(tag string, value string)
 			return fmt.Errorf("invalid relationship format for %s", value)
 		}
 
-		parser.rln.RefA = strings.TrimSpace(rp[0])
+		aID, err := extractDocElementID(strings.TrimSpace(rp[0]))
+		if err != nil {
+			return err
+		}
+		parser.rln.RefA = aID
 		parser.rln.Relationship = strings.TrimSpace(rp[1])
-		parser.rln.RefB = strings.TrimSpace(rp[2])
+		bID, err := extractDocElementID(strings.TrimSpace(rp[2]))
+		if err != nil {
+			return err
+		}
+		parser.rln.RefB = bID
 		return nil
 	}
 

--- a/tvloader/parser2v1/parse_relationship_test.go
+++ b/tvloader/parser2v1/parse_relationship_test.go
@@ -151,3 +151,21 @@ func TestParser2_1InvalidRelationshipTagsInvalidRefIDs(t *testing.T) {
 		t.Errorf("expected error for missing SPDXRef- prefix, got nil")
 	}
 }
+
+func TestParser2_1FailsToParseUnknownTagInRelationshipSection(t *testing.T) {
+	parser := tvParser2_1{
+		doc: &spdx.Document2_1{},
+		st:  psCreationInfo2_1,
+	}
+
+	// Relationship
+	err := parser.parsePair2_1("Relationship", "SPDXRef-something CONTAINS DocumentRef-otherdoc:SPDXRef-something-else")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid tag
+	err = parser.parsePairForRelationship2_1("blah", "whoops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}

--- a/tvloader/parser2v1/parse_review_test.go
+++ b/tvloader/parser2v1/parse_review_test.go
@@ -12,10 +12,10 @@ func TestParser2_1ReviewStartsNewReviewAfterParsingReviewerTag(t *testing.T) {
 	// create the first review
 	rev1 := "John Doe"
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psReview2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: "LicenseRef-Lic11",
 			LicenseName:       "License 11",
@@ -25,8 +25,8 @@ func TestParser2_1ReviewStartsNewReviewAfterParsingReviewerTag(t *testing.T) {
 			ReviewerType: "Person",
 		},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
 	r1 := parser.rev
@@ -82,10 +82,10 @@ func TestParser2_1ReviewStartsNewReviewAfterParsingReviewerTag(t *testing.T) {
 
 func TestParser2_1ReviewStaysAfterParsingRelationshipTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psReview2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: "LicenseRef-Lic11",
 			LicenseName:       "License 11",
@@ -95,12 +95,12 @@ func TestParser2_1ReviewStaysAfterParsingRelationshipTags(t *testing.T) {
 			ReviewerType: "Person",
 		},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
 
-	err := parser.parsePair2_1("Relationship", "blah CONTAINS blah-else")
+	err := parser.parsePair2_1("Relationship", "SPDXRef-blah CONTAINS SPDXRef-blah-else")
 	if err != nil {
 		t.Errorf("got error when calling parsePair2_1: %v", err)
 	}
@@ -112,7 +112,8 @@ func TestParser2_1ReviewStaysAfterParsingRelationshipTags(t *testing.T) {
 	if len(parser.doc.Relationships) != 1 {
 		t.Fatalf("expected doc.Relationships to have len 1, got %d", len(parser.doc.Relationships))
 	}
-	if parser.doc.Relationships[0].RefA != "blah" {
+	deID := parser.doc.Relationships[0].RefA
+	if deID.DocumentRefID != "" || deID.ElementRefID != "blah" {
 		t.Errorf("expected RefA to be %s, got %s", "blah", parser.doc.Relationships[0].RefA)
 	}
 
@@ -128,10 +129,10 @@ func TestParser2_1ReviewStaysAfterParsingRelationshipTags(t *testing.T) {
 
 func TestParser2_1ReviewStaysAfterParsingAnnotationTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psReview2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: "LicenseRef-Lic11",
 			LicenseName:       "License 11",
@@ -141,8 +142,8 @@ func TestParser2_1ReviewStaysAfterParsingAnnotationTags(t *testing.T) {
 			ReviewerType: "Person",
 		},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
 
@@ -197,18 +198,18 @@ func TestParser2_1ReviewStaysAfterParsingAnnotationTags(t *testing.T) {
 
 func TestParser2_1ReviewFailsAfterParsingOtherSectionTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psReview2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: "LicenseRef-Lic11",
 			LicenseName:       "License 11",
 		},
 		rev: &spdx.Review2_1{},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
 
@@ -234,18 +235,18 @@ func TestParser2_1ReviewFailsAfterParsingOtherSectionTags(t *testing.T) {
 // ===== Review data section tests =====
 func TestParser2_1CanParseReviewTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psReview2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: "LicenseRef-Lic11",
 			LicenseName:       "License 11",
 		},
 		rev: &spdx.Review2_1{},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
 
@@ -273,18 +274,18 @@ func TestParser2_1CanParseReviewTags(t *testing.T) {
 
 func TestParser2_1CanParseReviewerPersonTag(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psReview2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: "LicenseRef-Lic11",
 			LicenseName:       "License 11",
 		},
 		rev: &spdx.Review2_1{},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
 
@@ -303,18 +304,18 @@ func TestParser2_1CanParseReviewerPersonTag(t *testing.T) {
 
 func TestParser2_1CanParseReviewerOrganizationTag(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psReview2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: "LicenseRef-Lic11",
 			LicenseName:       "License 11",
 		},
 		rev: &spdx.Review2_1{},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
 
@@ -333,18 +334,18 @@ func TestParser2_1CanParseReviewerOrganizationTag(t *testing.T) {
 
 func TestParser2_1CanParseReviewerToolTag(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psReview2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: "LicenseRef-Lic11",
 			LicenseName:       "License 11",
 		},
 		rev: &spdx.Review2_1{},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
 
@@ -363,18 +364,18 @@ func TestParser2_1CanParseReviewerToolTag(t *testing.T) {
 
 func TestParser2_1ReviewUnknownTagFails(t *testing.T) {
 	parser := tvParser2_1{
-		doc:  &spdx.Document2_1{},
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:   psReview2_1,
-		pkg:  &spdx.Package2_1{PackageName: "test"},
-		file: &spdx.File2_1{FileName: "f1.txt"},
+		pkg:  &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file: &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1"},
 		otherLic: &spdx.OtherLicense2_1{
 			LicenseIdentifier: "LicenseRef-Lic11",
 			LicenseName:       "License 11",
 		},
 		rev: &spdx.Review2_1{},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 	parser.doc.OtherLicenses = append(parser.doc.OtherLicenses, parser.otherLic)
 	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
 

--- a/tvloader/parser2v1/parse_review_test.go
+++ b/tvloader/parser2v1/parse_review_test.go
@@ -362,6 +362,34 @@ func TestParser2_1CanParseReviewerToolTag(t *testing.T) {
 	}
 }
 
+func TestParser2_1FailsIfReviewerInvalidFormat(t *testing.T) {
+	parser := tvParser2_1{
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:   psReview2_1,
+		rev: &spdx.Review2_1{},
+	}
+	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
+
+	err := parser.parsePairFromReview2_1("Reviewer", "oops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsIfReviewerUnknownType(t *testing.T) {
+	parser := tvParser2_1{
+		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:   psReview2_1,
+		rev: &spdx.Review2_1{},
+	}
+	parser.doc.Reviews = append(parser.doc.Reviews, parser.rev)
+
+	err := parser.parsePairFromReview2_1("Reviewer", "whoops: John Doe")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
 func TestParser2_1ReviewUnknownTagFails(t *testing.T) {
 	parser := tvParser2_1{
 		doc:  &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
@@ -384,3 +412,5 @@ func TestParser2_1ReviewUnknownTagFails(t *testing.T) {
 		t.Errorf("expected error from parsing unknown tag")
 	}
 }
+
+

--- a/tvloader/parser2v1/parse_snippet.go
+++ b/tvloader/parser2v1/parse_snippet.go
@@ -14,8 +14,18 @@ func (parser *tvParser2_1) parsePairFromSnippet2_1(tag string, value string) err
 	// tag for creating new snippet section
 	case "SnippetSPDXID":
 		parser.snippet = &spdx.Snippet2_1{}
-		parser.file.Snippets = append(parser.file.Snippets, parser.snippet)
-		parser.snippet.SnippetSPDXIdentifier = value
+		eID, err := extractElementID(value)
+		if err != nil {
+			return err
+		}
+		// FIXME: how should we handle where not associated with current file?
+		if parser.file != nil {
+			if parser.file.Snippets == nil {
+				parser.file.Snippets = map[spdx.ElementID]*spdx.Snippet2_1{}
+			}
+			parser.file.Snippets[eID] = parser.snippet
+		}
+		parser.snippet.SnippetSPDXIdentifier = eID
 	// tag for creating new file section and going back to parsing File
 	case "FileName":
 		parser.st = psFile2_1
@@ -33,7 +43,11 @@ func (parser *tvParser2_1) parsePairFromSnippet2_1(tag string, value string) err
 		return parser.parsePairFromOtherLicense2_1(tag, value)
 	// tags for snippet data
 	case "SnippetFromFileSPDXID":
-		parser.snippet.SnippetFromFileSPDXIdentifier = value
+		deID, err := extractDocElementID(value)
+		if err != nil {
+			return err
+		}
+		parser.snippet.SnippetFromFileSPDXIdentifier = deID
 	case "SnippetByteRange":
 		byteStart, byteEnd, err := extractSubs(value)
 		if err != nil {

--- a/tvloader/parser2v1/parse_snippet_test.go
+++ b/tvloader/parser2v1/parse_snippet_test.go
@@ -10,34 +10,32 @@ import (
 // ===== Parser snippet section state change tests =====
 func TestParser2_1SnippetStartsNewSnippetAfterParsingSnippetSPDXIDTag(t *testing.T) {
 	// create the first snippet
-	sid1 := "SPDXRef-s1"
-
+	sid1 := spdx.ElementID("s1")
 	parser := tvParser2_1{
-		doc:     &spdx.Document2_1{},
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:      psSnippet2_1,
-		pkg:     &spdx.Package2_1{PackageName: "test"},
-		file:    &spdx.File2_1{FileName: "f1.txt"},
+		pkg:     &spdx.Package2_1{PackageName: "test", PackageSPDXIdentifier: "test", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
 		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: sid1},
 	}
 	s1 := parser.snippet
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
-	parser.file.Snippets = append(parser.file.Snippets, parser.snippet)
+	parser.doc.Packages["test"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
+	parser.file.Snippets[sid1] = parser.snippet
 
 	// the File's Snippets should have this one only
 	if len(parser.file.Snippets) != 1 {
 		t.Errorf("Expected len(Snippets) to be 1, got %d", len(parser.file.Snippets))
 	}
-	if parser.file.Snippets[0] != s1 {
-		t.Errorf("Expected snippet %v in Snippets[0], got %v", s1, parser.file.Snippets[0])
+	if parser.file.Snippets["s1"] != s1 {
+		t.Errorf("Expected snippet %v in Snippets[s1], got %v", s1, parser.file.Snippets["s1"])
 	}
-	if parser.file.Snippets[0].SnippetSPDXIdentifier != sid1 {
-		t.Errorf("expected snippet ID %s in Snippets[0], got %s", sid1, parser.file.Snippets[0].SnippetSPDXIdentifier)
+	if parser.file.Snippets["s1"].SnippetSPDXIdentifier != sid1 {
+		t.Errorf("expected snippet ID %s in Snippets[s1], got %s", sid1, parser.file.Snippets["s1"].SnippetSPDXIdentifier)
 	}
 
 	// now add a new snippet
-	sid2 := "SPDXRef-s2"
-	err := parser.parsePair2_1("SnippetSPDXID", sid2)
+	err := parser.parsePair2_1("SnippetSPDXID", "SPDXRef-s2")
 	if err != nil {
 		t.Errorf("got error when calling parsePair2_1: %v", err)
 	}
@@ -50,43 +48,40 @@ func TestParser2_1SnippetStartsNewSnippetAfterParsingSnippetSPDXIDTag(t *testing
 		t.Fatalf("parser didn't create new snippet")
 	}
 	// and the snippet ID should be as expected
-	if parser.snippet.SnippetSPDXIdentifier != sid2 {
-		t.Errorf("expected snippet ID %s, got %s", sid2, parser.snippet.SnippetSPDXIdentifier)
+	if parser.snippet.SnippetSPDXIdentifier != "s2" {
+		t.Errorf("expected snippet ID %s, got %s", "s2", parser.snippet.SnippetSPDXIdentifier)
 	}
 	// and the File's Snippets should be of size 2 and have these two
 	if len(parser.file.Snippets) != 2 {
 		t.Errorf("Expected len(Snippets) to be 2, got %d", len(parser.file.Snippets))
 	}
-	if parser.file.Snippets[0] != s1 {
-		t.Errorf("Expected snippet %v in Snippets[0], got %v", s1, parser.file.Snippets[0])
+	if parser.file.Snippets["s1"] != s1 {
+		t.Errorf("Expected snippet %v in Snippets[s1], got %v", s1, parser.file.Snippets["s1"])
 	}
-	if parser.file.Snippets[0].SnippetSPDXIdentifier != sid1 {
-		t.Errorf("expected snippet ID %s in Snippets[0], got %s", sid1, parser.file.Snippets[0].SnippetSPDXIdentifier)
+	if parser.file.Snippets["s1"].SnippetSPDXIdentifier != sid1 {
+		t.Errorf("expected snippet ID %s in Snippets[s1], got %s", sid1, parser.file.Snippets["s1"].SnippetSPDXIdentifier)
 	}
-	if parser.file.Snippets[1] != parser.snippet {
-		t.Errorf("Expected snippet %v in Snippets[1], got %v", parser.snippet, parser.file.Snippets[1])
+	if parser.file.Snippets["s2"] != parser.snippet {
+		t.Errorf("Expected snippet %v in Snippets[s2], got %v", parser.snippet, parser.file.Snippets["s2"])
 	}
-	if parser.file.Snippets[1].SnippetSPDXIdentifier != sid2 {
-		t.Errorf("expected snippet ID %s in Snippets[1], got %s", sid2, parser.file.Snippets[1].SnippetSPDXIdentifier)
+	if parser.file.Snippets["s2"].SnippetSPDXIdentifier != "s2" {
+		t.Errorf("expected snippet ID %s in Snippets[s2], got %s", "s2", parser.file.Snippets["s2"].SnippetSPDXIdentifier)
 	}
 }
 
 func TestParser2_1SnippetStartsNewPackageAfterParsingPackageNameTag(t *testing.T) {
-	p1Name := "package1"
-	f1Name := "f1.txt"
-	s1Name := "SPDXRef-s1"
 	parser := tvParser2_1{
-		doc:     &spdx.Document2_1{},
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:      psSnippet2_1,
-		pkg:     &spdx.Package2_1{PackageName: p1Name},
-		file:    &spdx.File2_1{FileName: f1Name},
-		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: s1Name},
+		pkg:     &spdx.Package2_1{PackageName: "package1", PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
+		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: "s1"},
 	}
 	p1 := parser.pkg
 	f1 := parser.file
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
-	parser.file.Snippets = append(parser.file.Snippets, parser.snippet)
+	parser.doc.Packages["package1"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
+	parser.file.Snippets["s1"] = parser.snippet
 
 	// now add a new package
 	p2Name := "package2"
@@ -113,39 +108,30 @@ func TestParser2_1SnippetStartsNewPackageAfterParsingPackageNameTag(t *testing.T
 	if parser.pkg.IsFilesAnalyzedTagPresent != false {
 		t.Errorf("expected IsFilesAnalyzedTagPresent to default to false, got true")
 	}
-	// and the package should _not_ be an "unpackaged" placeholder
-	if parser.pkg.IsUnpackaged == true {
-		t.Errorf("package incorrectly has IsUnpackaged flag set")
+	// and the Document's Packages should still be of size 1 b/c no SPDX
+	// identifier has been seen yet
+	if len(parser.doc.Packages) != 1 {
+		t.Errorf("Expected len(Packages) to be 1, got %d", len(parser.doc.Packages))
 	}
-	// and the Document's Packages should be of size 2 and have these two
-	if len(parser.doc.Packages) != 2 {
-		t.Errorf("Expected len(Packages) to be 2, got %d", len(parser.doc.Packages))
+	if parser.doc.Packages["package1"] != p1 {
+		t.Errorf("Expected package %v in Packages[package1], got %v", p1, parser.doc.Packages["package1"])
 	}
-	if parser.doc.Packages[0] != p1 {
-		t.Errorf("Expected package %v in Packages[0], got %v", p1, parser.doc.Packages[0])
-	}
-	if parser.doc.Packages[0].PackageName != p1Name {
-		t.Errorf("expected package name %s in Packages[0], got %s", p1Name, parser.doc.Packages[0].PackageName)
-	}
-	if parser.doc.Packages[1] != parser.pkg {
-		t.Errorf("Expected package %v in Packages[1], got %v", parser.pkg, parser.doc.Packages[1])
-	}
-	if parser.doc.Packages[1].PackageName != p2Name {
-		t.Errorf("expected package name %s in Packages[1], got %s", p2Name, parser.doc.Packages[1].PackageName)
+	if parser.doc.Packages["package1"].PackageName != "package1" {
+		t.Errorf("expected package name %s in Packages[package1], got %s", "package1", parser.doc.Packages["package1"].PackageName)
 	}
 	// and the first Package's Files should be of size 1 and have f1 only
-	if len(parser.doc.Packages[0].Files) != 1 {
-		t.Errorf("Expected 1 file in Packages[0].Files, got %d", len(parser.doc.Packages[0].Files))
+	if len(parser.doc.Packages["package1"].Files) != 1 {
+		t.Errorf("Expected 1 file in Packages[package1].Files, got %d", len(parser.doc.Packages["package1"].Files))
 	}
-	if parser.doc.Packages[0].Files[0] != f1 {
-		t.Errorf("Expected file %v in Files[0], got %v", f1, parser.doc.Packages[0].Files[0])
+	if parser.doc.Packages["package1"].Files["f1"] != f1 {
+		t.Errorf("Expected file %v in Files[f1], got %v", f1, parser.doc.Packages["package1"].Files["f1"])
 	}
-	if parser.doc.Packages[0].Files[0].FileName != f1Name {
-		t.Errorf("expected file name %s in Files[0], got %s", f1Name, parser.doc.Packages[0].Files[0].FileName)
+	if parser.doc.Packages["package1"].Files["f1"].FileName != "f1.txt" {
+		t.Errorf("expected file name %s in Files[f1], got %s", "f1.txt", parser.doc.Packages["package1"].Files["f1"].FileName)
 	}
-	// and the second Package should have no files
-	if len(parser.doc.Packages[1].Files) != 0 {
-		t.Errorf("Expected no files in Packages[1].Files, got %d", len(parser.doc.Packages[1].Files))
+	// and the new Package should have no files
+	if len(parser.pkg.Files) != 0 {
+		t.Errorf("Expected no files in Packages[1].Files, got %d", len(parser.pkg.Files))
 	}
 	// and the current file should be nil
 	if parser.file != nil {
@@ -158,21 +144,19 @@ func TestParser2_1SnippetStartsNewPackageAfterParsingPackageNameTag(t *testing.T
 }
 
 func TestParser2_1SnippetMovesToFileAfterParsingFileNameTag(t *testing.T) {
-	p1Name := "package1"
 	f1Name := "f1.txt"
-	s1Name := "SPDXRef-s1"
 	parser := tvParser2_1{
-		doc:     &spdx.Document2_1{},
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:      psSnippet2_1,
-		pkg:     &spdx.Package2_1{PackageName: p1Name},
-		file:    &spdx.File2_1{FileName: f1Name},
-		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: s1Name},
+		pkg:     &spdx.Package2_1{PackageName: "package1", PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
+		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: "s1"},
 	}
 	p1 := parser.pkg
 	f1 := parser.file
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
-	parser.file.Snippets = append(parser.file.Snippets, parser.snippet)
+	parser.doc.Packages["package1"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
+	parser.file.Snippets["s1"] = parser.snippet
 
 	f2Name := "f2.txt"
 	err := parser.parsePair2_1("FileName", f2Name)
@@ -195,18 +179,16 @@ func TestParser2_1SnippetMovesToFileAfterParsingFileNameTag(t *testing.T) {
 	if parser.file.FileName != f2Name {
 		t.Errorf("expected file name %s, got %s", f2Name, parser.file.FileName)
 	}
-	// and the Package's Files should be of size 2 and have these two
-	if parser.pkg.Files[0] != f1 {
-		t.Errorf("Expected file %v in Files[0], got %v", f1, parser.pkg.Files[0])
+	// and the Package's Files should still be of size 1 since we haven't seen
+	// an SPDX identifier yet for this new file
+	if len(parser.pkg.Files) != 1 {
+		t.Errorf("Expected len(Files) to be 1, got %d", len(parser.pkg.Files))
 	}
-	if parser.pkg.Files[0].FileName != f1Name {
-		t.Errorf("expected file name %s in Files[0], got %s", f1Name, parser.pkg.Files[0].FileName)
+	if parser.pkg.Files["f1"] != f1 {
+		t.Errorf("Expected file %v in Files[f1], got %v", f1, parser.pkg.Files["f1"])
 	}
-	if parser.pkg.Files[1] != parser.file {
-		t.Errorf("Expected file %v in Files[1], got %v", parser.file, parser.pkg.Files[1])
-	}
-	if parser.pkg.Files[1].FileName != f2Name {
-		t.Errorf("expected file name %s in Files[1], got %s", f2Name, parser.pkg.Files[1].FileName)
+	if parser.pkg.Files["f1"].FileName != f1Name {
+		t.Errorf("expected file name %s in Files[f1], got %s", f1Name, parser.pkg.Files["f1"].FileName)
 	}
 	// and the current snippet should be nil
 	if parser.snippet != nil {
@@ -216,15 +198,15 @@ func TestParser2_1SnippetMovesToFileAfterParsingFileNameTag(t *testing.T) {
 
 func TestParser2_1SnippetMovesToOtherLicenseAfterParsingLicenseIDTag(t *testing.T) {
 	parser := tvParser2_1{
-		doc:     &spdx.Document2_1{},
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:      psSnippet2_1,
-		pkg:     &spdx.Package2_1{PackageName: "package1"},
-		file:    &spdx.File2_1{FileName: "f1.txt"},
-		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: "SPDXRef-s1"},
+		pkg:     &spdx.Package2_1{PackageName: "package1", PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
+		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: "s1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
-	parser.file.Snippets = append(parser.file.Snippets, parser.snippet)
+	parser.doc.Packages["package1"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
+	parser.file.Snippets["s1"] = parser.snippet
 
 	err := parser.parsePair2_1("LicenseID", "LicenseRef-TestLic")
 	if err != nil {
@@ -237,15 +219,15 @@ func TestParser2_1SnippetMovesToOtherLicenseAfterParsingLicenseIDTag(t *testing.
 
 func TestParser2_1SnippetMovesToReviewAfterParsingReviewerTag(t *testing.T) {
 	parser := tvParser2_1{
-		doc:     &spdx.Document2_1{},
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:      psSnippet2_1,
-		pkg:     &spdx.Package2_1{PackageName: "package1"},
-		file:    &spdx.File2_1{FileName: "f1.txt"},
-		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: "SPDXRef-s1"},
+		pkg:     &spdx.Package2_1{PackageName: "package1", PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
+		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: "s1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
-	parser.file.Snippets = append(parser.file.Snippets, parser.snippet)
+	parser.doc.Packages["package1"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
+	parser.file.Snippets["s1"] = parser.snippet
 
 	err := parser.parsePair2_1("Reviewer", "Person: John Doe")
 	if err != nil {
@@ -258,17 +240,17 @@ func TestParser2_1SnippetMovesToReviewAfterParsingReviewerTag(t *testing.T) {
 
 func TestParser2_1SnippetStaysAfterParsingRelationshipTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:     &spdx.Document2_1{},
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:      psSnippet2_1,
-		pkg:     &spdx.Package2_1{PackageName: "package1"},
-		file:    &spdx.File2_1{FileName: "f1.txt"},
-		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: "SPDXRef-s1"},
+		pkg:     &spdx.Package2_1{PackageName: "package1", PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
+		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: "s1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
-	parser.file.Snippets = append(parser.file.Snippets, parser.snippet)
+	parser.doc.Packages["package1"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
+	parser.file.Snippets["s1"] = parser.snippet
 
-	err := parser.parsePair2_1("Relationship", "blah CONTAINS blah-else")
+	err := parser.parsePair2_1("Relationship", "SPDXRef-blah CONTAINS SPDXRef-blah-else")
 	if err != nil {
 		t.Errorf("got error when calling parsePair2_1: %v", err)
 	}
@@ -280,7 +262,8 @@ func TestParser2_1SnippetStaysAfterParsingRelationshipTags(t *testing.T) {
 	if len(parser.doc.Relationships) != 1 {
 		t.Fatalf("expected doc.Relationships to have len 1, got %d", len(parser.doc.Relationships))
 	}
-	if parser.doc.Relationships[0].RefA != "blah" {
+	deID := parser.doc.Relationships[0].RefA
+	if deID.DocumentRefID != "" || deID.ElementRefID != "blah" {
 		t.Errorf("expected RefA to be %s, got %s", "blah", parser.doc.Relationships[0].RefA)
 	}
 
@@ -296,15 +279,15 @@ func TestParser2_1SnippetStaysAfterParsingRelationshipTags(t *testing.T) {
 
 func TestParser2_1SnippetStaysAfterParsingAnnotationTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:     &spdx.Document2_1{},
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:      psSnippet2_1,
-		pkg:     &spdx.Package2_1{PackageName: "package1"},
-		file:    &spdx.File2_1{FileName: "f1.txt"},
-		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: "SPDXRef-s1"},
+		pkg:     &spdx.Package2_1{PackageName: "package1", PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
+		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: "s1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
-	parser.file.Snippets = append(parser.file.Snippets, parser.snippet)
+	parser.doc.Packages["package1"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
+	parser.file.Snippets["s1"] = parser.snippet
 
 	err := parser.parsePair2_1("Annotator", "Person: John Doe ()")
 	if err != nil {
@@ -358,22 +341,21 @@ func TestParser2_1SnippetStaysAfterParsingAnnotationTags(t *testing.T) {
 // ===== Snippet data section tests =====
 func TestParser2_1CanParseSnippetTags(t *testing.T) {
 	parser := tvParser2_1{
-		doc:     &spdx.Document2_1{},
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:      psSnippet2_1,
-		pkg:     &spdx.Package2_1{PackageName: "package1"},
-		file:    &spdx.File2_1{FileName: "f1.txt"},
+		pkg:     &spdx.Package2_1{PackageName: "package1", PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
 		snippet: &spdx.Snippet2_1{},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
-	parser.file.Snippets = append(parser.file.Snippets, parser.snippet)
+	parser.doc.Packages["package1"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 
 	// Snippet SPDX Identifier
 	err := parser.parsePairFromSnippet2_1("SnippetSPDXID", "SPDXRef-s1")
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
-	if parser.snippet.SnippetSPDXIdentifier != "SPDXRef-s1" {
+	if parser.snippet.SnippetSPDXIdentifier != "s1" {
 		t.Errorf("got %v for SnippetSPDXIdentifier", parser.snippet.SnippetSPDXIdentifier)
 	}
 
@@ -382,7 +364,8 @@ func TestParser2_1CanParseSnippetTags(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
-	if parser.snippet.SnippetFromFileSPDXIdentifier != "SPDXRef-f1" {
+	wantDeID := spdx.DocElementID{DocumentRefID: "", ElementRefID: spdx.ElementID("f1")}
+	if parser.snippet.SnippetFromFileSPDXIdentifier != wantDeID {
 		t.Errorf("got %v for SnippetFromFileSPDXIdentifier", parser.snippet.SnippetFromFileSPDXIdentifier)
 	}
 
@@ -486,15 +469,14 @@ func TestParser2_1CanParseSnippetTags(t *testing.T) {
 
 func TestParser2_1SnippetUnknownTagFails(t *testing.T) {
 	parser := tvParser2_1{
-		doc:     &spdx.Document2_1{},
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
 		st:      psSnippet2_1,
-		pkg:     &spdx.Package2_1{PackageName: "package1"},
-		file:    &spdx.File2_1{FileName: "f1.txt"},
-		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: "SPDXRef-s1"},
+		pkg:     &spdx.Package2_1{PackageName: "package1", PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
+		snippet: &spdx.Snippet2_1{SnippetSPDXIdentifier: "s1"},
 	}
-	parser.doc.Packages = append(parser.doc.Packages, parser.pkg)
-	parser.pkg.Files = append(parser.pkg.Files, parser.file)
-	parser.file.Snippets = append(parser.file.Snippets, parser.snippet)
+	parser.doc.Packages["package1"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
 
 	err := parser.parsePairFromSnippet2_1("blah", "something")
 	if err == nil {

--- a/tvloader/parser2v1/parse_snippet_test.go
+++ b/tvloader/parser2v1/parse_snippet_test.go
@@ -483,3 +483,107 @@ func TestParser2_1SnippetUnknownTagFails(t *testing.T) {
 		t.Errorf("expected error from parsing unknown tag")
 	}
 }
+
+func TestParser2_1FailsForInvalidSnippetSPDXID(t *testing.T) {
+	parser := tvParser2_1{
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:      psSnippet2_1,
+		pkg:     &spdx.Package2_1{PackageName: "package1", PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
+		snippet: &spdx.Snippet2_1{},
+	}
+	parser.doc.Packages["package1"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
+
+	// invalid Snippet SPDX Identifier
+	err := parser.parsePairFromSnippet2_1("SnippetSPDXID", "whoops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsForInvalidSnippetFromFileSPDXID(t *testing.T) {
+	parser := tvParser2_1{
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:      psSnippet2_1,
+		pkg:     &spdx.Package2_1{PackageName: "package1", PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
+		snippet: &spdx.Snippet2_1{},
+	}
+	parser.doc.Packages["package1"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
+
+	// start with Snippet SPDX Identifier
+	err := parser.parsePairFromSnippet2_1("SnippetSPDXID", "SPDXRef-s1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid From File identifier
+	err = parser.parsePairFromSnippet2_1("SnippetFromFileSPDXID", "whoops")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsForInvalidSnippetByteValues(t *testing.T) {
+	parser := tvParser2_1{
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:      psSnippet2_1,
+		pkg:     &spdx.Package2_1{PackageName: "package1", PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
+		snippet: &spdx.Snippet2_1{},
+	}
+	parser.doc.Packages["package1"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
+
+	// start with Snippet SPDX Identifier
+	err := parser.parsePairFromSnippet2_1("SnippetSPDXID", "SPDXRef-s1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid byte formats and values
+	err = parser.parsePairFromSnippet2_1("SnippetByteRange", "200 210")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+	err = parser.parsePairFromSnippet2_1("SnippetByteRange", "a:210")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+	err = parser.parsePairFromSnippet2_1("SnippetByteRange", "200:a")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+
+func TestParser2_1FailsForInvalidSnippetLineValues(t *testing.T) {
+	parser := tvParser2_1{
+		doc:     &spdx.Document2_1{Packages: map[spdx.ElementID]*spdx.Package2_1{}},
+		st:      psSnippet2_1,
+		pkg:     &spdx.Package2_1{PackageName: "package1", PackageSPDXIdentifier: "package1", Files: map[spdx.ElementID]*spdx.File2_1{}},
+		file:    &spdx.File2_1{FileName: "f1.txt", FileSPDXIdentifier: "f1", Snippets: map[spdx.ElementID]*spdx.Snippet2_1{}},
+		snippet: &spdx.Snippet2_1{},
+	}
+	parser.doc.Packages["package1"] = parser.pkg
+	parser.pkg.Files["f1"] = parser.file
+
+	// start with Snippet SPDX Identifier
+	err := parser.parsePairFromSnippet2_1("SnippetSPDXID", "SPDXRef-s1")
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	// invalid byte formats and values
+	err = parser.parsePairFromSnippet2_1("SnippetLineRange", "200 210")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+	err = parser.parsePairFromSnippet2_1("SnippetLineRange", "a:210")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+	err = parser.parsePairFromSnippet2_1("SnippetLineRange", "200:a")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+

--- a/tvloader/parser2v1/parser_test.go
+++ b/tvloader/parser2v1/parser_test.go
@@ -69,3 +69,12 @@ func TestParser2_1StartMovesToCreationInfoStateAfterParsingFirstTag(t *testing.T
 		t.Errorf("parser is in state %v, expected %v", parser.st, psCreationInfo2_1)
 	}
 }
+
+func TestParser2_1StartFailsToParseIfInInvalidState(t *testing.T) {
+	parser := tvParser2_1{st: psReview2_1}
+	err := parser.parsePairFromStart2_1("SPDXVersion", "SPDX-2.1")
+	if err == nil {
+		t.Errorf("expected non-nil error, got nil")
+	}
+}
+

--- a/tvloader/parser2v1/util.go
+++ b/tvloader/parser2v1/util.go
@@ -5,6 +5,8 @@ package parser2v1
 import (
 	"fmt"
 	"strings"
+
+	"github.com/spdx/tools-golang/spdx"
 )
 
 // used to extract key / value from embedded substrings
@@ -20,4 +22,77 @@ func extractSubs(value string) (string, string, error) {
 	subvalue := strings.TrimSpace(sp[1])
 
 	return subkey, subvalue, nil
+}
+
+// used to extract DocumentRef and SPDXRef values from an SPDX Identifier
+// which can point either to this document or to a different one
+func extractDocElementID(value string) (spdx.DocElementID, error) {
+	docRefID := ""
+	idStr := value
+
+	// check prefix to see if it's a DocumentRef ID
+	if strings.HasPrefix(idStr, "DocumentRef-") {
+		// extract the part that comes between "DocumentRef-" and ":"
+		strs := strings.Split(idStr, ":")
+		// should be exactly two, part before and part after
+		if len(strs) < 2 {
+			return spdx.DocElementID{}, fmt.Errorf("no colon found although DocumentRef- prefix present")
+		}
+		if len(strs) > 2 {
+			return spdx.DocElementID{}, fmt.Errorf("more than one colon found")
+		}
+
+		// trim the prefix and confirm non-empty
+		docRefID = strings.TrimPrefix(strs[0], "DocumentRef-")
+		if docRefID == "" {
+			return spdx.DocElementID{}, fmt.Errorf("document identifier has nothing after prefix")
+		}
+		// and use remainder for element ID parsing
+		idStr = strs[1]
+	}
+
+	// check prefix to confirm it's got the right prefix for element IDs
+	if !strings.HasPrefix(idStr, "SPDXRef-") {
+		return spdx.DocElementID{}, fmt.Errorf("missing SPDXRef- prefix for element identifier")
+	}
+
+	// make sure no colons are present
+	if strings.Contains(idStr, ":") {
+		// we know this means there was no DocumentRef- prefix, because
+		// we would have handled multiple colons above if it was
+		return spdx.DocElementID{}, fmt.Errorf("invalid colon in element identifier")
+	}
+
+	// trim the prefix and confirm non-empty
+	eltRefID := strings.TrimPrefix(idStr, "SPDXRef-")
+	if eltRefID == "" {
+		return spdx.DocElementID{}, fmt.Errorf("element identifier has nothing after prefix")
+	}
+
+	// we're good
+	return spdx.DocElementID{DocumentRefID: docRefID, ElementRefID: spdx.ElementID(eltRefID)}, nil
+}
+
+// used to extract SPDXRef values only from an SPDX Identifier which can point
+// to this document only. Use extractDocElementID for parsing IDs that can
+// refer either to this document or a different one.
+func extractElementID(value string) (spdx.ElementID, error) {
+	// check prefix to confirm it's got the right prefix for element IDs
+	if !strings.HasPrefix(value, "SPDXRef-") {
+		return spdx.ElementID(""), fmt.Errorf("missing SPDXRef- prefix for element identifier")
+	}
+
+	// make sure no colons are present
+	if strings.Contains(value, ":") {
+		return spdx.ElementID(""), fmt.Errorf("invalid colon in element identifier")
+	}
+
+	// trim the prefix and confirm non-empty
+	eltRefID := strings.TrimPrefix(value, "SPDXRef-")
+	if eltRefID == "" {
+		return spdx.ElementID(""), fmt.Errorf("element identifier has nothing after prefix")
+	}
+
+	// we're good
+	return spdx.ElementID(eltRefID), nil
 }

--- a/tvloader/parser2v1/util_test.go
+++ b/tvloader/parser2v1/util_test.go
@@ -3,6 +3,8 @@ package parser2v1
 
 import (
 	"testing"
+
+	"github.com/spdx/tools-golang/spdx"
 )
 
 // ===== Helper function tests =====
@@ -24,5 +26,82 @@ func TestReturnsErrorForInvalidSubvalueFormat(t *testing.T) {
 	_, _, err := extractSubs("blah")
 	if err == nil {
 		t.Errorf("expected error when calling extractSubs for invalid format (0 colons), got nil")
+	}
+}
+
+func TestCanExtractDocumentAndElementRefsFromID(t *testing.T) {
+	// test with valid ID in this document
+	helperForExtractDocElementID(t, "SPDXRef-file1", false, "", "file1")
+	// test with valid ID in another document
+	helperForExtractDocElementID(t, "DocumentRef-doc2:SPDXRef-file2", false, "doc2", "file2")
+	// test with invalid ID in this document
+	helperForExtractDocElementID(t, "a:SPDXRef-file1", true, "", "")
+	helperForExtractDocElementID(t, "file1", true, "", "")
+	helperForExtractDocElementID(t, "SPDXRef-", true, "", "")
+	// test with invalid ID in another document
+	helperForExtractDocElementID(t, "DocumentRef-doc2", true, "", "")
+	helperForExtractDocElementID(t, "DocumentRef-doc2:", true, "", "")
+	helperForExtractDocElementID(t, "DocumentRef-doc2:SPDXRef-", true, "", "")
+	helperForExtractDocElementID(t, "DocumentRef-doc2:a", true, "", "")
+	helperForExtractDocElementID(t, "DocumentRef-:", true, "", "")
+	helperForExtractDocElementID(t, "DocumentRef-:SPDXRef-file1", true, "", "")
+}
+
+func helperForExtractDocElementID(t *testing.T, tst string, wantErr bool, wantDoc string, wantElt string) {
+	deID, err := extractDocElementID(tst)
+	if err != nil && wantErr == false {
+		t.Errorf("testing %v: expected nil error, got %v", tst, err)
+	}
+	if err == nil && wantErr == true {
+		t.Errorf("testing %v: expected non-nil error, got nil", tst)
+	}
+	if deID.DocumentRefID != wantDoc {
+		if wantDoc == "" {
+			t.Errorf("testing %v: want empty string for DocumentRefID, got %v", tst, deID.DocumentRefID)
+		} else {
+			t.Errorf("testing %v: want %v for DocumentRefID, got %v", tst, wantDoc, deID.DocumentRefID)
+		}
+	}
+	if deID.ElementRefID != spdx.ElementID(wantElt) {
+		if wantElt == "" {
+			t.Errorf("testing %v: want emptyString for ElementRefID, got %v", tst, deID.ElementRefID)
+		} else {
+			t.Errorf("testing %v: want %v for ElementRefID, got %v", tst, wantElt, deID.ElementRefID)
+		}
+	}
+}
+
+func TestCanExtractElementRefsOnlyFromID(t *testing.T) {
+	// test with valid ID in this document
+	helperForExtractElementID(t, "SPDXRef-file1", false, "file1")
+	// test with valid ID in another document
+	helperForExtractElementID(t, "DocumentRef-doc2:SPDXRef-file2", true, "")
+	// test with invalid ID in this document
+	helperForExtractElementID(t, "a:SPDXRef-file1", true, "")
+	helperForExtractElementID(t, "file1", true, "")
+	helperForExtractElementID(t, "SPDXRef-", true, "")
+	// test with invalid ID in another document
+	helperForExtractElementID(t, "DocumentRef-doc2", true, "")
+	helperForExtractElementID(t, "DocumentRef-doc2:", true, "")
+	helperForExtractElementID(t, "DocumentRef-doc2:SPDXRef-", true, "")
+	helperForExtractElementID(t, "DocumentRef-doc2:a", true, "")
+	helperForExtractElementID(t, "DocumentRef-:", true, "")
+	helperForExtractElementID(t, "DocumentRef-:SPDXRef-file1", true, "")
+}
+
+func helperForExtractElementID(t *testing.T, tst string, wantErr bool, wantElt string) {
+	eID, err := extractElementID(tst)
+	if err != nil && wantErr == false {
+		t.Errorf("testing %v: expected nil error, got %v", tst, err)
+	}
+	if err == nil && wantErr == true {
+		t.Errorf("testing %v: expected non-nil error, got nil", tst)
+	}
+	if eID != spdx.ElementID(wantElt) {
+		if wantElt == "" {
+			t.Errorf("testing %v: want emptyString for ElementRefID, got %v", tst, eID)
+		} else {
+			t.Errorf("testing %v: want %v for ElementRefID, got %v", tst, wantElt, eID)
+		}
 	}
 }

--- a/tvloader/parser2v1/util_test.go
+++ b/tvloader/parser2v1/util_test.go
@@ -38,6 +38,7 @@ func TestCanExtractDocumentAndElementRefsFromID(t *testing.T) {
 	helperForExtractDocElementID(t, "a:SPDXRef-file1", true, "", "")
 	helperForExtractDocElementID(t, "file1", true, "", "")
 	helperForExtractDocElementID(t, "SPDXRef-", true, "", "")
+	helperForExtractDocElementID(t, "SPDXRef-file1:", true, "", "")
 	// test with invalid ID in another document
 	helperForExtractDocElementID(t, "DocumentRef-doc2", true, "", "")
 	helperForExtractDocElementID(t, "DocumentRef-doc2:", true, "", "")
@@ -45,6 +46,8 @@ func TestCanExtractDocumentAndElementRefsFromID(t *testing.T) {
 	helperForExtractDocElementID(t, "DocumentRef-doc2:a", true, "", "")
 	helperForExtractDocElementID(t, "DocumentRef-:", true, "", "")
 	helperForExtractDocElementID(t, "DocumentRef-:SPDXRef-file1", true, "", "")
+	// test with invalid formats
+	helperForExtractDocElementID(t, "DocumentRef-doc2:SPDXRef-file1:file2", true, "", "")
 }
 
 func helperForExtractDocElementID(t *testing.T, tst string, wantErr bool, wantDoc string, wantElt string) {
@@ -80,6 +83,7 @@ func TestCanExtractElementRefsOnlyFromID(t *testing.T) {
 	helperForExtractElementID(t, "a:SPDXRef-file1", true, "")
 	helperForExtractElementID(t, "file1", true, "")
 	helperForExtractElementID(t, "SPDXRef-", true, "")
+	helperForExtractElementID(t, "SPDXRef-file1:", true, "")
 	// test with invalid ID in another document
 	helperForExtractElementID(t, "DocumentRef-doc2", true, "")
 	helperForExtractElementID(t, "DocumentRef-doc2:", true, "")

--- a/tvsaver/saver2v1/save_annotation.go
+++ b/tvsaver/saver2v1/save_annotation.go
@@ -19,8 +19,9 @@ func renderAnnotation2_1(ann *spdx.Annotation2_1, w io.Writer) error {
 	if ann.AnnotationType != "" {
 		fmt.Fprintf(w, "AnnotationType: %s\n", ann.AnnotationType)
 	}
-	if ann.AnnotationSPDXIdentifier != "" {
-		fmt.Fprintf(w, "SPDXREF: %s\n", ann.AnnotationSPDXIdentifier)
+	annIDStr := spdx.RenderDocElementID(ann.AnnotationSPDXIdentifier)
+	if annIDStr != "SPDXRef-" {
+		fmt.Fprintf(w, "SPDXREF: %s\n", annIDStr)
 	}
 	if ann.AnnotationComment != "" {
 		fmt.Fprintf(w, "AnnotationComment: %s\n", textify(ann.AnnotationComment))

--- a/tvsaver/saver2v1/save_annotation_test.go
+++ b/tvsaver/saver2v1/save_annotation_test.go
@@ -16,7 +16,7 @@ func TestSaver2_1AnnotationSavesTextForPerson(t *testing.T) {
 		AnnotatorType:            "Person",
 		AnnotationDate:           "2018-10-10T17:52:00Z",
 		AnnotationType:           "REVIEW",
-		AnnotationSPDXIdentifier: "SPDXRef-DOCUMENT",
+		AnnotationSPDXIdentifier: spdx.MakeDocElementID("", "DOCUMENT"),
 		AnnotationComment:        "This is an annotation about the SPDX document",
 	}
 
@@ -49,7 +49,7 @@ func TestSaver2_1AnnotationSavesTextForOrganization(t *testing.T) {
 		AnnotatorType:            "Organization",
 		AnnotationDate:           "2018-10-10T17:52:00Z",
 		AnnotationType:           "REVIEW",
-		AnnotationSPDXIdentifier: "SPDXRef-DOCUMENT",
+		AnnotationSPDXIdentifier: spdx.MakeDocElementID("", "DOCUMENT"),
 		AnnotationComment:        "This is an annotation about the SPDX document",
 	}
 
@@ -82,7 +82,7 @@ func TestSaver2_1AnnotationSavesTextForTool(t *testing.T) {
 		AnnotatorType:            "Tool",
 		AnnotationDate:           "2018-10-10T17:52:00Z",
 		AnnotationType:           "REVIEW",
-		AnnotationSPDXIdentifier: "SPDXRef-DOCUMENT",
+		AnnotationSPDXIdentifier: spdx.MakeDocElementID("", "DOCUMENT"),
 		AnnotationComment:        "This is an annotation about the SPDX document",
 	}
 

--- a/tvsaver/saver2v1/save_creation_info.go
+++ b/tvsaver/saver2v1/save_creation_info.go
@@ -17,7 +17,7 @@ func renderCreationInfo2_1(ci *spdx.CreationInfo2_1, w io.Writer) error {
 		fmt.Fprintf(w, "DataLicense: %s\n", ci.DataLicense)
 	}
 	if ci.SPDXIdentifier != "" {
-		fmt.Fprintf(w, "SPDXID: %s\n", ci.SPDXIdentifier)
+		fmt.Fprintf(w, "SPDXID: %s\n", spdx.RenderElementID(ci.SPDXIdentifier))
 	}
 	if ci.DocumentName != "" {
 		fmt.Fprintf(w, "DocumentName: %s\n", ci.DocumentName)

--- a/tvsaver/saver2v1/save_creation_info_test.go
+++ b/tvsaver/saver2v1/save_creation_info_test.go
@@ -14,7 +14,7 @@ func TestSaver2_1CISavesText(t *testing.T) {
 	ci := &spdx.CreationInfo2_1{
 		SPDXVersion:       "SPDX-2.1",
 		DataLicense:       "CC0-1.0",
-		SPDXIdentifier:    "SPDXRef-DOCUMENT",
+		SPDXIdentifier:    spdx.ElementID("DOCUMENT"),
 		DocumentName:      "spdx-go-0.0.1.abcdef",
 		DocumentNamespace: "https://github.com/swinslow/spdx-docs/spdx-go/spdx-go-0.0.1.abcdef.whatever",
 		ExternalDocumentReferences: []string{
@@ -81,7 +81,7 @@ func TestSaver2_1CIOmitsOptionalFieldsIfEmpty(t *testing.T) {
 	ci1 := &spdx.CreationInfo2_1{
 		SPDXVersion:       "SPDX-2.1",
 		DataLicense:       "CC0-1.0",
-		SPDXIdentifier:    "SPDXRef-DOCUMENT",
+		SPDXIdentifier:    spdx.ElementID("DOCUMENT"),
 		DocumentName:      "spdx-go-0.0.1.abcdef",
 		DocumentNamespace: "https://github.com/swinslow/spdx-docs/spdx-go/spdx-go-0.0.1.abcdef.whatever",
 		CreatorPersons: []string{
@@ -118,7 +118,7 @@ Created: 2018-10-10T06:20:00Z
 	ci2 := &spdx.CreationInfo2_1{
 		SPDXVersion:       "SPDX-2.1",
 		DataLicense:       "CC0-1.0",
-		SPDXIdentifier:    "SPDXRef-DOCUMENT",
+		SPDXIdentifier:    spdx.ElementID("DOCUMENT"),
 		DocumentName:      "spdx-go-0.0.1.abcdef",
 		DocumentNamespace: "https://github.com/swinslow/spdx-docs/spdx-go/spdx-go-0.0.1.abcdef.whatever",
 		CreatorOrganizations: []string{

--- a/tvsaver/saver2v1/save_document.go
+++ b/tvsaver/saver2v1/save_document.go
@@ -7,6 +7,7 @@ package saver2v1
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/spdx/tools-golang/spdx"
 )
@@ -24,12 +25,26 @@ func RenderDocument2_1(doc *spdx.Document2_1, w io.Writer) error {
 
 	if len(doc.UnpackagedFiles) > 0 {
 		fmt.Fprintf(w, "##### Unpackaged files\n\n")
-		for _, fi := range doc.UnpackagedFiles {
+		// get slice of identifiers so we can sort them
+		unpackagedFileKeys := []string{}
+		for k := range doc.UnpackagedFiles {
+			unpackagedFileKeys = append(unpackagedFileKeys, string(k))
+		}
+		sort.Strings(unpackagedFileKeys)
+		for _, fiID := range unpackagedFileKeys {
+			fi := doc.UnpackagedFiles[spdx.ElementID(fiID)]
 			renderFile2_1(fi, w)
 		}
 	}
 
-	for _, pkg := range doc.Packages {
+	// get slice of Package identifiers so we can sort them
+	packageKeys := []string{}
+	for k := range doc.Packages {
+		packageKeys = append(packageKeys, string(k))
+	}
+	sort.Strings(packageKeys)
+	for _, pkgID := range packageKeys {
+		pkg := doc.Packages[spdx.ElementID(pkgID)]
 		fmt.Fprintf(w, "##### Package: %s\n\n", pkg.PackageName)
 		renderPackage2_1(pkg, w)
 	}

--- a/tvsaver/saver2v1/save_document.go
+++ b/tvsaver/saver2v1/save_document.go
@@ -22,12 +22,15 @@ func RenderDocument2_1(doc *spdx.Document2_1, w io.Writer) error {
 
 	renderCreationInfo2_1(doc.CreationInfo, w)
 
-	for _, pkg := range doc.Packages {
-		if pkg.IsUnpackaged == true {
-			fmt.Fprintf(w, "##### Unpackaged files\n\n")
-		} else {
-			fmt.Fprintf(w, "##### Package: %s\n\n", pkg.PackageName)
+	if len(doc.UnpackagedFiles) > 0 {
+		fmt.Fprintf(w, "##### Unpackaged files\n\n")
+		for _, fi := range doc.UnpackagedFiles {
+			renderFile2_1(fi, w)
 		}
+	}
+
+	for _, pkg := range doc.Packages {
+		fmt.Fprintf(w, "##### Package: %s\n\n", pkg.PackageName)
 		renderPackage2_1(pkg, w)
 	}
 

--- a/tvsaver/saver2v1/save_document_test.go
+++ b/tvsaver/saver2v1/save_document_test.go
@@ -16,7 +16,7 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 	ci := &spdx.CreationInfo2_1{
 		SPDXVersion:       "SPDX-2.1",
 		DataLicense:       "CC0-1.0",
-		SPDXIdentifier:    "SPDXRef-DOCUMENT",
+		SPDXIdentifier:    spdx.ElementID("DOCUMENT"),
 		DocumentName:      "spdx-go-0.0.1.abcdef",
 		DocumentNamespace: "https://github.com/swinslow/spdx-docs/spdx-go/spdx-go-0.0.1.abcdef.whatever",
 		CreatorPersons: []string{
@@ -28,7 +28,7 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 	// unpackaged files
 	f1 := &spdx.File2_1{
 		FileName:           "/tmp/whatever1.txt",
-		FileSPDXIdentifier: "SPDXRef-File1231",
+		FileSPDXIdentifier: spdx.ElementID("File1231"),
 		FileChecksumSHA1:   "85ed0817af83a24ad8da68c2b5094de69833983c",
 		LicenseConcluded:   "Apache-2.0",
 		LicenseInfoInFile:  []string{"Apache-2.0"},
@@ -37,7 +37,7 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 
 	f2 := &spdx.File2_1{
 		FileName:           "/tmp/whatever2.txt",
-		FileSPDXIdentifier: "SPDXRef-File1232",
+		FileSPDXIdentifier: spdx.ElementID("File1232"),
 		FileChecksumSHA1:   "85ed0817af83a24ad8da68c2b5094de69833983d",
 		LicenseConcluded:   "MIT",
 		LicenseInfoInFile:  []string{"MIT"},
@@ -45,14 +45,14 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 	}
 
 	unFiles := map[spdx.ElementID]*spdx.File2_1{
-		"File1231": f1,
-		"File1232": f2,
+		spdx.ElementID("File1231"): f1,
+		spdx.ElementID("File1232"): f2,
 	}
 
 	// Package 1: packaged files with snippets
 	sn1 := &spdx.Snippet2_1{
-		SnippetSPDXIdentifier:         "SPDXRef-Snippet19",
-		SnippetFromFileSPDXIdentifier: "SPDXRef-FileHasSnippets",
+		SnippetSPDXIdentifier:         "Snippet19",
+		SnippetFromFileSPDXIdentifier: spdx.MakeDocElementID("", "FileHasSnippets"),
 		SnippetByteRangeStart:         17,
 		SnippetByteRangeEnd:           209,
 		SnippetLicenseConcluded:       "GPL-2.0-or-later",
@@ -60,8 +60,8 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 	}
 
 	sn2 := &spdx.Snippet2_1{
-		SnippetSPDXIdentifier:         "SPDXRef-Snippet20",
-		SnippetFromFileSPDXIdentifier: "SPDXRef-FileHasSnippets",
+		SnippetSPDXIdentifier:         "Snippet20",
+		SnippetFromFileSPDXIdentifier: spdx.MakeDocElementID("", "FileHasSnippets"),
 		SnippetByteRangeStart:         268,
 		SnippetByteRangeEnd:           309,
 		SnippetLicenseConcluded:       "WTFPL",
@@ -70,7 +70,7 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 
 	f3 := &spdx.File2_1{
 		FileName:           "/tmp/file-with-snippets.txt",
-		FileSPDXIdentifier: "SPDXRef-FileHasSnippets",
+		FileSPDXIdentifier: spdx.ElementID("FileHasSnippets"),
 		FileChecksumSHA1:   "85ed0817af83a24ad8da68c2b5094de69833983e",
 		LicenseConcluded:   "GPL-2.0-or-later AND WTFPL",
 		LicenseInfoInFile: []string{
@@ -80,14 +80,14 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 		},
 		FileCopyrightText: "Copyright (c) Jane Doe",
 		Snippets: map[spdx.ElementID]*spdx.Snippet2_1{
-			"Snippet19": sn1,
-			"Snippet20": sn2,
+			spdx.ElementID("Snippet19"): sn1,
+			spdx.ElementID("Snippet20"): sn2,
 		},
 	}
 
 	f4 := &spdx.File2_1{
 		FileName:           "/tmp/another-file.txt",
-		FileSPDXIdentifier: "SPDXRef-FileAnother",
+		FileSPDXIdentifier: spdx.ElementID("FileAnother"),
 		FileChecksumSHA1:   "85ed0817af83a24ad8da68c2b5094de69833983f",
 		LicenseConcluded:   "BSD-3-Clause",
 		LicenseInfoInFile:  []string{"BSD-3-Clause"},
@@ -96,7 +96,7 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 
 	pkgWith := &spdx.Package2_1{
 		PackageName:               "p1",
-		PackageSPDXIdentifier:     "SPDXRef-p1",
+		PackageSPDXIdentifier:     spdx.ElementID("p1"),
 		PackageDownloadLocation:   "http://example.com/p1/p1-0.1.0-master.tar.gz",
 		FilesAnalyzed:             true,
 		IsFilesAnalyzedTagPresent: true,
@@ -111,8 +111,8 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 		PackageLicenseDeclared: "Apache-2.0 OR GPL-2.0-or-later",
 		PackageCopyrightText:   "Copyright (c) John Doe, Inc.",
 		Files: map[spdx.ElementID]*spdx.File2_1{
-			"FileHasSnippets": f3,
-			"FileAnother":     f4,
+			spdx.ElementID("FileHasSnippets"): f3,
+			spdx.ElementID("FileAnother"):     f4,
 		},
 	}
 
@@ -133,20 +133,20 @@ blah blah blah blah`,
 
 	// Relationships
 	rln1 := &spdx.Relationship2_1{
-		RefA:         "SPDXRef-DOCUMENT",
-		RefB:         "SPDXRef-p1",
+		RefA:         spdx.MakeDocElementID("", "DOCUMENT"),
+		RefB:         spdx.MakeDocElementID("", "p1"),
 		Relationship: "DESCRIBES",
 	}
 
 	rln2 := &spdx.Relationship2_1{
-		RefA:         "SPDXRef-DOCUMENT",
-		RefB:         "SPDXRef-File1231",
+		RefA:         spdx.MakeDocElementID("", "DOCUMENT"),
+		RefB:         spdx.MakeDocElementID("", "File1231"),
 		Relationship: "DESCRIBES",
 	}
 
 	rln3 := &spdx.Relationship2_1{
-		RefA:         "SPDXRef-DOCUMENT",
-		RefB:         "SPDXRef-File1232",
+		RefA:         spdx.MakeDocElementID("", "DOCUMENT"),
+		RefB:         spdx.MakeDocElementID("", "File1232"),
 		Relationship: "DESCRIBES",
 	}
 
@@ -156,7 +156,7 @@ blah blah blah blah`,
 		AnnotatorType:            "Person",
 		AnnotationDate:           "2018-10-10T17:52:00Z",
 		AnnotationType:           "REVIEW",
-		AnnotationSPDXIdentifier: "SPDXRef-DOCUMENT",
+		AnnotationSPDXIdentifier: spdx.MakeDocElementID("", "DOCUMENT"),
 		AnnotationComment:        "This is an annotation about the SPDX document",
 	}
 
@@ -165,7 +165,7 @@ blah blah blah blah`,
 		AnnotatorType:            "Organization",
 		AnnotationDate:           "2018-10-10T17:52:00Z",
 		AnnotationType:           "REVIEW",
-		AnnotationSPDXIdentifier: "SPDXRef-p1",
+		AnnotationSPDXIdentifier: spdx.MakeDocElementID("", "p1"),
 		AnnotationComment:        "This is an annotation about Package p1",
 	}
 
@@ -186,7 +186,7 @@ blah blah blah blah`,
 	doc := &spdx.Document2_1{
 		CreationInfo: ci,
 		Packages: map[spdx.ElementID]*spdx.Package2_1{
-			pkgWith,
+			spdx.ElementID("p1"): pkgWith,
 		},
 		UnpackagedFiles: unFiles,
 		OtherLicenses: []*spdx.OtherLicense2_1{
@@ -247,6 +247,13 @@ PackageLicenseInfoFromFiles: BSD-3-Clause
 PackageLicenseDeclared: Apache-2.0 OR GPL-2.0-or-later
 PackageCopyrightText: Copyright (c) John Doe, Inc.
 
+FileName: /tmp/another-file.txt
+SPDXID: SPDXRef-FileAnother
+FileChecksum: SHA1: 85ed0817af83a24ad8da68c2b5094de69833983f
+LicenseConcluded: BSD-3-Clause
+LicenseInfoInFile: BSD-3-Clause
+FileCopyrightText: Copyright (c) Jane Doe LLC
+
 FileName: /tmp/file-with-snippets.txt
 SPDXID: SPDXRef-FileHasSnippets
 FileChecksum: SHA1: 85ed0817af83a24ad8da68c2b5094de69833983e
@@ -267,13 +274,6 @@ SnippetFromFileSPDXID: SPDXRef-FileHasSnippets
 SnippetByteRange: 268:309
 SnippetLicenseConcluded: WTFPL
 SnippetCopyrightText: NOASSERTION
-
-FileName: /tmp/another-file.txt
-SPDXID: SPDXRef-FileAnother
-FileChecksum: SHA1: 85ed0817af83a24ad8da68c2b5094de69833983f
-LicenseConcluded: BSD-3-Clause
-LicenseInfoInFile: BSD-3-Clause
-FileCopyrightText: Copyright (c) Jane Doe LLC
 
 ##### Other Licenses
 

--- a/tvsaver/saver2v1/save_document_test.go
+++ b/tvsaver/saver2v1/save_document_test.go
@@ -25,7 +25,7 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 		Created: "2018-10-10T06:20:00Z",
 	}
 
-	// Package 1: unpackaged files
+	// unpackaged files
 	f1 := &spdx.File2_1{
 		FileName:           "/tmp/whatever1.txt",
 		FileSPDXIdentifier: "SPDXRef-File1231",
@@ -44,15 +44,12 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 		FileCopyrightText:  "Copyright (c) John Doe",
 	}
 
-	pkgUn := &spdx.Package2_1{
-		IsUnpackaged: true,
-		Files: []*spdx.File2_1{
-			f1,
-			f2,
-		},
+	unFiles := map[spdx.ElementID]*spdx.File2_1{
+		"File1231": f1,
+		"File1232": f2,
 	}
 
-	// Package 2: packaged files with snippets
+	// Package 1: packaged files with snippets
 	sn1 := &spdx.Snippet2_1{
 		SnippetSPDXIdentifier:         "SPDXRef-Snippet19",
 		SnippetFromFileSPDXIdentifier: "SPDXRef-FileHasSnippets",
@@ -82,9 +79,9 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 			"WTFPL",
 		},
 		FileCopyrightText: "Copyright (c) Jane Doe",
-		Snippets: []*spdx.Snippet2_1{
-			sn1,
-			sn2,
+		Snippets: map[spdx.ElementID]*spdx.Snippet2_1{
+			"Snippet19": sn1,
+			"Snippet20": sn2,
 		},
 	}
 
@@ -98,7 +95,6 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 	}
 
 	pkgWith := &spdx.Package2_1{
-		IsUnpackaged:              false,
 		PackageName:               "p1",
 		PackageSPDXIdentifier:     "SPDXRef-p1",
 		PackageDownloadLocation:   "http://example.com/p1/p1-0.1.0-master.tar.gz",
@@ -114,9 +110,9 @@ func TestSaver2_1DocumentSavesText(t *testing.T) {
 		},
 		PackageLicenseDeclared: "Apache-2.0 OR GPL-2.0-or-later",
 		PackageCopyrightText:   "Copyright (c) John Doe, Inc.",
-		Files: []*spdx.File2_1{
-			f3,
-			f4,
+		Files: map[spdx.ElementID]*spdx.File2_1{
+			"FileHasSnippets": f3,
+			"FileAnother":     f4,
 		},
 	}
 
@@ -189,10 +185,10 @@ blah blah blah blah`,
 	// now, build the document
 	doc := &spdx.Document2_1{
 		CreationInfo: ci,
-		Packages: []*spdx.Package2_1{
-			pkgUn,
+		Packages: map[spdx.ElementID]*spdx.Package2_1{
 			pkgWith,
 		},
+		UnpackagedFiles: unFiles,
 		OtherLicenses: []*spdx.OtherLicense2_1{
 			ol1,
 			ol2,

--- a/tvsaver/saver2v1/save_file.go
+++ b/tvsaver/saver2v1/save_file.go
@@ -5,6 +5,7 @@ package saver2v1
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/spdx/tools-golang/spdx"
 )
@@ -14,7 +15,7 @@ func renderFile2_1(f *spdx.File2_1, w io.Writer) error {
 		fmt.Fprintf(w, "FileName: %s\n", f.FileName)
 	}
 	if f.FileSPDXIdentifier != "" {
-		fmt.Fprintf(w, "SPDXID: %s\n", f.FileSPDXIdentifier)
+		fmt.Fprintf(w, "SPDXID: %s\n", spdx.RenderElementID(f.FileSPDXIdentifier))
 	}
 	for _, s := range f.FileType {
 		fmt.Fprintf(w, "FileType: %s\n", s)
@@ -65,7 +66,14 @@ func renderFile2_1(f *spdx.File2_1, w io.Writer) error {
 	fmt.Fprintf(w, "\n")
 
 	// also render any snippets for this file
-	for _, s := range f.Snippets {
+	// get slice of Snippet identifiers so we can sort them
+	snippetKeys := []string{}
+	for k := range f.Snippets {
+		snippetKeys = append(snippetKeys, string(k))
+	}
+	sort.Strings(snippetKeys)
+	for _, sID := range snippetKeys {
+		s := f.Snippets[spdx.ElementID(sID)]
 		renderSnippet2_1(s, w)
 	}
 

--- a/tvsaver/saver2v1/save_file_test.go
+++ b/tvsaver/saver2v1/save_file_test.go
@@ -13,7 +13,7 @@ import (
 func TestSaver2_1FileSavesText(t *testing.T) {
 	f := &spdx.File2_1{
 		FileName:           "/tmp/whatever.txt",
-		FileSPDXIdentifier: "SPDXRef-File123",
+		FileSPDXIdentifier: spdx.ElementID("File123"),
 		FileType: []string{
 			"TEXT",
 			"DOCUMENTATION",
@@ -104,8 +104,8 @@ FileDependency: g.txt
 
 func TestSaver2_1FileSavesSnippetsAlso(t *testing.T) {
 	sn1 := &spdx.Snippet2_1{
-		SnippetSPDXIdentifier:         "SPDXRef-Snippet19",
-		SnippetFromFileSPDXIdentifier: "SPDXRef-File123",
+		SnippetSPDXIdentifier:         spdx.ElementID("Snippet19"),
+		SnippetFromFileSPDXIdentifier: spdx.MakeDocElementID("", "File123"),
 		SnippetByteRangeStart:         17,
 		SnippetByteRangeEnd:           209,
 		SnippetLicenseConcluded:       "GPL-2.0-or-later",
@@ -113,22 +113,22 @@ func TestSaver2_1FileSavesSnippetsAlso(t *testing.T) {
 	}
 
 	sn2 := &spdx.Snippet2_1{
-		SnippetSPDXIdentifier:         "SPDXRef-Snippet20",
-		SnippetFromFileSPDXIdentifier: "SPDXRef-File123",
+		SnippetSPDXIdentifier:         spdx.ElementID("Snippet20"),
+		SnippetFromFileSPDXIdentifier: spdx.MakeDocElementID("", "File123"),
 		SnippetByteRangeStart:         268,
 		SnippetByteRangeEnd:           309,
 		SnippetLicenseConcluded:       "WTFPL",
 		SnippetCopyrightText:          "NOASSERTION",
 	}
 
-	sns := []*spdx.Snippet2_1{
-		sn1,
-		sn2,
+	sns := map[spdx.ElementID]*spdx.Snippet2_1{
+		spdx.ElementID("Snippet19"): sn1,
+		spdx.ElementID("Snippet20"): sn2,
 	}
 
 	f := &spdx.File2_1{
 		FileName:           "/tmp/whatever.txt",
-		FileSPDXIdentifier: "SPDXRef-File123",
+		FileSPDXIdentifier: spdx.ElementID("File123"),
 		FileChecksumSHA1:   "85ed0817af83a24ad8da68c2b5094de69833983c",
 		LicenseConcluded:   "Apache-2.0",
 		LicenseInfoInFile: []string{
@@ -177,7 +177,7 @@ SnippetCopyrightText: NOASSERTION
 func TestSaver2_1FileOmitsOptionalFieldsIfEmpty(t *testing.T) {
 	f := &spdx.File2_1{
 		FileName:           "/tmp/whatever.txt",
-		FileSPDXIdentifier: "SPDXRef-File123",
+		FileSPDXIdentifier: spdx.ElementID("File123"),
 		FileChecksumSHA1:   "85ed0817af83a24ad8da68c2b5094de69833983c",
 		LicenseConcluded:   "Apache-2.0",
 		LicenseInfoInFile: []string{
@@ -213,7 +213,7 @@ FileCopyrightText: Copyright (c) Jane Doe
 func TestSaver2_1FileWrapsCopyrightMultiLine(t *testing.T) {
 	f := &spdx.File2_1{
 		FileName:           "/tmp/whatever.txt",
-		FileSPDXIdentifier: "SPDXRef-File123",
+		FileSPDXIdentifier: spdx.ElementID("File123"),
 		FileChecksumSHA1:   "85ed0817af83a24ad8da68c2b5094de69833983c",
 		LicenseConcluded:   "Apache-2.0",
 		LicenseInfoInFile: []string{

--- a/tvsaver/saver2v1/save_package.go
+++ b/tvsaver/saver2v1/save_package.go
@@ -5,6 +5,7 @@ package saver2v1
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/spdx/tools-golang/spdx"
 )
@@ -14,7 +15,7 @@ func renderPackage2_1(pkg *spdx.Package2_1, w io.Writer) error {
 		fmt.Fprintf(w, "PackageName: %s\n", pkg.PackageName)
 	}
 	if pkg.PackageSPDXIdentifier != "" {
-		fmt.Fprintf(w, "SPDXID: %s\n", pkg.PackageSPDXIdentifier)
+		fmt.Fprintf(w, "SPDXID: %s\n", spdx.RenderElementID(pkg.PackageSPDXIdentifier))
 	}
 	if pkg.PackageVersion != "" {
 		fmt.Fprintf(w, "PackageVersion: %s\n", pkg.PackageVersion)
@@ -108,8 +109,15 @@ func renderPackage2_1(pkg *spdx.Package2_1, w io.Writer) error {
 	fmt.Fprintf(w, "\n")
 
 	// also render any files for this package
-	for _, f := range pkg.Files {
-		renderFile2_1(f, w)
+	// get slice of File identifiers so we can sort them
+	fileKeys := []string{}
+	for k := range pkg.Files {
+		fileKeys = append(fileKeys, string(k))
+	}
+	sort.Strings(fileKeys)
+	for _, fiID := range fileKeys {
+		fi := pkg.Files[spdx.ElementID(fiID)]
+		renderFile2_1(fi, w)
 	}
 
 	return nil

--- a/tvsaver/saver2v1/save_package.go
+++ b/tvsaver/saver2v1/save_package.go
@@ -10,106 +10,104 @@ import (
 )
 
 func renderPackage2_1(pkg *spdx.Package2_1, w io.Writer) error {
-	if pkg.IsUnpackaged == false {
-		if pkg.PackageName != "" {
-			fmt.Fprintf(w, "PackageName: %s\n", pkg.PackageName)
+	if pkg.PackageName != "" {
+		fmt.Fprintf(w, "PackageName: %s\n", pkg.PackageName)
+	}
+	if pkg.PackageSPDXIdentifier != "" {
+		fmt.Fprintf(w, "SPDXID: %s\n", pkg.PackageSPDXIdentifier)
+	}
+	if pkg.PackageVersion != "" {
+		fmt.Fprintf(w, "PackageVersion: %s\n", pkg.PackageVersion)
+	}
+	if pkg.PackageFileName != "" {
+		fmt.Fprintf(w, "PackageFileName: %s\n", pkg.PackageFileName)
+	}
+	if pkg.PackageSupplierPerson != "" {
+		fmt.Fprintf(w, "PackageSupplier: Person: %s\n", pkg.PackageSupplierPerson)
+	}
+	if pkg.PackageSupplierOrganization != "" {
+		fmt.Fprintf(w, "PackageSupplier: Organization: %s\n", pkg.PackageSupplierOrganization)
+	}
+	if pkg.PackageSupplierNOASSERTION == true {
+		fmt.Fprintf(w, "PackageSupplier: NOASSERTION\n")
+	}
+	if pkg.PackageOriginatorPerson != "" {
+		fmt.Fprintf(w, "PackageOriginator: Person: %s\n", pkg.PackageOriginatorPerson)
+	}
+	if pkg.PackageOriginatorOrganization != "" {
+		fmt.Fprintf(w, "PackageOriginator: Organization: %s\n", pkg.PackageOriginatorOrganization)
+	}
+	if pkg.PackageOriginatorNOASSERTION == true {
+		fmt.Fprintf(w, "PackageOriginator: NOASSERTION\n")
+	}
+	if pkg.PackageDownloadLocation != "" {
+		fmt.Fprintf(w, "PackageDownloadLocation: %s\n", pkg.PackageDownloadLocation)
+	}
+	if pkg.FilesAnalyzed == true {
+		if pkg.IsFilesAnalyzedTagPresent == true {
+			fmt.Fprintf(w, "FilesAnalyzed: true\n")
 		}
-		if pkg.PackageSPDXIdentifier != "" {
-			fmt.Fprintf(w, "SPDXID: %s\n", pkg.PackageSPDXIdentifier)
-		}
-		if pkg.PackageVersion != "" {
-			fmt.Fprintf(w, "PackageVersion: %s\n", pkg.PackageVersion)
-		}
-		if pkg.PackageFileName != "" {
-			fmt.Fprintf(w, "PackageFileName: %s\n", pkg.PackageFileName)
-		}
-		if pkg.PackageSupplierPerson != "" {
-			fmt.Fprintf(w, "PackageSupplier: Person: %s\n", pkg.PackageSupplierPerson)
-		}
-		if pkg.PackageSupplierOrganization != "" {
-			fmt.Fprintf(w, "PackageSupplier: Organization: %s\n", pkg.PackageSupplierOrganization)
-		}
-		if pkg.PackageSupplierNOASSERTION == true {
-			fmt.Fprintf(w, "PackageSupplier: NOASSERTION\n")
-		}
-		if pkg.PackageOriginatorPerson != "" {
-			fmt.Fprintf(w, "PackageOriginator: Person: %s\n", pkg.PackageOriginatorPerson)
-		}
-		if pkg.PackageOriginatorOrganization != "" {
-			fmt.Fprintf(w, "PackageOriginator: Organization: %s\n", pkg.PackageOriginatorOrganization)
-		}
-		if pkg.PackageOriginatorNOASSERTION == true {
-			fmt.Fprintf(w, "PackageOriginator: NOASSERTION\n")
-		}
-		if pkg.PackageDownloadLocation != "" {
-			fmt.Fprintf(w, "PackageDownloadLocation: %s\n", pkg.PackageDownloadLocation)
-		}
-		if pkg.FilesAnalyzed == true {
-			if pkg.IsFilesAnalyzedTagPresent == true {
-				fmt.Fprintf(w, "FilesAnalyzed: true\n")
-			}
+	} else {
+		fmt.Fprintf(w, "FilesAnalyzed: false\n")
+	}
+	if pkg.PackageVerificationCode != "" && pkg.FilesAnalyzed == true {
+		if pkg.PackageVerificationCodeExcludedFile == "" {
+			fmt.Fprintf(w, "PackageVerificationCode: %s\n", pkg.PackageVerificationCode)
 		} else {
-			fmt.Fprintf(w, "FilesAnalyzed: false\n")
+			fmt.Fprintf(w, "PackageVerificationCode: %s (excludes %s)\n", pkg.PackageVerificationCode, pkg.PackageVerificationCodeExcludedFile)
 		}
-		if pkg.PackageVerificationCode != "" && pkg.FilesAnalyzed == true {
-			if pkg.PackageVerificationCodeExcludedFile == "" {
-				fmt.Fprintf(w, "PackageVerificationCode: %s\n", pkg.PackageVerificationCode)
-			} else {
-				fmt.Fprintf(w, "PackageVerificationCode: %s (excludes %s)\n", pkg.PackageVerificationCode, pkg.PackageVerificationCodeExcludedFile)
-			}
+	}
+	if pkg.PackageChecksumSHA1 != "" {
+		fmt.Fprintf(w, "PackageChecksum: SHA1: %s\n", pkg.PackageChecksumSHA1)
+	}
+	if pkg.PackageChecksumSHA256 != "" {
+		fmt.Fprintf(w, "PackageChecksum: SHA256: %s\n", pkg.PackageChecksumSHA256)
+	}
+	if pkg.PackageChecksumMD5 != "" {
+		fmt.Fprintf(w, "PackageChecksum: MD5: %s\n", pkg.PackageChecksumMD5)
+	}
+	if pkg.PackageHomePage != "" {
+		fmt.Fprintf(w, "PackageHomePage: %s\n", pkg.PackageHomePage)
+	}
+	if pkg.PackageSourceInfo != "" {
+		fmt.Fprintf(w, "PackageSourceInfo: %s\n", textify(pkg.PackageSourceInfo))
+	}
+	if pkg.PackageLicenseConcluded != "" {
+		fmt.Fprintf(w, "PackageLicenseConcluded: %s\n", pkg.PackageLicenseConcluded)
+	}
+	if pkg.FilesAnalyzed == true {
+		for _, s := range pkg.PackageLicenseInfoFromFiles {
+			fmt.Fprintf(w, "PackageLicenseInfoFromFiles: %s\n", s)
 		}
-		if pkg.PackageChecksumSHA1 != "" {
-			fmt.Fprintf(w, "PackageChecksum: SHA1: %s\n", pkg.PackageChecksumSHA1)
+	}
+	if pkg.PackageLicenseDeclared != "" {
+		fmt.Fprintf(w, "PackageLicenseDeclared: %s\n", pkg.PackageLicenseDeclared)
+	}
+	if pkg.PackageLicenseComments != "" {
+		fmt.Fprintf(w, "PackageLicenseComments: %s\n", textify(pkg.PackageLicenseComments))
+	}
+	if pkg.PackageCopyrightText != "" {
+		fmt.Fprintf(w, "PackageCopyrightText: %s\n", pkg.PackageCopyrightText)
+	}
+	if pkg.PackageSummary != "" {
+		fmt.Fprintf(w, "PackageSummary: %s\n", textify(pkg.PackageSummary))
+	}
+	if pkg.PackageDescription != "" {
+		fmt.Fprintf(w, "PackageDescription: %s\n", textify(pkg.PackageDescription))
+	}
+	if pkg.PackageComment != "" {
+		fmt.Fprintf(w, "PackageComment: %s\n", textify(pkg.PackageComment))
+	}
+	for _, s := range pkg.PackageExternalReferences {
+		fmt.Fprintf(w, "ExternalRef: %s %s %s\n", s.Category, s.RefType, s.Locator)
+		if s.ExternalRefComment != "" {
+			fmt.Fprintf(w, "ExternalRefComment: %s\n", s.ExternalRefComment)
 		}
-		if pkg.PackageChecksumSHA256 != "" {
-			fmt.Fprintf(w, "PackageChecksum: SHA256: %s\n", pkg.PackageChecksumSHA256)
-		}
-		if pkg.PackageChecksumMD5 != "" {
-			fmt.Fprintf(w, "PackageChecksum: MD5: %s\n", pkg.PackageChecksumMD5)
-		}
-		if pkg.PackageHomePage != "" {
-			fmt.Fprintf(w, "PackageHomePage: %s\n", pkg.PackageHomePage)
-		}
-		if pkg.PackageSourceInfo != "" {
-			fmt.Fprintf(w, "PackageSourceInfo: %s\n", textify(pkg.PackageSourceInfo))
-		}
-		if pkg.PackageLicenseConcluded != "" {
-			fmt.Fprintf(w, "PackageLicenseConcluded: %s\n", pkg.PackageLicenseConcluded)
-		}
-		if pkg.FilesAnalyzed == true {
-			for _, s := range pkg.PackageLicenseInfoFromFiles {
-				fmt.Fprintf(w, "PackageLicenseInfoFromFiles: %s\n", s)
-			}
-		}
-		if pkg.PackageLicenseDeclared != "" {
-			fmt.Fprintf(w, "PackageLicenseDeclared: %s\n", pkg.PackageLicenseDeclared)
-		}
-		if pkg.PackageLicenseComments != "" {
-			fmt.Fprintf(w, "PackageLicenseComments: %s\n", textify(pkg.PackageLicenseComments))
-		}
-		if pkg.PackageCopyrightText != "" {
-			fmt.Fprintf(w, "PackageCopyrightText: %s\n", pkg.PackageCopyrightText)
-		}
-		if pkg.PackageSummary != "" {
-			fmt.Fprintf(w, "PackageSummary: %s\n", textify(pkg.PackageSummary))
-		}
-		if pkg.PackageDescription != "" {
-			fmt.Fprintf(w, "PackageDescription: %s\n", textify(pkg.PackageDescription))
-		}
-		if pkg.PackageComment != "" {
-			fmt.Fprintf(w, "PackageComment: %s\n", textify(pkg.PackageComment))
-		}
-		for _, s := range pkg.PackageExternalReferences {
-			fmt.Fprintf(w, "ExternalRef: %s %s %s\n", s.Category, s.RefType, s.Locator)
-			if s.ExternalRefComment != "" {
-				fmt.Fprintf(w, "ExternalRefComment: %s\n", s.ExternalRefComment)
-			}
-		}
-
-		fmt.Fprintf(w, "\n")
 	}
 
-	// also render any files for this package, even if unpackaged
+	fmt.Fprintf(w, "\n")
+
+	// also render any files for this package
 	for _, f := range pkg.Files {
 		renderFile2_1(f, w)
 	}

--- a/tvsaver/saver2v1/save_package_test.go
+++ b/tvsaver/saver2v1/save_package_test.go
@@ -40,7 +40,6 @@ func TestSaver2_1PackageSavesTextCombo1(t *testing.T) {
 	}
 
 	pkg := &spdx.Package2_1{
-		IsUnpackaged:                        false,
 		PackageName:                         "p1",
 		PackageSPDXIdentifier:               "SPDXRef-p1",
 		PackageVersion:                      "0.1.0",
@@ -129,7 +128,6 @@ func TestSaver2_1PackageSavesTextCombo2(t *testing.T) {
 	// PackageVerificationCodeExcludedFile is empty
 
 	pkg := &spdx.Package2_1{
-		IsUnpackaged:                  false,
 		PackageName:                   "p1",
 		PackageSPDXIdentifier:         "SPDXRef-p1",
 		PackageVersion:                "0.1.0",
@@ -207,7 +205,6 @@ func TestSaver2_1PackageSavesTextCombo3(t *testing.T) {
 	// PackageVerificationCodeExcludedFile is empty
 
 	pkg := &spdx.Package2_1{
-		IsUnpackaged:                 false,
 		PackageName:                  "p1",
 		PackageSPDXIdentifier:        "SPDXRef-p1",
 		PackageVersion:               "0.1.0",
@@ -281,7 +278,6 @@ PackageComment: this is a comment comment
 
 func TestSaver2_1PackageSaveOmitsOptionalFieldsIfEmpty(t *testing.T) {
 	pkg := &spdx.Package2_1{
-		IsUnpackaged:              false,
 		PackageName:               "p1",
 		PackageSPDXIdentifier:     "SPDXRef-p1",
 		PackageDownloadLocation:   "http://example.com/p1/p1-0.1.0-master.tar.gz",
@@ -346,7 +342,6 @@ func TestSaver2_1PackageSavesFilesIfPresent(t *testing.T) {
 	}
 
 	pkg := &spdx.Package2_1{
-		IsUnpackaged:              false,
 		PackageName:               "p1",
 		PackageSPDXIdentifier:     "SPDXRef-p1",
 		PackageDownloadLocation:   "http://example.com/p1/p1-0.1.0-master.tar.gz",
@@ -428,12 +423,9 @@ func TestSaver2_1PackageSavesUnpackagedFilesIfPresent(t *testing.T) {
 		FileCopyrightText:  "Copyright (c) John Doe",
 	}
 
-	pkg := &spdx.Package2_1{
-		IsUnpackaged: true,
-		Files: []*spdx.File2_1{
-			f1,
-			f2,
-		},
+	unFiles := map[spdx.ElementID]*spdx.File2_1{
+		"File1231": f1,
+		"File1232": f2,
 	}
 
 	// what we want to get, as a buffer of bytes
@@ -455,29 +447,11 @@ FileCopyrightText: Copyright (c) John Doe
 
 	// render as buffer of bytes
 	var got bytes.Buffer
-	err := renderPackage2_1(pkg, &got)
-	if err != nil {
-		t.Errorf("Expected nil error, got %v", err)
-	}
-
-	// check that they match
-	c := bytes.Compare(want.Bytes(), got.Bytes())
-	if c != 0 {
-		t.Errorf("Expected %v, got %v", want.String(), got.String())
-	}
-}
-
-func TestSaver2_1PackageSavesNothingIfUnpackagedAndNoFilesPresent(t *testing.T) {
-	pkg := &spdx.Package2_1{IsUnpackaged: true}
-
-	// what we want to get, as a buffer of bytes
-	want := bytes.NewBufferString("")
-
-	// render as buffer of bytes
-	var got bytes.Buffer
-	err := renderPackage2_1(pkg, &got)
-	if err != nil {
-		t.Errorf("Expected nil error, got %v", err)
+	for fi := unFiles {
+		err := renderFile2_1(fi, &got)
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
 	}
 
 	// check that they match

--- a/tvsaver/saver2v1/save_package_test.go
+++ b/tvsaver/saver2v1/save_package_test.go
@@ -41,7 +41,7 @@ func TestSaver2_1PackageSavesTextCombo1(t *testing.T) {
 
 	pkg := &spdx.Package2_1{
 		PackageName:                         "p1",
-		PackageSPDXIdentifier:               "SPDXRef-p1",
+		PackageSPDXIdentifier:               spdx.ElementID("p1"),
 		PackageVersion:                      "0.1.0",
 		PackageFileName:                     "p1-0.1.0-master.tar.gz",
 		PackageSupplierOrganization:         "John Doe, Inc.",
@@ -129,7 +129,7 @@ func TestSaver2_1PackageSavesTextCombo2(t *testing.T) {
 
 	pkg := &spdx.Package2_1{
 		PackageName:                   "p1",
-		PackageSPDXIdentifier:         "SPDXRef-p1",
+		PackageSPDXIdentifier:         spdx.ElementID("p1"),
 		PackageVersion:                "0.1.0",
 		PackageFileName:               "p1-0.1.0-master.tar.gz",
 		PackageSupplierNOASSERTION:    true,
@@ -206,7 +206,7 @@ func TestSaver2_1PackageSavesTextCombo3(t *testing.T) {
 
 	pkg := &spdx.Package2_1{
 		PackageName:                  "p1",
-		PackageSPDXIdentifier:        "SPDXRef-p1",
+		PackageSPDXIdentifier:        spdx.ElementID("p1"),
 		PackageVersion:               "0.1.0",
 		PackageFileName:              "p1-0.1.0-master.tar.gz",
 		PackageSupplierPerson:        "John Doe",
@@ -279,7 +279,7 @@ PackageComment: this is a comment comment
 func TestSaver2_1PackageSaveOmitsOptionalFieldsIfEmpty(t *testing.T) {
 	pkg := &spdx.Package2_1{
 		PackageName:               "p1",
-		PackageSPDXIdentifier:     "SPDXRef-p1",
+		PackageSPDXIdentifier:     spdx.ElementID("p1"),
 		PackageDownloadLocation:   "http://example.com/p1/p1-0.1.0-master.tar.gz",
 		FilesAnalyzed:             false,
 		IsFilesAnalyzedTagPresent: true,
@@ -325,7 +325,7 @@ PackageCopyrightText: Copyright (c) John Doe, Inc.
 func TestSaver2_1PackageSavesFilesIfPresent(t *testing.T) {
 	f1 := &spdx.File2_1{
 		FileName:           "/tmp/whatever1.txt",
-		FileSPDXIdentifier: "SPDXRef-File1231",
+		FileSPDXIdentifier: spdx.ElementID("File1231"),
 		FileChecksumSHA1:   "85ed0817af83a24ad8da68c2b5094de69833983c",
 		LicenseConcluded:   "Apache-2.0",
 		LicenseInfoInFile:  []string{"Apache-2.0"},
@@ -334,7 +334,7 @@ func TestSaver2_1PackageSavesFilesIfPresent(t *testing.T) {
 
 	f2 := &spdx.File2_1{
 		FileName:           "/tmp/whatever2.txt",
-		FileSPDXIdentifier: "SPDXRef-File1232",
+		FileSPDXIdentifier: spdx.ElementID("File1232"),
 		FileChecksumSHA1:   "85ed0817af83a24ad8da68c2b5094de69833983d",
 		LicenseConcluded:   "MIT",
 		LicenseInfoInFile:  []string{"MIT"},
@@ -343,7 +343,7 @@ func TestSaver2_1PackageSavesFilesIfPresent(t *testing.T) {
 
 	pkg := &spdx.Package2_1{
 		PackageName:               "p1",
-		PackageSPDXIdentifier:     "SPDXRef-p1",
+		PackageSPDXIdentifier:     spdx.ElementID("p1"),
 		PackageDownloadLocation:   "http://example.com/p1/p1-0.1.0-master.tar.gz",
 		FilesAnalyzed:             false,
 		IsFilesAnalyzedTagPresent: true,
@@ -359,9 +359,9 @@ func TestSaver2_1PackageSavesFilesIfPresent(t *testing.T) {
 		},
 		PackageLicenseDeclared: "Apache-2.0 OR GPL-2.0-or-later",
 		PackageCopyrightText:   "Copyright (c) John Doe, Inc.",
-		Files: []*spdx.File2_1{
-			f1,
-			f2,
+		Files: map[spdx.ElementID]*spdx.File2_1{
+			spdx.ElementID("File1231"): f1,
+			spdx.ElementID("File1232"): f2,
 		},
 	}
 
@@ -395,63 +395,6 @@ FileCopyrightText: Copyright (c) John Doe
 	err := renderPackage2_1(pkg, &got)
 	if err != nil {
 		t.Errorf("Expected nil error, got %v", err)
-	}
-
-	// check that they match
-	c := bytes.Compare(want.Bytes(), got.Bytes())
-	if c != 0 {
-		t.Errorf("Expected %v, got %v", want.String(), got.String())
-	}
-}
-
-func TestSaver2_1PackageSavesUnpackagedFilesIfPresent(t *testing.T) {
-	f1 := &spdx.File2_1{
-		FileName:           "/tmp/whatever1.txt",
-		FileSPDXIdentifier: "SPDXRef-File1231",
-		FileChecksumSHA1:   "85ed0817af83a24ad8da68c2b5094de69833983c",
-		LicenseConcluded:   "Apache-2.0",
-		LicenseInfoInFile:  []string{"Apache-2.0"},
-		FileCopyrightText:  "Copyright (c) Jane Doe",
-	}
-
-	f2 := &spdx.File2_1{
-		FileName:           "/tmp/whatever2.txt",
-		FileSPDXIdentifier: "SPDXRef-File1232",
-		FileChecksumSHA1:   "85ed0817af83a24ad8da68c2b5094de69833983d",
-		LicenseConcluded:   "MIT",
-		LicenseInfoInFile:  []string{"MIT"},
-		FileCopyrightText:  "Copyright (c) John Doe",
-	}
-
-	unFiles := map[spdx.ElementID]*spdx.File2_1{
-		"File1231": f1,
-		"File1232": f2,
-	}
-
-	// what we want to get, as a buffer of bytes
-	want := bytes.NewBufferString(`FileName: /tmp/whatever1.txt
-SPDXID: SPDXRef-File1231
-FileChecksum: SHA1: 85ed0817af83a24ad8da68c2b5094de69833983c
-LicenseConcluded: Apache-2.0
-LicenseInfoInFile: Apache-2.0
-FileCopyrightText: Copyright (c) Jane Doe
-
-FileName: /tmp/whatever2.txt
-SPDXID: SPDXRef-File1232
-FileChecksum: SHA1: 85ed0817af83a24ad8da68c2b5094de69833983d
-LicenseConcluded: MIT
-LicenseInfoInFile: MIT
-FileCopyrightText: Copyright (c) John Doe
-
-`)
-
-	// render as buffer of bytes
-	var got bytes.Buffer
-	for fi := unFiles {
-		err := renderFile2_1(fi, &got)
-		if err != nil {
-			t.Errorf("Expected nil error, got %v", err)
-		}
 	}
 
 	// check that they match

--- a/tvsaver/saver2v1/save_relationship.go
+++ b/tvsaver/saver2v1/save_relationship.go
@@ -10,8 +10,10 @@ import (
 )
 
 func renderRelationship2_1(rln *spdx.Relationship2_1, w io.Writer) error {
-	if rln.RefA != "" && rln.RefB != "" && rln.Relationship != "" {
-		fmt.Fprintf(w, "Relationship: %s %s %s\n", rln.RefA, rln.Relationship, rln.RefB)
+	rlnAStr := spdx.RenderDocElementID(rln.RefA)
+	rlnBStr := spdx.RenderDocElementID(rln.RefB)
+	if rlnAStr != "SPDXRef-" && rlnBStr != "SPDXRef-" && rln.Relationship != "" {
+		fmt.Fprintf(w, "Relationship: %s %s %s\n", rlnAStr, rln.Relationship, rlnBStr)
 	}
 	if rln.RelationshipComment != "" {
 		fmt.Fprintf(w, "RelationshipComment: %s\n", rln.RelationshipComment)

--- a/tvsaver/saver2v1/save_relationship_test.go
+++ b/tvsaver/saver2v1/save_relationship_test.go
@@ -12,8 +12,8 @@ import (
 // ===== Relationship section Saver tests =====
 func TestSaver2_1RelationshipSavesText(t *testing.T) {
 	rln := &spdx.Relationship2_1{
-		RefA:                "SPDXRef-DOCUMENT",
-		RefB:                "SPDXRef-2",
+		RefA:                spdx.MakeDocElementID("", "DOCUMENT"),
+		RefB:                spdx.MakeDocElementID("", "2"),
 		Relationship:        "DESCRIBES",
 		RelationshipComment: "this is a comment",
 	}
@@ -40,8 +40,8 @@ RelationshipComment: this is a comment
 
 func TestSaver2_1RelationshipOmitsOptionalFieldsIfEmpty(t *testing.T) {
 	rln := &spdx.Relationship2_1{
-		RefA:         "SPDXRef-DOCUMENT",
-		RefB:         "SPDXRef-2",
+		RefA:         spdx.MakeDocElementID("", "DOCUMENT"),
+		RefB:         spdx.MakeDocElementID("", "2"),
 		Relationship: "DESCRIBES",
 	}
 

--- a/tvsaver/saver2v1/save_snippet.go
+++ b/tvsaver/saver2v1/save_snippet.go
@@ -11,10 +11,11 @@ import (
 
 func renderSnippet2_1(sn *spdx.Snippet2_1, w io.Writer) error {
 	if sn.SnippetSPDXIdentifier != "" {
-		fmt.Fprintf(w, "SnippetSPDXIdentifier: %s\n", sn.SnippetSPDXIdentifier)
+		fmt.Fprintf(w, "SnippetSPDXIdentifier: %s\n", spdx.RenderElementID(sn.SnippetSPDXIdentifier))
 	}
-	if sn.SnippetFromFileSPDXIdentifier != "" {
-		fmt.Fprintf(w, "SnippetFromFileSPDXID: %s\n", sn.SnippetFromFileSPDXIdentifier)
+	snFromFileIDStr := spdx.RenderDocElementID(sn.SnippetFromFileSPDXIdentifier)
+	if snFromFileIDStr != "" {
+		fmt.Fprintf(w, "SnippetFromFileSPDXID: %s\n", snFromFileIDStr)
 	}
 	if sn.SnippetByteRangeStart != 0 && sn.SnippetByteRangeEnd != 0 {
 		fmt.Fprintf(w, "SnippetByteRange: %d:%d\n", sn.SnippetByteRangeStart, sn.SnippetByteRangeEnd)

--- a/tvsaver/saver2v1/save_snippet_test.go
+++ b/tvsaver/saver2v1/save_snippet_test.go
@@ -12,8 +12,8 @@ import (
 // ===== Snippet section Saver tests =====
 func TestSaver2_1SnippetSavesText(t *testing.T) {
 	sn := &spdx.Snippet2_1{
-		SnippetSPDXIdentifier:         "SPDXRef-Snippet17",
-		SnippetFromFileSPDXIdentifier: "SPDXRef-File292",
+		SnippetSPDXIdentifier:         spdx.ElementID("Snippet17"),
+		SnippetFromFileSPDXIdentifier: spdx.MakeDocElementID("", "File292"),
 		SnippetByteRangeStart:         17,
 		SnippetByteRangeEnd:           209,
 		SnippetLineRangeStart:         3,
@@ -60,8 +60,8 @@ SnippetName: from John's program
 
 func TestSaver2_1SnippetOmitsOptionalFieldsIfEmpty(t *testing.T) {
 	sn := &spdx.Snippet2_1{
-		SnippetSPDXIdentifier:         "SPDXRef-Snippet17",
-		SnippetFromFileSPDXIdentifier: "SPDXRef-File292",
+		SnippetSPDXIdentifier:         spdx.ElementID("Snippet17"),
+		SnippetFromFileSPDXIdentifier: spdx.MakeDocElementID("", "File292"),
 		SnippetByteRangeStart:         17,
 		SnippetByteRangeEnd:           209,
 		SnippetLicenseConcluded:       "GPL-2.0-or-later",

--- a/utils/verification.go
+++ b/utils/verification.go
@@ -15,12 +15,12 @@ import (
 // GetVerificationCode2_1 takes a slice of files and an optional filename
 // for an "excludes" file, and returns a Package Verification Code calculated
 // according to SPDX spec version 2.1, section 3.9.4.
-func GetVerificationCode2_1(files []*spdx.File2_1, excludeFile string) (string, error) {
+func GetVerificationCode2_1(files map[spdx.ElementID]*spdx.File2_1, excludeFile string) (string, error) {
 	// create slice of strings - unsorted SHA1s for all files
 	shas := []string{}
 	for i, f := range files {
 		if f == nil {
-			return "", fmt.Errorf("got nil file in index %d", i)
+			return "", fmt.Errorf("got nil file for identifier %v", i)
 		}
 		if f.FileName != excludeFile {
 			shas = append(shas, f.FileChecksumSHA1)

--- a/utils/verification_test.go
+++ b/utils/verification_test.go
@@ -11,26 +11,31 @@ import (
 // ===== Verification code functionality tests =====
 
 func TestPackage2_1CanGetVerificationCode(t *testing.T) {
-	files := []*spdx.File2_1{
-		&spdx.File2_1{
-			FileName:         "file2.txt",
-			FileChecksumSHA1: "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
+	files := map[spdx.ElementID]*spdx.File2_1{
+		"File0": &spdx.File2_1{
+			FileName:           "file2.txt",
+			FileSPDXIdentifier: "File0",
+			FileChecksumSHA1:   "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
 		},
-		&spdx.File2_1{
-			FileName:         "file1.txt",
-			FileChecksumSHA1: "3333333333bbbbbbbbbbccccccccccdddddddddd",
+		"File1": &spdx.File2_1{
+			FileName:           "file1.txt",
+			FileSPDXIdentifier: "File1",
+			FileChecksumSHA1:   "3333333333bbbbbbbbbbccccccccccdddddddddd",
 		},
-		&spdx.File2_1{
-			FileName:         "file3.txt",
-			FileChecksumSHA1: "8888888888bbbbbbbbbbccccccccccdddddddddd",
+		"File2": &spdx.File2_1{
+			FileName:           "file3.txt",
+			FileSPDXIdentifier: "File2",
+			FileChecksumSHA1:   "8888888888bbbbbbbbbbccccccccccdddddddddd",
 		},
-		&spdx.File2_1{
-			FileName:         "file5.txt",
-			FileChecksumSHA1: "2222222222bbbbbbbbbbccccccccccdddddddddd",
+		"File3": &spdx.File2_1{
+			FileName:           "file5.txt",
+			FileSPDXIdentifier: "File3",
+			FileChecksumSHA1:   "2222222222bbbbbbbbbbccccccccccdddddddddd",
 		},
-		&spdx.File2_1{
-			FileName:         "file4.txt",
-			FileChecksumSHA1: "bbbbbbbbbbccccccccccddddddddddaaaaaaaaaa",
+		"File4": &spdx.File2_1{
+			FileName:           "file4.txt",
+			FileSPDXIdentifier: "File4",
+			FileChecksumSHA1:   "bbbbbbbbbbccccccccccddddddddddaaaaaaaaaa",
 		},
 	}
 
@@ -47,26 +52,31 @@ func TestPackage2_1CanGetVerificationCode(t *testing.T) {
 }
 
 func TestPackage2_1CanGetVerificationCodeIgnoringExcludesFile(t *testing.T) {
-	files := []*spdx.File2_1{
-		&spdx.File2_1{
-			FileName:         "file1.txt",
-			FileChecksumSHA1: "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
+	files := map[spdx.ElementID]*spdx.File2_1{
+		spdx.ElementID("File0"): &spdx.File2_1{
+			FileName:           "file1.txt",
+			FileSPDXIdentifier: "File0",
+			FileChecksumSHA1:   "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
 		},
-		&spdx.File2_1{
-			FileName:         "file2.txt",
-			FileChecksumSHA1: "3333333333bbbbbbbbbbccccccccccdddddddddd",
+		spdx.ElementID("File1"): &spdx.File2_1{
+			FileName:           "file2.txt",
+			FileSPDXIdentifier: "File1",
+			FileChecksumSHA1:   "3333333333bbbbbbbbbbccccccccccdddddddddd",
 		},
-		&spdx.File2_1{
-			FileName:         "thisfile.spdx",
-			FileChecksumSHA1: "bbbbbbbbbbccccccccccddddddddddaaaaaaaaaa",
+		spdx.ElementID("File2"): &spdx.File2_1{
+			FileName:           "thisfile.spdx",
+			FileSPDXIdentifier: "File2",
+			FileChecksumSHA1:   "bbbbbbbbbbccccccccccddddddddddaaaaaaaaaa",
 		},
-		&spdx.File2_1{
-			FileName:         "file3.txt",
-			FileChecksumSHA1: "8888888888bbbbbbbbbbccccccccccdddddddddd",
+		spdx.ElementID("File3"): &spdx.File2_1{
+			FileName:           "file3.txt",
+			FileSPDXIdentifier: "File3",
+			FileChecksumSHA1:   "8888888888bbbbbbbbbbccccccccccdddddddddd",
 		},
-		&spdx.File2_1{
-			FileName:         "file4.txt",
-			FileChecksumSHA1: "2222222222bbbbbbbbbbccccccccccdddddddddd",
+		spdx.ElementID("File4"): &spdx.File2_1{
+			FileName:           "file4.txt",
+			FileSPDXIdentifier: "File4",
+			FileChecksumSHA1:   "2222222222bbbbbbbbbbccccccccccdddddddddd",
 		},
 	}
 
@@ -83,15 +93,17 @@ func TestPackage2_1CanGetVerificationCodeIgnoringExcludesFile(t *testing.T) {
 }
 
 func TestPackage2_1GetVerificationCodeFailsIfNilFileInSlice(t *testing.T) {
-	files := []*spdx.File2_1{
-		&spdx.File2_1{
-			FileName:         "file2.txt",
-			FileChecksumSHA1: "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
+	files := map[spdx.ElementID]*spdx.File2_1{
+		spdx.ElementID("File0"): &spdx.File2_1{
+			FileName:           "file2.txt",
+			FileSPDXIdentifier: "File0",
+			FileChecksumSHA1:   "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
 		},
-		nil,
-		&spdx.File2_1{
-			FileName:         "file3.txt",
-			FileChecksumSHA1: "8888888888bbbbbbbbbbccccccccccdddddddddd",
+		spdx.ElementID("File1"): nil,
+		spdx.ElementID("File2"): &spdx.File2_1{
+			FileName:           "file3.txt",
+			FileSPDXIdentifier: "File2",
+			FileChecksumSHA1:   "8888888888bbbbbbbbbbccccccccccdddddddddd",
 		},
 	}
 


### PR DESCRIPTION
This refactors all of the spdx/tools-golang packages to use element IDs (and, where applicable, optional document IDs) as keys for documents, packages, files and snippets, rather than having them as slices.

It also changes relationships and annotations to use document/element IDs for references rather than arbitrary strings.

It _**does not**_ change Other Licensing Information sections to use LicenseRef- IDs as keys. Other Licensing Information sections are still stored in a slice in the Document rather than a map. That should be fixed, but it's a separate issue.

This PR also bundles in the first function for spdxlib, to help with identifying which packages are DESCRIBES / DESCRIBED_BY an SPDX document. This was necessary to get several of the examples working, since previously they just pulled from the index 0 package in a document.

Fixes #24 

Fixes #28

Signed-off-by: Steve Winslow <steve@swinslow.net>