### PR TITLE
Fix for wrapping multiline snippet copyright in tvsaver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 .vscode
+.idea
 .DS_Store
 scratch/*
 *.swp

--- a/tvsaver/saver2v1/save_snippet.go
+++ b/tvsaver/saver2v1/save_snippet.go
@@ -33,7 +33,7 @@ func renderSnippet2_1(sn *spdx.Snippet2_1, w io.Writer) error {
 		fmt.Fprintf(w, "SnippetLicenseComments: %s\n", textify(sn.SnippetLicenseComments))
 	}
 	if sn.SnippetCopyrightText != "" {
-		fmt.Fprintf(w, "SnippetCopyrightText: %s\n", sn.SnippetCopyrightText)
+		fmt.Fprintf(w, "SnippetCopyrightText: %s\n", textify(sn.SnippetCopyrightText))
 	}
 	if sn.SnippetComment != "" {
 		fmt.Fprintf(w, "SnippetComment: %s\n", textify(sn.SnippetComment))

--- a/tvsaver/saver2v1/save_snippet_test.go
+++ b/tvsaver/saver2v1/save_snippet_test.go
@@ -90,3 +90,38 @@ SnippetCopyrightText: Copyright (c) John Doe 20x6
 		t.Errorf("Expected %v, got %v", want.String(), got.String())
 	}
 }
+
+func TestSaver2_1SnippetWrapsCopyrightMultiline(t *testing.T) {
+	sn := &spdx.Snippet2_1{
+		SnippetSPDXIdentifier:         spdx.ElementID("Snippet17"),
+		SnippetFromFileSPDXIdentifier: spdx.MakeDocElementID("", "File292"),
+		SnippetByteRangeStart:         17,
+		SnippetByteRangeEnd:           209,
+		SnippetLicenseConcluded:       "GPL-2.0-or-later",
+		SnippetCopyrightText:          `Copyright (c) John Doe 20x6
+Copyright (c) John Doe 20x6`,
+	}
+
+	// what we want to get, as a buffer of bytes
+	want := bytes.NewBufferString(`SnippetSPDXIdentifier: SPDXRef-Snippet17
+SnippetFromFileSPDXID: SPDXRef-File292
+SnippetByteRange: 17:209
+SnippetLicenseConcluded: GPL-2.0-or-later
+SnippetCopyrightText: <text>Copyright (c) John Doe 20x6
+Copyright (c) John Doe 20x6</text>
+
+`)
+
+	// render as buffer of bytes
+	var got bytes.Buffer
+	err := renderSnippet2_1(sn, &got)
+	if err != nil {
+		t.Errorf("Expected nil error, got %v", err)
+	}
+
+	// check that they match
+	c := bytes.Compare(want.Bytes(), got.Bytes())
+	if c != 0 {
+		t.Errorf("Expected %v, got %v", want.String(), got.String())
+	}
+}

--- a/tvsaver/saver2v2/save_snippet.go
+++ b/tvsaver/saver2v2/save_snippet.go
@@ -33,7 +33,7 @@ func renderSnippet2_2(sn *spdx.Snippet2_2, w io.Writer) error {
 		fmt.Fprintf(w, "SnippetLicenseComments: %s\n", textify(sn.SnippetLicenseComments))
 	}
 	if sn.SnippetCopyrightText != "" {
-		fmt.Fprintf(w, "SnippetCopyrightText: %s\n", sn.SnippetCopyrightText)
+		fmt.Fprintf(w, "SnippetCopyrightText: %s\n", textify(sn.SnippetCopyrightText))
 	}
 	if sn.SnippetComment != "" {
 		fmt.Fprintf(w, "SnippetComment: %s\n", textify(sn.SnippetComment))

--- a/tvsaver/saver2v2/save_snippet_test.go
+++ b/tvsaver/saver2v2/save_snippet_test.go
@@ -92,3 +92,38 @@ SnippetCopyrightText: Copyright (c) John Doe 20x6
 		t.Errorf("Expected %v, got %v", want.String(), got.String())
 	}
 }
+
+func TestSaver2_2SnippetWrapsCopyrightMultiline(t *testing.T) {
+	sn := &spdx.Snippet2_2{
+		SnippetSPDXIdentifier:         spdx.ElementID("Snippet17"),
+		SnippetFromFileSPDXIdentifier: spdx.MakeDocElementID("", "File292"),
+		SnippetByteRangeStart:         17,
+		SnippetByteRangeEnd:           209,
+		SnippetLicenseConcluded:       "GPL-2.0-or-later",
+		SnippetCopyrightText:          `Copyright (c) John Doe 20x6
+Copyright (c) John Doe 20x6`,
+	}
+
+	// what we want to get, as a buffer of bytes
+	want := bytes.NewBufferString(`SnippetSPDXIdentifier: SPDXRef-Snippet17
+SnippetFromFileSPDXID: SPDXRef-File292
+SnippetByteRange: 17:209
+SnippetLicenseConcluded: GPL-2.0-or-later
+SnippetCopyrightText: <text>Copyright (c) John Doe 20x6
+Copyright (c) John Doe 20x6</text>
+
+`)
+
+	// render as buffer of bytes
+	var got bytes.Buffer
+	err := renderSnippet2_2(sn, &got)
+	if err != nil {
+		t.Errorf("Expected nil error, got %v", err)
+	}
+
+	// check that they match
+	c := bytes.Compare(want.Bytes(), got.Bytes())
+	if c != 0 {
+		t.Errorf("Expected %v, got %v", want.String(), got.String())
+	}
+}


### PR DESCRIPTION
Signed-off-by: Bisakh Mondal bisakhmondal00@gmail.com

This is a fix for wrapping multiline snippet copyright in `<text></text>` block in `tvsaver` package. Hope this may close #31.