### PR TITLE
Enable Caching And Parse Cyclic Dependent Objects

### DIFF
--- a/rdfloader/parser2v2/parse_file_test.go
+++ b/rdfloader/parser2v2/parse_file_test.go
@@ -494,6 +494,25 @@ func Test_rdfParser2_2_getFileFromNode(t *testing.T) {
 		t.Errorf("expected %s, found %s", expectedLicenseInfoInFile, file.LicenseInfoInFile[0])
 	}
 
+
+	// TestCase 12: checking if recursive dependencies are resolved.
+	parser, _ = parserFromBodyContent(`
+		<spdx:File rdf:about="#SPDXRef-ParentFile">
+			<spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+			<spdx:fileDependency>
+				<spdx:File rdf:about="#SPDXRef-ChildFile">
+					<spdx:fileDependency>
+						<spdx:File rdf:about="#SPDXRef-ParentFile">
+							<spdx:fileName>ParentFile</spdx:fileName>
+						</spdx:File>
+					</spdx:fileDependency>
+				</spdx:File>
+			</spdx:fileDependency>
+		</spdx:File>
+	`)
+	fileNode = gordfWriter.FilterTriples(parser.gordfParserObj.Triples, nil, &RDF_TYPE, &SPDX_FILE)[0].Subject
+	file, err = parser.getFileFromNode(fileNode)
+
 	// TestCase 11: all valid attribute and it's values.
 	parser, _ = parserFromBodyContent(`
 		<spdx:File rdf:about="http://anupam-VirtualBox/repo/SPDX2_time-1.9.tar.gz_1535120734-spdx.rdf#SPDXRef-item177">

--- a/rdfloader/parser2v2/parse_license_test.go
+++ b/rdfloader/parser2v2/parse_license_test.go
@@ -196,6 +196,24 @@ func Test_rdfParser2_2_getAnyLicenseFromNode(t *testing.T) {
 	if err == nil {
 		t.Errorf("should've raised an error for invalid input")
 	}
+
+	// TestCase 8: cyclic dependent license must raise an error.
+	parser, _ = parserFromBodyContent(`
+		<spdx:ConjunctiveLicenseSet rdf:about="#SPDXRef-RecursiveLicense">
+			<spdx:member rdf:resource="http://spdx.org/licenses/GPL-2.0-or-later"/>
+			<spdx:member>
+				<spdx:ConjunctiveLicenseSet rdf:about="#SPDXRef-RecursiveLicense">
+					<spdx:member rdf:resource="http://spdx.org/licenses/LGPL-2.0"/>
+					<spdx:member rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-RecursiveLicense"/>
+				</spdx:ConjunctiveLicenseSet>
+			</spdx:member>
+		</spdx:ConjunctiveLicenseSet>
+	`)
+	node = parser.gordfParserObj.Triples[0].Subject
+	_, err = parser.getAnyLicenseFromNode(node)
+	if err == nil {
+		t.Errorf("expected an error due to cyclic dependent license. found %v", err)
+	}
 }
 
 func Test_rdfParser2_2_getConjunctiveLicenseSetFromNode(t *testing.T) {

--- a/rdfloader/parser2v2/parse_package_test.go
+++ b/rdfloader/parser2v2/parse_package_test.go
@@ -459,7 +459,39 @@ func Test_rdfParser2_2_getPackageFromNode(t *testing.T) {
 		t.Errorf("expected package name: %s, got %s", expectedPkgFileName, pkg.PackageName)
 	}
 
-	// TestCase 8: everything valid
+	// TestCase 8: Checking if packages can handle cyclic dependencies:
+	// Simulating a smallest possible cycle: package related to itself.
+	parser, _ = parserFromBodyContent(`
+		<spdx:Package rdf:about="http://anupam-VirtualBox/repo/SPDX2_time-1.9#SPDXRef-upload2">
+			<spdx:name>Test Package</spdx:name>
+			<spdx:relationship>
+			    <spdx:Relationship>
+					<spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes" />
+					<spdx:relatedSpdxElement>
+						<spdx:Package rdf:about="http://anupam-VirtualBox/repo/SPDX2_time-1.9#SPDXRef-upload2">
+							<spdx:versionInfo>1.1.1</spdx:versionInfo>
+						</spdx:Package>
+					</spdx:relatedSpdxElement>
+				</spdx:Relationship>
+			</spdx:relationship>
+		</spdx:Package>
+	`)
+	node = parser.gordfParserObj.Triples[0].Subject
+	pkg, err = parser.getPackageFromNode(node)
+	if err != nil {
+		t.Errorf("error parsing a valid package: %v", err)
+	}
+	// checking if both the attributes of the packages are set.
+	expectedVersionInfo := "1.1.1"
+	expectedPackageName := "Test Package"
+	if pkg.PackageVersion != expectedVersionInfo {
+		t.Errorf("Expected %s, found %s", expectedVersionInfo, pkg.PackageVersion)
+	}
+	if pkg.PackageName != expectedPackageName {
+		t.Errorf("Expected %s, found %s", expectedPackageName, pkg.PackageName)
+	}
+
+	// TestCase 9: everything valid
 	parser, _ = parserFromBodyContent(`
 		<spdx:Package rdf:about="http://anupam-VirtualBox/repo/SPDX2_time-1.9#SPDXRef-upload2">
 			<spdx:name>Test Package</spdx:name>

--- a/rdfloader/parser2v2/parse_relationship.go
+++ b/rdfloader/parser2v2/parse_relationship.go
@@ -22,6 +22,26 @@ func (parser *rdfParser2_2) parseRelationship(triple *gordfParser.Triple) (err e
 		return err
 	}
 
+	currState := parser.cache[triple.Object.ID]
+	if currState == nil {
+		// there is no entry about the state of current package node.
+		// this is the first time we're seeing this node.
+		parser.cache[triple.Object.ID] = &nodeState{
+			object: reln,
+			Color:  WHITE,
+		}
+	} else if currState.Color == GREY {
+		// we have already started parsing this relationship node and we needn't parse it again.
+		return nil
+	}
+
+	// setting color of the state to grey to indicate that we've started to
+	// parse this node once.
+	parser.cache[triple.Object.ID].Color = GREY
+
+	// setting state color to black to indicate when we're done parsing this node.
+	defer func(){parser.cache[triple.Object.ID].Color = BLACK}();
+
 	for _, subTriple := range parser.nodeToTriples(triple.Object) {
 		switch subTriple.Predicate.ID {
 		case SPDX_RELATIONSHIP_TYPE:

--- a/rdfloader/parser2v2/parse_relationship_test.go
+++ b/rdfloader/parser2v2/parse_relationship_test.go
@@ -320,7 +320,33 @@ func Test_rdfParser2_2_parseRelationship(t *testing.T) {
 		t.Errorf("should've raised an error due to unknown predicate in a relationship")
 	}
 
-	// TestCase 6: completely valid example:
+	// TestCase 8: Recursive relationships mustn't raise any error:
+	parser, _ = parserFromBodyContent(`
+		<spdx:File rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File">
+			<spdx:relationship>
+				<spdx:Relationship rdf:about="#SPDXRef-reln">
+					<spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+					<spdx:relatedSpdxElement>
+						<spdx:Package rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Saxon">
+							<spdx:relationship>
+								<spdx:Relationship rdf:about="#SPDXRef-reln">
+									<spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+									<spdx:relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File"/>
+								</spdx:Relationship>
+							</spdx:relationship>
+						</spdx:Package>
+					</spdx:relatedSpdxElement>
+				</spdx:Relationship>
+			</spdx:relationship>
+		</spdx:File>
+	`)
+	triple = rdfwriter.FilterTriples(parser.gordfParserObj.Triples, nil, &SPDX_RELATIONSHIP, nil)[0]
+	err = parser.parseRelationship(triple)
+	if err != nil {
+		t.Errorf("error parsing a valid example")
+	}
+
+	// TestCase 7: completely valid example:
 	parser, _ = parserFromBodyContent(`
 		<spdx:File rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File">
 			<spdx:relationship>

--- a/rdfloader/parser2v2/parser.go
+++ b/rdfloader/parser2v2/parser.go
@@ -28,6 +28,7 @@ func NewParser2_2(gordfParserObj *gordfParser.Parser, nodeToTriples map[string][
 		},
 		files:            map[spdx.ElementID]*spdx.File2_2{},
 		assocWithPackage: map[spdx.ElementID]bool{},
+		cache: map[string]*nodeState{},
 	}
 	return &parser
 }

--- a/rdfloader/parser2v2/types.go
+++ b/rdfloader/parser2v2/types.go
@@ -21,7 +21,22 @@ type rdfParser2_2 struct {
 	assocWithPackage map[spdx.ElementID]bool
 
 	// mapping of nodeStrings to parsed object to save double computation.
-	cache map[string]interface{}
+	cache map[string]*nodeState
+}
+
+type Color int
+
+const (
+	GREY Color = iota // represents that the node is being visited
+	WHITE             // unvisited node
+	BLACK             // visited node
+)
+
+type nodeState struct {
+	// object will be pointer to the parsed or element being parsed.
+	object interface{}
+	// color of a state represents if the node is visited/unvisited/being-visited.
+	Color  Color
 }
 
 type AnyLicenseInfo interface {


### PR DESCRIPTION
 - File, Package, Relationship can have cyclic dependent objects.
 - Cyclic dependent License will raise an error.
 - Double computation for File, Package, Relationship, and License is enabled.

This fixes #55 and attempts to fix #51.

@swinslow, this time, I've personally checked if the parsed document has all the bits from the [canonical sample SPDX RDF file](https://github.com/spdx/spdx-spec/blob/development/v2.2.1/examples/SPDXRdfExample-v2.2.spdx.rdf.xml).
Please let me know if there are still any missing elements in the parsed document.

Also, please feel free to try it out using other documents as well. 

Signed-off-by: Rishabh Bhatnagar <bhatnagarrishabh4@gmail.com>