### PR TITLE
Fix pulling main branch for code coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   tests:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
       - uses: actions/setup-go@v2
         with:
           go-version: '1.14'


### PR DESCRIPTION
After the branch renaming from 'master' to 'main' in 0.2.0 per #69,
the tests were being run by GitHub Actions on the 'main' branch.
However, the code coverage tooling appears to still have been
pulling the old 'master' branch and therefore was not including
later changes such as the new JSON code. This PR fixes this by
changing the branch name in the GitHub Actions config file.

Signed-off-by: Steve Winslow <steve@swinslow.net>