### PR TITLE
Update RDFLoader wrt new ExternalDocumentReference and Change Module Path of GoRdf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/spdx/tools-golang
 
 go 1.13
+
+require github.com/spdx/gordf v0.0.0-20201111095634-7098f93598fb

--- a/rdfloader/parser2v2/constants.go
+++ b/rdfloader/parser2v2/constants.go
@@ -1,6 +1,6 @@
 package parser2v2
 
-import "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+import "github.com/spdx/gordf/rdfloader/parser"
 
 var (
 	// NAMESPACES

--- a/rdfloader/parser2v2/license_utils.go
+++ b/rdfloader/parser2v2/license_utils.go
@@ -2,7 +2,7 @@ package parser2v2
 
 import (
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"strings"
 )
 

--- a/rdfloader/parser2v2/parse_annotation.go
+++ b/rdfloader/parser2v2/parse_annotation.go
@@ -5,7 +5,7 @@ package parser2v2
 import (
 	"errors"
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"github.com/spdx/tools-golang/spdx"
 )
 

--- a/rdfloader/parser2v2/parse_creation_info.go
+++ b/rdfloader/parser2v2/parse_creation_info.go
@@ -4,7 +4,7 @@ package parser2v2
 
 import (
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"github.com/spdx/tools-golang/spdx"
 )
 

--- a/rdfloader/parser2v2/parse_file.go
+++ b/rdfloader/parser2v2/parse_file.go
@@ -4,7 +4,7 @@ package parser2v2
 
 import (
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"github.com/spdx/tools-golang/spdx"
 	"strings"
 )

--- a/rdfloader/parser2v2/parse_file_test.go
+++ b/rdfloader/parser2v2/parse_file_test.go
@@ -2,9 +2,9 @@ package parser2v2
 
 import (
 	"bufio"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
-	rdfloader2 "github.com/RishabhBhatnagar/gordf/rdfloader/xmlreader"
-	gordfWriter "github.com/RishabhBhatnagar/gordf/rdfwriter"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
+	rdfloader2 "github.com/spdx/gordf/rdfloader/xmlreader"
+	gordfWriter "github.com/spdx/gordf/rdfwriter"
 	"github.com/spdx/tools-golang/spdx"
 	"strings"
 	"testing"

--- a/rdfloader/parser2v2/parse_license.go
+++ b/rdfloader/parser2v2/parse_license.go
@@ -4,8 +4,8 @@ package parser2v2
 
 import (
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
-	"github.com/RishabhBhatnagar/gordf/rdfwriter"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
+	"github.com/spdx/gordf/rdfwriter"
 	"strings"
 )
 

--- a/rdfloader/parser2v2/parse_license_test.go
+++ b/rdfloader/parser2v2/parse_license_test.go
@@ -1,7 +1,7 @@
 package parser2v2
 
 import (
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"reflect"
 	"sort"
 	"testing"

--- a/rdfloader/parser2v2/parse_other_license_info.go
+++ b/rdfloader/parser2v2/parse_other_license_info.go
@@ -4,8 +4,8 @@ package parser2v2
 
 import (
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
-	"github.com/RishabhBhatnagar/gordf/rdfwriter"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
+	"github.com/spdx/gordf/rdfwriter"
 	"github.com/spdx/tools-golang/spdx"
 )
 

--- a/rdfloader/parser2v2/parse_other_license_info_test.go
+++ b/rdfloader/parser2v2/parse_other_license_info_test.go
@@ -1,7 +1,7 @@
 package parser2v2
 
 import (
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"reflect"
 	"testing"
 )

--- a/rdfloader/parser2v2/parse_package.go
+++ b/rdfloader/parser2v2/parse_package.go
@@ -4,7 +4,7 @@ package parser2v2
 
 import (
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"github.com/spdx/tools-golang/spdx"
 	"strings"
 )

--- a/rdfloader/parser2v2/parse_package_test.go
+++ b/rdfloader/parser2v2/parse_package_test.go
@@ -1,7 +1,7 @@
 package parser2v2
 
 import (
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"github.com/spdx/tools-golang/spdx"
 	"reflect"
 	"testing"

--- a/rdfloader/parser2v2/parse_relationship.go
+++ b/rdfloader/parser2v2/parse_relationship.go
@@ -4,8 +4,8 @@ package parser2v2
 
 import (
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
-	"github.com/RishabhBhatnagar/gordf/rdfwriter"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
+	"github.com/spdx/gordf/rdfwriter"
 	"github.com/spdx/tools-golang/spdx"
 	"strings"
 )

--- a/rdfloader/parser2v2/parse_relationship_test.go
+++ b/rdfloader/parser2v2/parse_relationship_test.go
@@ -1,7 +1,7 @@
 package parser2v2
 
 import (
-	"github.com/RishabhBhatnagar/gordf/rdfwriter"
+	"github.com/spdx/gordf/rdfwriter"
 	"github.com/spdx/tools-golang/spdx"
 	"reflect"
 	"testing"

--- a/rdfloader/parser2v2/parse_review.go
+++ b/rdfloader/parser2v2/parse_review.go
@@ -4,7 +4,7 @@ package parser2v2
 
 import (
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"github.com/spdx/tools-golang/spdx"
 )
 

--- a/rdfloader/parser2v2/parse_snippet_info.go
+++ b/rdfloader/parser2v2/parse_snippet_info.go
@@ -4,8 +4,8 @@ package parser2v2
 
 import (
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
-	"github.com/RishabhBhatnagar/gordf/rdfwriter"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
+	"github.com/spdx/gordf/rdfwriter"
 	"github.com/spdx/tools-golang/spdx"
 	"strconv"
 )

--- a/rdfloader/parser2v2/parse_snippet_info_test.go
+++ b/rdfloader/parser2v2/parse_snippet_info_test.go
@@ -1,7 +1,7 @@
 package parser2v2
 
 import (
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"github.com/spdx/tools-golang/spdx"
 	"testing"
 )

--- a/rdfloader/parser2v2/parse_spdx_document.go
+++ b/rdfloader/parser2v2/parse_spdx_document.go
@@ -4,7 +4,7 @@ package parser2v2
 
 import (
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"github.com/spdx/tools-golang/spdx"
 )
 

--- a/rdfloader/parser2v2/parse_spdx_document_test.go
+++ b/rdfloader/parser2v2/parse_spdx_document_test.go
@@ -1,7 +1,7 @@
 package parser2v2
 
 import (
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"testing"
 )
 

--- a/rdfloader/parser2v2/parser.go
+++ b/rdfloader/parser2v2/parser.go
@@ -5,8 +5,8 @@ package parser2v2
 import (
 	"errors"
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
-	gordfWriter "github.com/RishabhBhatnagar/gordf/rdfwriter"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
+	gordfWriter "github.com/spdx/gordf/rdfwriter"
 	"github.com/spdx/tools-golang/spdx"
 )
 

--- a/rdfloader/parser2v2/parser.go
+++ b/rdfloader/parser2v2/parser.go
@@ -16,7 +16,9 @@ func NewParser2_2(gordfParserObj *gordfParser.Parser, nodeToTriples map[string][
 		gordfParserObj:      gordfParserObj,
 		nodeStringToTriples: nodeToTriples,
 		doc: &spdx.Document2_2{
-			CreationInfo:    &spdx.CreationInfo2_2{},
+			CreationInfo: &spdx.CreationInfo2_2{
+				ExternalDocumentReferences: map[string]spdx.ExternalDocumentRef2_2{},
+			},
 			Packages:        map[spdx.ElementID]*spdx.Package2_2{},
 			UnpackagedFiles: map[spdx.ElementID]*spdx.File2_2{},
 			OtherLicenses:   []*spdx.OtherLicense2_2{},

--- a/rdfloader/parser2v2/types.go
+++ b/rdfloader/parser2v2/types.go
@@ -3,7 +3,7 @@
 package parser2v2
 
 import (
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"github.com/spdx/tools-golang/spdx"
 )
 

--- a/rdfloader/parser2v2/utils.go
+++ b/rdfloader/parser2v2/utils.go
@@ -3,9 +3,9 @@ package parser2v2
 import (
 	"errors"
 	"fmt"
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
-	"github.com/RishabhBhatnagar/gordf/rdfwriter"
-	urilib "github.com/RishabhBhatnagar/gordf/uri"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
+	"github.com/spdx/gordf/rdfwriter"
+	urilib "github.com/spdx/gordf/uri"
 	"github.com/spdx/tools-golang/spdx"
 	"strings"
 )

--- a/rdfloader/parser2v2/utils_test.go
+++ b/rdfloader/parser2v2/utils_test.go
@@ -1,7 +1,7 @@
 package parser2v2
 
 import (
-	gordfParser "github.com/RishabhBhatnagar/gordf/rdfloader/parser"
+	gordfParser "github.com/spdx/gordf/rdfloader/parser"
 	"github.com/spdx/tools-golang/spdx"
 	"reflect"
 	"testing"

--- a/rdfloader/rdfloader.go
+++ b/rdfloader/rdfloader.go
@@ -1,7 +1,7 @@
 package rdfloader
 
 import (
-	"github.com/RishabhBhatnagar/gordf/rdfloader"
+	"github.com/spdx/gordf/rdfloader"
 	"github.com/spdx/tools-golang/rdfloader/parser2v2"
 	"github.com/spdx/tools-golang/spdx"
 	"io"

--- a/spdx/creation_info.go
+++ b/spdx/creation_info.go
@@ -28,7 +28,7 @@ type CreationInfo2_1 struct {
 
 	// 2.6: External Document References
 	// Cardinality: optional, one or many
-	ExternalDocumentReferences []string
+	ExternalDocumentReferences map[string]ExternalDocumentRef2_1
 
 	// 2.7: License List Version
 	// Cardinality: optional, one
@@ -52,6 +52,25 @@ type CreationInfo2_1 struct {
 	// 2.11: Document Comment
 	// Cardinality: optional, one
 	DocumentComment string
+}
+
+// ExternalDocumentRef2_1 is a reference to an external SPDX document
+// as defined in section 2.6 for version 2.1 of the spec.
+type ExternalDocumentRef2_1 struct {
+
+	// DocumentRefID is the ID string defined in the start of the
+	// reference. It should _not_ contain the "DocumentRef-" part
+	// of the mandatory ID string.
+	DocumentRefID string
+
+	// URI is the URI defined for the external document
+	URI string
+
+	// Alg is the type of hash algorithm used, e.g. "SHA1", "SHA256"
+	Alg string
+
+	// Checksum is the actual hash data
+	Checksum string
 }
 
 // CreationInfo2_2 is a Document Creation Information section of an
@@ -80,7 +99,7 @@ type CreationInfo2_2 struct {
 
 	// 2.6: External Document References
 	// Cardinality: optional, one or many
-	ExternalDocumentReferences []string
+	ExternalDocumentReferences map[string]ExternalDocumentRef2_2
 
 	// 2.7: License List Version
 	// Cardinality: optional, one
@@ -104,4 +123,23 @@ type CreationInfo2_2 struct {
 	// 2.11: Document Comment
 	// Cardinality: optional, one
 	DocumentComment string
+}
+
+// ExternalDocumentRef2_2 is a reference to an external SPDX document
+// as defined in section 2.6 for version 2.2 of the spec.
+type ExternalDocumentRef2_2 struct {
+
+	// DocumentRefID is the ID string defined in the start of the
+	// reference. It should _not_ contain the "DocumentRef-" part
+	// of the mandatory ID string.
+	DocumentRefID string
+
+	// URI is the URI defined for the external document
+	URI string
+
+	// Alg is the type of hash algorithm used, e.g. "SHA1", "SHA256"
+	Alg string
+
+	// Checksum is the actual hash data
+	Checksum string
 }

--- a/tvloader/parser2v1/parse_creation_info.go
+++ b/tvloader/parser2v1/parse_creation_info.go
@@ -4,6 +4,7 @@ package parser2v1
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spdx/tools-golang/spdx"
 )
@@ -16,7 +17,9 @@ func (parser *tvParser2_1) parsePairFromCreationInfo2_1(tag string, value string
 
 	// create an SPDX Creation Info data struct if we don't have one already
 	if parser.doc.CreationInfo == nil {
-		parser.doc.CreationInfo = &spdx.CreationInfo2_1{}
+		parser.doc.CreationInfo = &spdx.CreationInfo2_1{
+			ExternalDocumentReferences: map[string]spdx.ExternalDocumentRef2_1{},
+		}
 	}
 
 	ci := parser.doc.CreationInfo
@@ -32,7 +35,17 @@ func (parser *tvParser2_1) parsePairFromCreationInfo2_1(tag string, value string
 	case "DocumentNamespace":
 		ci.DocumentNamespace = value
 	case "ExternalDocumentRef":
-		ci.ExternalDocumentReferences = append(ci.ExternalDocumentReferences, value)
+		documentRefID, uri, alg, checksum, err := extractExternalDocumentReference(value)
+		if err != nil {
+			return err
+		}
+		edr := spdx.ExternalDocumentRef2_1{
+			DocumentRefID: documentRefID,
+			URI:           uri,
+			Alg:           alg,
+			Checksum:      checksum,
+		}
+		ci.ExternalDocumentReferences[documentRefID] = edr
 	case "LicenseListVersion":
 		ci.LicenseListVersion = value
 	case "Creator":
@@ -104,4 +117,58 @@ func (parser *tvParser2_1) parsePairFromCreationInfo2_1(tag string, value string
 	}
 
 	return nil
+}
+
+// ===== Helper functions =====
+
+func extractExternalDocumentReference(value string) (string, string, string, string, error) {
+	sp := strings.Split(value, " ")
+	// remove any that are just whitespace
+	keepSp := []string{}
+	for _, s := range sp {
+		ss := strings.TrimSpace(s)
+		if ss != "" {
+			keepSp = append(keepSp, ss)
+		}
+	}
+
+	var documentRefID, uri, alg, checksum string
+
+	// now, should have 4 items (or 3, if Alg and Checksum were joined)
+	// and should be able to map them
+	if len(keepSp) == 4 {
+		documentRefID = keepSp[0]
+		uri = keepSp[1]
+		alg = keepSp[2]
+		// check that colon is present for alg, and remove it
+		if !strings.HasSuffix(alg, ":") {
+			return "", "", "", "", fmt.Errorf("algorithm does not end with colon")
+		}
+		alg = strings.TrimSuffix(alg, ":")
+		checksum = keepSp[3]
+	} else if len(keepSp) == 3 {
+		documentRefID = keepSp[0]
+		uri = keepSp[1]
+		// split on colon into alg and checksum
+		parts := strings.SplitN(keepSp[2], ":", 2)
+		if len(parts) != 2 {
+			return "", "", "", "", fmt.Errorf("missing colon separator between algorithm and checksum")
+		}
+		alg = parts[0]
+		checksum = parts[1]
+	} else {
+		return "", "", "", "", fmt.Errorf("expected 4 elements, got %d", len(keepSp))
+	}
+
+	// additionally, we should be able to parse the first element as a
+	// DocumentRef- ID string, and we should remove that prefix
+	if !strings.HasPrefix(documentRefID, "DocumentRef-") {
+		return "", "", "", "", fmt.Errorf("expected first element to have DocumentRef- prefix")
+	}
+	documentRefID = strings.TrimPrefix(documentRefID, "DocumentRef-")
+	if documentRefID == "" {
+		return "", "", "", "", fmt.Errorf("document identifier has nothing after prefix")
+	}
+
+	return documentRefID, uri, alg, checksum, nil
 }

--- a/tvloader/parser2v2/parse_creation_info_test.go
+++ b/tvloader/parser2v2/parse_creation_info_test.go
@@ -242,7 +242,19 @@ func TestParser2_2CanParseCreationInfoTags(t *testing.T) {
 	// External Document Reference
 	refs := []string{
 		"DocumentRef-spdx-tool-1.2 http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301 SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759",
-		"DocumentRef-xyz-2.1.2 http://example.com/xyz-2.1.2 SHA1: d6a770ba38583ed4bb4525bd96e50461655d2760",
+		"DocumentRef-xyz-2.1.2 http://example.com/xyz-2.1.2 SHA1:d6a770ba38583ed4bb4525bd96e50461655d2760",
+	}
+	wantRef0 := spdx.ExternalDocumentRef2_2{
+		DocumentRefID: "spdx-tool-1.2",
+		URI:           "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301",
+		Alg:           "SHA1",
+		Checksum:      "d6a770ba38583ed4bb4525bd96e50461655d2759",
+	}
+	wantRef1 := spdx.ExternalDocumentRef2_2{
+		DocumentRefID: "xyz-2.1.2",
+		URI:           "http://example.com/xyz-2.1.2",
+		Alg:           "SHA1",
+		Checksum:      "d6a770ba38583ed4bb4525bd96e50461655d2760",
 	}
 	err = parser.parsePairFromCreationInfo2_2("ExternalDocumentRef", refs[0])
 	if err != nil {
@@ -252,10 +264,22 @@ func TestParser2_2CanParseCreationInfoTags(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
-	if len(parser.doc.CreationInfo.ExternalDocumentReferences) != 2 ||
-		parser.doc.CreationInfo.ExternalDocumentReferences[0] != refs[0] ||
-		parser.doc.CreationInfo.ExternalDocumentReferences[1] != refs[1] {
-		t.Errorf("got %v for ExternalDocumentReferences", parser.doc.CreationInfo.ExternalDocumentReferences)
+	if len(parser.doc.CreationInfo.ExternalDocumentReferences) != 2 {
+		t.Errorf("got %d ExternalDocumentReferences, expected %d", len(parser.doc.CreationInfo.ExternalDocumentReferences), 2)
+	}
+	gotRef0 := parser.doc.CreationInfo.ExternalDocumentReferences["spdx-tool-1.2"]
+	if gotRef0.DocumentRefID != wantRef0.DocumentRefID ||
+		gotRef0.URI != wantRef0.URI ||
+		gotRef0.Alg != wantRef0.Alg ||
+		gotRef0.Checksum != wantRef0.Checksum {
+		t.Errorf("got %#v for ExternalDocumentReferences[0], wanted %#v", gotRef0, wantRef0)
+	}
+	gotRef1 := parser.doc.CreationInfo.ExternalDocumentReferences["xyz-2.1.2"]
+	if gotRef1.DocumentRefID != wantRef1.DocumentRefID ||
+		gotRef1.URI != wantRef1.URI ||
+		gotRef1.Alg != wantRef1.Alg ||
+		gotRef1.Checksum != wantRef1.Checksum {
+		t.Errorf("got %#v for ExternalDocumentReferences[1], wanted %#v", gotRef1, wantRef1)
 	}
 
 	// License List Version
@@ -427,5 +451,75 @@ func TestParser2_2CICreatesAnnotation(t *testing.T) {
 	}
 	if parser.ann != parser.doc.Annotations[0] {
 		t.Errorf("pointer to new Annotation doesn't match idx 0 for doc.Annotations[]")
+	}
+}
+
+// ===== Helper function tests =====
+
+func TestCanExtractExternalDocumentReference(t *testing.T) {
+	refstring := "DocumentRef-spdx-tool-1.2 http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301 SHA1:d6a770ba38583ed4bb4525bd96e50461655d2759"
+	wantDocumentRefID := "spdx-tool-1.2"
+	wantURI := "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+	wantAlg := "SHA1"
+	wantChecksum := "d6a770ba38583ed4bb4525bd96e50461655d2759"
+
+	gotDocumentRefID, gotURI, gotAlg, gotChecksum, err := extractExternalDocumentReference(refstring)
+	if err != nil {
+		t.Errorf("got non-nil error: %v", err)
+	}
+	if wantDocumentRefID != gotDocumentRefID {
+		t.Errorf("wanted document ref ID %s, got %s", wantDocumentRefID, gotDocumentRefID)
+	}
+	if wantURI != gotURI {
+		t.Errorf("wanted URI %s, got %s", wantURI, gotURI)
+	}
+	if wantAlg != gotAlg {
+		t.Errorf("wanted alg %s, got %s", wantAlg, gotAlg)
+	}
+	if wantChecksum != gotChecksum {
+		t.Errorf("wanted checksum %s, got %s", wantChecksum, gotChecksum)
+	}
+}
+
+func TestCanExtractExternalDocumentReferenceWithExtraWhitespace(t *testing.T) {
+	refstring := "   DocumentRef-spdx-tool-1.2    \t http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301 \t SHA1:  \t   d6a770ba38583ed4bb4525bd96e50461655d2759"
+	wantDocumentRefID := "spdx-tool-1.2"
+	wantURI := "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+	wantAlg := "SHA1"
+	wantChecksum := "d6a770ba38583ed4bb4525bd96e50461655d2759"
+
+	gotDocumentRefID, gotURI, gotAlg, gotChecksum, err := extractExternalDocumentReference(refstring)
+	if err != nil {
+		t.Errorf("got non-nil error: %v", err)
+	}
+	if wantDocumentRefID != gotDocumentRefID {
+		t.Errorf("wanted document ref ID %s, got %s", wantDocumentRefID, gotDocumentRefID)
+	}
+	if wantURI != gotURI {
+		t.Errorf("wanted URI %s, got %s", wantURI, gotURI)
+	}
+	if wantAlg != gotAlg {
+		t.Errorf("wanted alg %s, got %s", wantAlg, gotAlg)
+	}
+	if wantChecksum != gotChecksum {
+		t.Errorf("wanted checksum %s, got %s", wantChecksum, gotChecksum)
+	}
+}
+
+func TestFailsExternalDocumentReferenceWithInvalidFormats(t *testing.T) {
+	invalidRefs := []string{
+		"whoops",
+		"DocumentRef-",
+		"DocumentRef-   ",
+		"DocumentRef-spdx-tool-1.2 http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301",
+		"DocumentRef-spdx-tool-1.2 http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301 d6a770ba38583ed4bb4525bd96e50461655d2759",
+		"DocumentRef-spdx-tool-1.2",
+		"spdx-tool-1.2 http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301 SHA1:d6a770ba38583ed4bb4525bd96e50461655d2759",
+	}
+	for _, refstring := range invalidRefs {
+		_, _, _, _, err := extractExternalDocumentReference(refstring)
+		if err == nil {
+			t.Errorf("expected non-nil error for %s, got nil", refstring)
+		}
 	}
 }

--- a/tvsaver/saver2v1/save_creation_info.go
+++ b/tvsaver/saver2v1/save_creation_info.go
@@ -5,6 +5,7 @@ package saver2v1
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/spdx/tools-golang/spdx"
 )
@@ -25,8 +26,16 @@ func renderCreationInfo2_1(ci *spdx.CreationInfo2_1, w io.Writer) error {
 	if ci.DocumentNamespace != "" {
 		fmt.Fprintf(w, "DocumentNamespace: %s\n", ci.DocumentNamespace)
 	}
-	for _, s := range ci.ExternalDocumentReferences {
-		fmt.Fprintf(w, "ExternalDocumentRef: %s\n", s)
+	// print EDRs in order sorted by identifier
+	edrIDs := []string{}
+	for docRefID := range ci.ExternalDocumentReferences {
+		edrIDs = append(edrIDs, docRefID)
+	}
+	sort.Strings(edrIDs)
+	for _, edrID := range edrIDs {
+		edr := ci.ExternalDocumentReferences[edrID]
+		fmt.Fprintf(w, "ExternalDocumentRef: DocumentRef-%s %s %s:%s\n",
+			edr.DocumentRefID, edr.URI, edr.Alg, edr.Checksum)
 	}
 	if ci.LicenseListVersion != "" {
 		fmt.Fprintf(w, "LicenseListVersion: %s\n", ci.LicenseListVersion)

--- a/tvsaver/saver2v1/save_creation_info_test.go
+++ b/tvsaver/saver2v1/save_creation_info_test.go
@@ -17,9 +17,19 @@ func TestSaver2_1CISavesText(t *testing.T) {
 		SPDXIdentifier:    spdx.ElementID("DOCUMENT"),
 		DocumentName:      "spdx-go-0.0.1.abcdef",
 		DocumentNamespace: "https://github.com/swinslow/spdx-docs/spdx-go/spdx-go-0.0.1.abcdef.whatever",
-		ExternalDocumentReferences: []string{
-			"DocumentRef-spdx-go-0.0.1a https://github.com/swinslow/spdx-docs/spdx-go/spdx-go-0.0.1a.cdefab.whatever SHA1:0123456701234567012345670123456701234567",
-			"DocumentRef-time-1.2.3 https://github.com/swinslow/spdx-docs/time/time-1.2.3.cdefab.whatever SHA1:0123456701234567012345670123456701234568",
+		ExternalDocumentReferences: map[string]spdx.ExternalDocumentRef2_1{
+			"spdx-go-0.0.1a": spdx.ExternalDocumentRef2_1{
+				DocumentRefID: "spdx-go-0.0.1a",
+				URI:           "https://github.com/swinslow/spdx-docs/spdx-go/spdx-go-0.0.1a.cdefab.whatever",
+				Alg:           "SHA1",
+				Checksum:      "0123456701234567012345670123456701234567",
+			},
+			"time-1.2.3": spdx.ExternalDocumentRef2_1{
+				DocumentRefID: "time-1.2.3",
+				URI:           "https://github.com/swinslow/spdx-docs/time/time-1.2.3.cdefab.whatever",
+				Alg:           "SHA1",
+				Checksum:      "0123456701234567012345670123456701234568",
+			},
 		},
 		LicenseListVersion: "2.0",
 		CreatorPersons: []string{

--- a/tvsaver/saver2v2/save_creation_info.go
+++ b/tvsaver/saver2v2/save_creation_info.go
@@ -5,6 +5,7 @@ package saver2v2
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/spdx/tools-golang/spdx"
 )
@@ -25,8 +26,16 @@ func renderCreationInfo2_2(ci *spdx.CreationInfo2_2, w io.Writer) error {
 	if ci.DocumentNamespace != "" {
 		fmt.Fprintf(w, "DocumentNamespace: %s\n", ci.DocumentNamespace)
 	}
-	for _, s := range ci.ExternalDocumentReferences {
-		fmt.Fprintf(w, "ExternalDocumentRef: %s\n", s)
+	// print EDRs in order sorted by identifier
+	edrIDs := []string{}
+	for docRefID := range ci.ExternalDocumentReferences {
+		edrIDs = append(edrIDs, docRefID)
+	}
+	sort.Strings(edrIDs)
+	for _, edrID := range edrIDs {
+		edr := ci.ExternalDocumentReferences[edrID]
+		fmt.Fprintf(w, "ExternalDocumentRef: DocumentRef-%s %s %s:%s\n",
+			edr.DocumentRefID, edr.URI, edr.Alg, edr.Checksum)
 	}
 	if ci.LicenseListVersion != "" {
 		fmt.Fprintf(w, "LicenseListVersion: %s\n", ci.LicenseListVersion)

--- a/tvsaver/saver2v2/save_creation_info_test.go
+++ b/tvsaver/saver2v2/save_creation_info_test.go
@@ -17,9 +17,19 @@ func TestSaver2_2CISavesText(t *testing.T) {
 		SPDXIdentifier:    spdx.ElementID("DOCUMENT"),
 		DocumentName:      "spdx-go-0.0.1.abcdef",
 		DocumentNamespace: "https://github.com/swinslow/spdx-docs/spdx-go/spdx-go-0.0.1.abcdef.whatever",
-		ExternalDocumentReferences: []string{
-			"DocumentRef-spdx-go-0.0.1a https://github.com/swinslow/spdx-docs/spdx-go/spdx-go-0.0.1a.cdefab.whatever SHA1:0123456701234567012345670123456701234567",
-			"DocumentRef-time-1.2.3 https://github.com/swinslow/spdx-docs/time/time-1.2.3.cdefab.whatever SHA1:0123456701234567012345670123456701234568",
+		ExternalDocumentReferences: map[string]spdx.ExternalDocumentRef2_2{
+			"spdx-go-0.0.1a": spdx.ExternalDocumentRef2_2{
+				DocumentRefID: "spdx-go-0.0.1a",
+				URI:           "https://github.com/swinslow/spdx-docs/spdx-go/spdx-go-0.0.1a.cdefab.whatever",
+				Alg:           "SHA1",
+				Checksum:      "0123456701234567012345670123456701234567",
+			},
+			"time-1.2.3": spdx.ExternalDocumentRef2_2{
+				DocumentRefID: "time-1.2.3",
+				URI:           "https://github.com/swinslow/spdx-docs/time/time-1.2.3.cdefab.whatever",
+				Alg:           "SHA1",
+				Checksum:      "0123456701234567012345670123456701234568",
+			},
 		},
 		LicenseListVersion: "3.9",
 		CreatorPersons: []string{


### PR DESCRIPTION
 - RdfLoader now uses ExternalDocumentReference struct as added in #44 .
 - The library path is updated as the gordf repository has been transferred from `github.com/RishabhBhatnagar/gordf` to `github.com/spdx/gordf` .