### PR TITLE
Expand algorithm support to all valid ones

### DIFF
--- a/rdfloader/parser2v2/parse_file.go
+++ b/rdfloader/parser2v2/parse_file.go
@@ -135,7 +135,15 @@ func (parser *rdfParser2_2) setFileChecksumFromNode(file *v2_2.File, checksumNod
 		file.Checksums = []common.Checksum{}
 	}
 	switch checksumAlgorithm {
-	case common.MD5, common.SHA1, common.SHA256:
+	case common.SHA1,
+		common.SHA224,
+		common.SHA256,
+		common.SHA384,
+		common.SHA512,
+		common.MD2,
+		common.MD4,
+		common.MD5,
+		common.MD6:
 		file.Checksums = append(file.Checksums, common.Checksum{Algorithm: checksumAlgorithm, Value: checksumValue})
 	case "":
 		return fmt.Errorf("empty checksum algorithm and value")

--- a/rdfloader/parser2v2/parse_file_test.go
+++ b/rdfloader/parser2v2/parse_file_test.go
@@ -315,7 +315,7 @@ func Test_rdfParser2_2_setFileChecksumFromNode(t *testing.T) {
 	// TestCase 6: valid checksum algorithm which is invalid for file (like md4, md6, sha384, etc.)
 	parser, _ = parserFromBodyContent(` 
 		<spdx:Checksum>
-			<spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha384" />
+			<spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha2000" />
 		    <spdx:checksumValue>d2356e0fe1c0b85285d83c6b2ad51b5f</spdx:checksumValue>
 		</spdx:Checksum>
     `)
@@ -355,7 +355,7 @@ func Test_rdfParser2_2_getFileFromNode(t *testing.T) {
 		<spdx:File rdf:about="http://anupam-VirtualBox/repo/SPDX2_time-1.9.tar.gz_1535120734-spdx.rdf#SPDXRef-item177">
 			<spdx:checksum>
 				<spdx:Checksum>
-					<spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha384" />
+					<spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha2000" />
 					<spdx:checksumValue>0a3a0e1ab72b7c132f5021c538a7a3ea6d539bcd</spdx:checksumValue>
 				</spdx:Checksum>
 			</spdx:checksum>

--- a/rdfloader/parser2v2/parse_package.go
+++ b/rdfloader/parser2v2/parse_package.go
@@ -237,7 +237,8 @@ func (parser *rdfParser2_2) setFileToPackage(pkg *v2_2.Package, file *v2_2.File)
 
 // given a supplierObject, sets the PackageSupplier attribute of the pkg.
 // Args:
-//    value: [NOASSERTION | [Person | Organization]: string]
+//
+//	value: [NOASSERTION | [Person | Organization]: string]
 func setPackageSupplier(pkg *v2_2.Package, value string) error {
 	value = strings.TrimSpace(value)
 	supplier := &common.Supplier{}
@@ -266,7 +267,8 @@ func setPackageSupplier(pkg *v2_2.Package, value string) error {
 
 // given a OriginatorObject, sets the PackageOriginator attribute of the pkg.
 // Args:
-//    value: [NOASSERTION | [Person | Organization]: string]
+//
+//	value: [NOASSERTION | [Person | Organization]: string]
 func setPackageOriginator(pkg *v2_2.Package, value string) error {
 	value = strings.TrimSpace(value)
 	originator := &common.Originator{}
@@ -326,7 +328,15 @@ func (parser *rdfParser2_2) setPackageChecksum(pkg *v2_2.Package, node *gordfPar
 		pkg.PackageChecksums = make([]common.Checksum, 0, 1)
 	}
 	switch checksumAlgorithm {
-	case common.MD5, common.SHA1, common.SHA256:
+	case common.SHA1,
+		common.SHA224,
+		common.SHA256,
+		common.SHA384,
+		common.SHA512,
+		common.MD2,
+		common.MD4,
+		common.MD5,
+		common.MD6:
 		pkg.PackageChecksums = append(pkg.PackageChecksums, common.Checksum{Algorithm: checksumAlgorithm, Value: checksumValue})
 	default:
 		return fmt.Errorf("unknown checksumAlgorithm %s while parsing a package", checksumAlgorithm)

--- a/rdfloader/parser2v2/parse_package_test.go
+++ b/rdfloader/parser2v2/parse_package_test.go
@@ -607,7 +607,7 @@ func Test_rdfParser2_2_setPackageChecksum(t *testing.T) {
 	parser, _ = parserFromBodyContent(`
 		<spdx:Checksum>
 			<spdx:checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</spdx:checksumValue>
-			<spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha384"/>
+			<spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha2000"/>
 		</spdx:Checksum>
 	`)
 	pkg = &v2_2.Package{}

--- a/rdfloader/parser2v3/parse_file.go
+++ b/rdfloader/parser2v3/parse_file.go
@@ -135,7 +135,23 @@ func (parser *rdfParser2_3) setFileChecksumFromNode(file *v2_3.File, checksumNod
 		file.Checksums = []common.Checksum{}
 	}
 	switch checksumAlgorithm {
-	case common.MD5, common.SHA1, common.SHA256:
+	case common.SHA1,
+		common.SHA224,
+		common.SHA256,
+		common.SHA384,
+		common.SHA512,
+		common.MD2,
+		common.MD4,
+		common.MD5,
+		common.MD6,
+		common.SHA3_256,
+		common.SHA3_384,
+		common.SHA3_512,
+		common.BLAKE2b_256,
+		common.BLAKE2b_384,
+		common.BLAKE2b_512,
+		common.BLAKE3,
+		common.ADLER32:
 		file.Checksums = append(file.Checksums, common.Checksum{Algorithm: checksumAlgorithm, Value: checksumValue})
 	case "":
 		return fmt.Errorf("empty checksum algorithm and value")

--- a/rdfloader/parser2v3/parse_file_test.go
+++ b/rdfloader/parser2v3/parse_file_test.go
@@ -315,7 +315,7 @@ func Test_rdfParser2_3_setFileChecksumFromNode(t *testing.T) {
 	// TestCase 6: valid checksum algorithm which is invalid for file (like md4, md6, sha384, etc.)
 	parser, _ = parserFromBodyContent(` 
 		<spdx:Checksum>
-			<spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha384" />
+			<spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha2000" />
 		    <spdx:checksumValue>d2356e0fe1c0b85285d83c6b2ad51b5f</spdx:checksumValue>
 		</spdx:Checksum>
     `)
@@ -355,7 +355,7 @@ func Test_rdfParser2_3_getFileFromNode(t *testing.T) {
 		<spdx:File rdf:about="http://anupam-VirtualBox/repo/SPDX2_time-1.9.tar.gz_1535120734-spdx.rdf#SPDXRef-item177">
 			<spdx:checksum>
 				<spdx:Checksum>
-					<spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha384" />
+					<spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha2000" />
 					<spdx:checksumValue>0a3a0e1ab72b7c132f5021c538a7a3ea6d539bcd</spdx:checksumValue>
 				</spdx:Checksum>
 			</spdx:checksum>

--- a/rdfloader/parser2v3/parse_package.go
+++ b/rdfloader/parser2v3/parse_package.go
@@ -264,7 +264,8 @@ func (parser *rdfParser2_3) setFileToPackage(pkg *v2_3.Package, file *v2_3.File)
 
 // given a supplierObject, sets the PackageSupplier attribute of the pkg.
 // Args:
-//    value: [NOASSERTION | [Person | Organization]: string]
+//
+//	value: [NOASSERTION | [Person | Organization]: string]
 func setPackageSupplier(pkg *v2_3.Package, value string) error {
 	value = strings.TrimSpace(value)
 	supplier := &common.Supplier{}
@@ -293,7 +294,8 @@ func setPackageSupplier(pkg *v2_3.Package, value string) error {
 
 // given a OriginatorObject, sets the PackageOriginator attribute of the pkg.
 // Args:
-//    value: [NOASSERTION | [Person | Organization]: string]
+//
+//	value: [NOASSERTION | [Person | Organization]: string]
 func setPackageOriginator(pkg *v2_3.Package, value string) error {
 	value = strings.TrimSpace(value)
 	originator := &common.Originator{}
@@ -353,7 +355,23 @@ func (parser *rdfParser2_3) setPackageChecksum(pkg *v2_3.Package, node *gordfPar
 		pkg.PackageChecksums = make([]common.Checksum, 0, 1)
 	}
 	switch checksumAlgorithm {
-	case common.MD5, common.SHA1, common.SHA256:
+	case common.SHA1,
+		common.SHA224,
+		common.SHA256,
+		common.SHA384,
+		common.SHA512,
+		common.MD2,
+		common.MD4,
+		common.MD5,
+		common.MD6,
+		common.SHA3_256,
+		common.SHA3_384,
+		common.SHA3_512,
+		common.BLAKE2b_256,
+		common.BLAKE2b_384,
+		common.BLAKE2b_512,
+		common.BLAKE3,
+		common.ADLER32:
 		pkg.PackageChecksums = append(pkg.PackageChecksums, common.Checksum{Algorithm: checksumAlgorithm, Value: checksumValue})
 	default:
 		return fmt.Errorf("unknown checksumAlgorithm %s while parsing a package", checksumAlgorithm)

--- a/rdfloader/parser2v3/parse_package_test.go
+++ b/rdfloader/parser2v3/parse_package_test.go
@@ -627,7 +627,7 @@ func Test_rdfParser2_3_setPackageChecksum(t *testing.T) {
 	parser, _ = parserFromBodyContent(`
 		<spdx:Checksum>
 			<spdx:checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</spdx:checksumValue>
-			<spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha384"/>
+			<spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha2000"/>
 		</spdx:Checksum>
 	`)
 	pkg = &v2_3.Package{}

--- a/spdx/v2_2/package.go
+++ b/spdx/v2_2/package.go
@@ -50,7 +50,7 @@ type Package struct {
 	// 7.9: Package Verification Code
 	PackageVerificationCode common.PackageVerificationCode `json:"packageVerificationCode"`
 
-	// 7.10: Package Checksum: may have keys for SHA1, SHA256 and/or MD5
+	// 7.10: Package Checksum: may have keys for SHA1, SHA256, SHA512 and/or MD5
 	// Cardinality: optional, one or many
 	PackageChecksums []common.Checksum `json:"checksums"`
 

--- a/spdx/v2_3/package.go
+++ b/spdx/v2_3/package.go
@@ -51,7 +51,7 @@ type Package struct {
 	// Cardinality: if FilesAnalyzed == true must be present, if FilesAnalyzed == false must be omitted
 	PackageVerificationCode *common.PackageVerificationCode `json:"packageVerificationCode,omitempty"`
 
-	// 7.10: Package Checksum: may have keys for SHA1, SHA256, MD5, SHA3-256, SHA3-384, SHA3-512, BLAKE2b-256, BLAKE2b-384, BLAKE2b-512, BLAKE3, ADLER32
+	// 7.10: Package Checksum: may have keys for SHA1, SHA256, SHA512, MD5, SHA3-256, SHA3-384, SHA3-512, BLAKE2b-256, BLAKE2b-384, BLAKE2b-512, BLAKE3, ADLER32
 	// Cardinality: optional, one or many
 	PackageChecksums []common.Checksum `json:"checksums,omitempty"`
 

--- a/tvloader/parser2v2/parse_file.go
+++ b/tvloader/parser2v2/parse_file.go
@@ -71,7 +71,7 @@ func (parser *tvParser2_2) parsePairFromFile2_2(tag string, value string) error 
 			parser.file.Checksums = []common.Checksum{}
 		}
 		switch common.ChecksumAlgorithm(subkey) {
-		case common.SHA1, common.SHA256, common.MD5:
+		case common.SHA1, common.SHA256, common.SHA512, common.MD5:
 			algorithm := common.ChecksumAlgorithm(subkey)
 			parser.file.Checksums = append(parser.file.Checksums, common.Checksum{Algorithm: algorithm, Value: subvalue})
 		default:

--- a/tvloader/parser2v2/parse_file.go
+++ b/tvloader/parser2v2/parse_file.go
@@ -71,7 +71,15 @@ func (parser *tvParser2_2) parsePairFromFile2_2(tag string, value string) error 
 			parser.file.Checksums = []common.Checksum{}
 		}
 		switch common.ChecksumAlgorithm(subkey) {
-		case common.SHA1, common.SHA256, common.SHA512, common.MD5:
+		case common.SHA1,
+			common.SHA224,
+			common.SHA256,
+			common.SHA384,
+			common.SHA512,
+			common.MD2,
+			common.MD4,
+			common.MD5,
+			common.MD6:
 			algorithm := common.ChecksumAlgorithm(subkey)
 			parser.file.Checksums = append(parser.file.Checksums, common.Checksum{Algorithm: algorithm, Value: subvalue})
 		default:

--- a/tvloader/parser2v2/parse_file_test.go
+++ b/tvloader/parser2v2/parse_file_test.go
@@ -2,6 +2,7 @@
 package parser2v2
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/spdx/tools-golang/spdx/common"
@@ -425,41 +426,29 @@ func TestParser2_2CanParseFileTags(t *testing.T) {
 			len(parser.file.FileTypes))
 	}
 
-	// File Checksums
-	codeSha1 := "85ed0817af83a24ad8da68c2b5094de69833983c"
-	sumSha1 := "SHA1: 85ed0817af83a24ad8da68c2b5094de69833983c"
-	codeSha256 := "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
-	sumSha256 := "SHA256: 11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
-	codeMd5 := "624c1abb3664f4b35547e7c73864ad24"
-	sumMd5 := "MD5: 624c1abb3664f4b35547e7c73864ad24"
-	err = parser.parsePairFromFile2_2("FileChecksum", sumSha1)
-	if err != nil {
-		t.Errorf("expected nil error, got %v", err)
+	testChecksums := map[common.ChecksumAlgorithm]string{
+		"MD5":    "624c1abb3664f4b35547e7c73864ad24",
+		"SHA1":   "85ed0817af83a24ad8da68c2b5094de69833983c",
+		"SHA256": "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd",
+		"SHA512": "4ced3267f5ed38df65ceebc43e97aa6c2948cc7ef3288c2e5074e7df7fab544cc93339604513ea5f65616f9ed1c48581465043c8a9b693ef20fd4fddaf25e1b9",
 	}
-	err = parser.parsePairFromFile2_2("FileChecksum", sumSha256)
-	if err != nil {
-		t.Errorf("expected nil error, got %v", err)
-	}
-	err = parser.parsePairFromFile2_2("FileChecksum", sumMd5)
-	if err != nil {
-		t.Errorf("expected nil error, got %v", err)
-	}
-	for _, checksum := range parser.file.Checksums {
-		switch checksum.Algorithm {
-		case common.SHA1:
-			if checksum.Value != codeSha1 {
-				t.Errorf("expected %s for FileChecksumSHA1, got %s", codeSha1, checksum.Value)
-			}
-		case common.SHA256:
-			if checksum.Value != codeSha256 {
-				t.Errorf("expected %s for FileChecksumSHA1, got %s", codeSha256, checksum.Value)
-			}
-		case common.MD5:
-			if checksum.Value != codeMd5 {
-				t.Errorf("expected %s for FileChecksumSHA1, got %s", codeMd5, checksum.Value)
-			}
+
+	for algo, tc := range testChecksums {
+		if err := parser.parsePairFromFile2_2(
+			"FileChecksum", fmt.Sprintf("%s: %s", algo, tc)); err != nil {
+			t.Errorf("expected error, got %v", err)
 		}
 	}
+
+	for _, checksum := range parser.file.Checksums {
+		if checksum.Value != testChecksums[checksum.Algorithm] {
+			t.Errorf(
+				"expected %s for FileChecksum%s, got %s",
+				testChecksums[checksum.Algorithm], checksum.Algorithm, checksum.Value,
+			)
+		}
+	}
+
 	// Concluded License
 	err = parser.parsePairFromFile2_2("LicenseConcluded", "Apache-2.0 OR GPL-2.0-or-later")
 	if err != nil {

--- a/tvloader/parser2v2/parse_package.go
+++ b/tvloader/parser2v2/parse_package.go
@@ -111,7 +111,15 @@ func (parser *tvParser2_2) parsePairFromPackage2_2(tag string, value string) err
 			parser.pkg.PackageChecksums = []common.Checksum{}
 		}
 		switch common.ChecksumAlgorithm(subkey) {
-		case common.SHA1, common.SHA256, common.SHA512, common.MD5:
+		case common.SHA1,
+			common.SHA224,
+			common.SHA256,
+			common.SHA384,
+			common.SHA512,
+			common.MD2,
+			common.MD4,
+			common.MD5,
+			common.MD6:
 			algorithm := common.ChecksumAlgorithm(subkey)
 			parser.pkg.PackageChecksums = append(parser.pkg.PackageChecksums, common.Checksum{Algorithm: algorithm, Value: subvalue})
 		default:

--- a/tvloader/parser2v2/parse_package.go
+++ b/tvloader/parser2v2/parse_package.go
@@ -111,7 +111,7 @@ func (parser *tvParser2_2) parsePairFromPackage2_2(tag string, value string) err
 			parser.pkg.PackageChecksums = []common.Checksum{}
 		}
 		switch common.ChecksumAlgorithm(subkey) {
-		case common.SHA1, common.SHA256, common.MD5:
+		case common.SHA1, common.SHA256, common.SHA512, common.MD5:
 			algorithm := common.ChecksumAlgorithm(subkey)
 			parser.pkg.PackageChecksums = append(parser.pkg.PackageChecksums, common.Checksum{Algorithm: algorithm, Value: subvalue})
 		default:

--- a/tvloader/parser2v2/parse_package_test.go
+++ b/tvloader/parser2v2/parse_package_test.go
@@ -2,6 +2,7 @@
 package parser2v2
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/spdx/tools-golang/spdx/common"
@@ -335,39 +336,26 @@ func TestParser2_2CanParsePackageTags(t *testing.T) {
 	// Package Verification Code
 	// SKIP -- separate tests for "excludes", or not, below
 
-	// Package Checksums
-	codeSha1 := "85ed0817af83a24ad8da68c2b5094de69833983c"
-	sumSha1 := "SHA1: 85ed0817af83a24ad8da68c2b5094de69833983c"
-	codeSha256 := "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
-	sumSha256 := "SHA256: 11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
-	codeMd5 := "624c1abb3664f4b35547e7c73864ad24"
-	sumMd5 := "MD5: 624c1abb3664f4b35547e7c73864ad24"
-	err = parser.parsePairFromPackage2_2("PackageChecksum", sumSha1)
-	if err != nil {
-		t.Errorf("expected nil error, got %v", err)
+	testChecksums := map[common.ChecksumAlgorithm]string{
+		"MD5":    "624c1abb3664f4b35547e7c73864ad24",
+		"SHA1":   "85ed0817af83a24ad8da68c2b5094de69833983c",
+		"SHA256": "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd",
+		"SHA512": "4ced3267f5ed38df65ceebc43e97aa6c2948cc7ef3288c2e5074e7df7fab544cc93339604513ea5f65616f9ed1c48581465043c8a9b693ef20fd4fddaf25e1b9",
 	}
-	err = parser.parsePairFromPackage2_2("PackageChecksum", sumSha256)
-	if err != nil {
-		t.Errorf("expected nil error, got %v", err)
+
+	for algo, tc := range testChecksums {
+		if err := parser.parsePairFromPackage2_2(
+			"PackageChecksum", fmt.Sprintf("%s: %s", algo, tc)); err != nil {
+			t.Errorf("expected error, got %v", err)
+		}
 	}
-	err = parser.parsePairFromPackage2_2("PackageChecksum", sumMd5)
-	if err != nil {
-		t.Errorf("expected nil error, got %v", err)
-	}
+
 	for _, checksum := range parser.pkg.PackageChecksums {
-		switch checksum.Algorithm {
-		case common.SHA1:
-			if checksum.Value != codeSha1 {
-				t.Errorf("expected %s for FileChecksumSHA1, got %s", codeSha1, checksum.Value)
-			}
-		case common.SHA256:
-			if checksum.Value != codeSha256 {
-				t.Errorf("expected %s for FileChecksumSHA1, got %s", codeSha256, checksum.Value)
-			}
-		case common.MD5:
-			if checksum.Value != codeMd5 {
-				t.Errorf("expected %s for FileChecksumSHA1, got %s", codeMd5, checksum.Value)
-			}
+		if checksum.Value != testChecksums[checksum.Algorithm] {
+			t.Errorf(
+				"expected %s for PackageChecksum%s, got %s",
+				testChecksums[checksum.Algorithm], checksum.Algorithm, checksum.Value,
+			)
 		}
 	}
 

--- a/tvloader/parser2v3/parse_file.go
+++ b/tvloader/parser2v3/parse_file.go
@@ -73,6 +73,7 @@ func (parser *tvParser2_3) parsePairFromFile2_3(tag string, value string) error 
 		switch common.ChecksumAlgorithm(subkey) {
 		case common.SHA1,
 			common.SHA256,
+			common.SHA512,
 			common.MD5,
 			common.SHA3_256,
 			common.SHA3_384,

--- a/tvloader/parser2v3/parse_file.go
+++ b/tvloader/parser2v3/parse_file.go
@@ -72,9 +72,14 @@ func (parser *tvParser2_3) parsePairFromFile2_3(tag string, value string) error 
 		}
 		switch common.ChecksumAlgorithm(subkey) {
 		case common.SHA1,
+			common.SHA224,
 			common.SHA256,
+			common.SHA384,
 			common.SHA512,
+			common.MD2,
+			common.MD4,
 			common.MD5,
+			common.MD6,
 			common.SHA3_256,
 			common.SHA3_384,
 			common.SHA3_512,

--- a/tvloader/parser2v3/parse_file_test.go
+++ b/tvloader/parser2v3/parse_file_test.go
@@ -2,6 +2,7 @@
 package parser2v3
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/spdx/tools-golang/spdx/common"
@@ -425,39 +426,26 @@ func TestParser2_3CanParseFileTags(t *testing.T) {
 			len(parser.file.FileTypes))
 	}
 
-	// File Checksums
-	codeSha1 := "85ed0817af83a24ad8da68c2b5094de69833983c"
-	sumSha1 := "SHA1: 85ed0817af83a24ad8da68c2b5094de69833983c"
-	codeSha256 := "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
-	sumSha256 := "SHA256: 11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
-	codeMd5 := "624c1abb3664f4b35547e7c73864ad24"
-	sumMd5 := "MD5: 624c1abb3664f4b35547e7c73864ad24"
-	err = parser.parsePairFromFile2_3("FileChecksum", sumSha1)
-	if err != nil {
-		t.Errorf("expected nil error, got %v", err)
+	testChecksums := map[common.ChecksumAlgorithm]string{
+		"MD5":    "624c1abb3664f4b35547e7c73864ad24",
+		"SHA1":   "85ed0817af83a24ad8da68c2b5094de69833983c",
+		"SHA256": "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd",
+		"SHA512": "4ced3267f5ed38df65ceebc43e97aa6c2948cc7ef3288c2e5074e7df7fab544cc93339604513ea5f65616f9ed1c48581465043c8a9b693ef20fd4fddaf25e1b9",
 	}
-	err = parser.parsePairFromFile2_3("FileChecksum", sumSha256)
-	if err != nil {
-		t.Errorf("expected nil error, got %v", err)
+
+	for algo, tc := range testChecksums {
+		if err := parser.parsePairFromFile2_3(
+			"FileChecksum", fmt.Sprintf("%s: %s", algo, tc)); err != nil {
+			t.Errorf("expected error, got %v", err)
+		}
 	}
-	err = parser.parsePairFromFile2_3("FileChecksum", sumMd5)
-	if err != nil {
-		t.Errorf("expected nil error, got %v", err)
-	}
+
 	for _, checksum := range parser.file.Checksums {
-		switch checksum.Algorithm {
-		case common.SHA1:
-			if checksum.Value != codeSha1 {
-				t.Errorf("expected %s for FileChecksumSHA1, got %s", codeSha1, checksum.Value)
-			}
-		case common.SHA256:
-			if checksum.Value != codeSha256 {
-				t.Errorf("expected %s for FileChecksumSHA1, got %s", codeSha256, checksum.Value)
-			}
-		case common.MD5:
-			if checksum.Value != codeMd5 {
-				t.Errorf("expected %s for FileChecksumSHA1, got %s", codeMd5, checksum.Value)
-			}
+		if checksum.Value != testChecksums[checksum.Algorithm] {
+			t.Errorf(
+				"expected %s for FileChecksum%s, got %s",
+				testChecksums[checksum.Algorithm], checksum.Algorithm, checksum.Value,
+			)
 		}
 	}
 	// Concluded License

--- a/tvloader/parser2v3/parse_file_test.go
+++ b/tvloader/parser2v3/parse_file_test.go
@@ -431,6 +431,7 @@ func TestParser2_3CanParseFileTags(t *testing.T) {
 		"SHA1":   "85ed0817af83a24ad8da68c2b5094de69833983c",
 		"SHA256": "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd",
 		"SHA512": "4ced3267f5ed38df65ceebc43e97aa6c2948cc7ef3288c2e5074e7df7fab544cc93339604513ea5f65616f9ed1c48581465043c8a9b693ef20fd4fddaf25e1b9",
+		"BLAKE3": "981d32ed7aad9e408c5c36f6346c915ba11c2bd8b3e7d44902a11d7a141abdd9",
 	}
 
 	for algo, tc := range testChecksums {
@@ -448,6 +449,7 @@ func TestParser2_3CanParseFileTags(t *testing.T) {
 			)
 		}
 	}
+
 	// Concluded License
 	err = parser.parsePairFromFile2_3("LicenseConcluded", "Apache-2.0 OR GPL-2.0-or-later")
 	if err != nil {

--- a/tvloader/parser2v3/parse_package.go
+++ b/tvloader/parser2v3/parse_package.go
@@ -111,7 +111,7 @@ func (parser *tvParser2_3) parsePairFromPackage2_3(tag string, value string) err
 			parser.pkg.PackageChecksums = []common.Checksum{}
 		}
 		switch common.ChecksumAlgorithm(subkey) {
-		case common.SHA1, common.SHA256, common.MD5:
+		case common.SHA1, common.SHA256, common.SHA512, common.MD5:
 			algorithm := common.ChecksumAlgorithm(subkey)
 			parser.pkg.PackageChecksums = append(parser.pkg.PackageChecksums, common.Checksum{Algorithm: algorithm, Value: subvalue})
 		default:

--- a/tvloader/parser2v3/parse_package.go
+++ b/tvloader/parser2v3/parse_package.go
@@ -111,7 +111,23 @@ func (parser *tvParser2_3) parsePairFromPackage2_3(tag string, value string) err
 			parser.pkg.PackageChecksums = []common.Checksum{}
 		}
 		switch common.ChecksumAlgorithm(subkey) {
-		case common.SHA1, common.SHA256, common.SHA512, common.MD5:
+		case common.SHA1,
+			common.SHA224,
+			common.SHA256,
+			common.SHA384,
+			common.SHA512,
+			common.MD2,
+			common.MD4,
+			common.MD5,
+			common.MD6,
+			common.SHA3_256,
+			common.SHA3_384,
+			common.SHA3_512,
+			common.BLAKE2b_256,
+			common.BLAKE2b_384,
+			common.BLAKE2b_512,
+			common.BLAKE3,
+			common.ADLER32:
 			algorithm := common.ChecksumAlgorithm(subkey)
 			parser.pkg.PackageChecksums = append(parser.pkg.PackageChecksums, common.Checksum{Algorithm: algorithm, Value: subvalue})
 		default:

--- a/tvloader/parser2v3/parse_package_test.go
+++ b/tvloader/parser2v3/parse_package_test.go
@@ -341,6 +341,7 @@ func TestParser2_3CanParsePackageTags(t *testing.T) {
 		"SHA1":   "85ed0817af83a24ad8da68c2b5094de69833983c",
 		"SHA256": "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd",
 		"SHA512": "4ced3267f5ed38df65ceebc43e97aa6c2948cc7ef3288c2e5074e7df7fab544cc93339604513ea5f65616f9ed1c48581465043c8a9b693ef20fd4fddaf25e1b9",
+		"BLAKE3": "981d32ed7aad9e408c5c36f6346c915ba11c2bd8b3e7d44902a11d7a141abdd9",
 	}
 
 	for algo, tc := range testChecksums {

--- a/tvloader/parser2v3/parse_package_test.go
+++ b/tvloader/parser2v3/parse_package_test.go
@@ -2,6 +2,7 @@
 package parser2v3
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/spdx/tools-golang/spdx/common"
@@ -335,39 +336,26 @@ func TestParser2_3CanParsePackageTags(t *testing.T) {
 	// Package Verification Code
 	// SKIP -- separate tests for "excludes", or not, below
 
-	// Package Checksums
-	codeSha1 := "85ed0817af83a24ad8da68c2b5094de69833983c"
-	sumSha1 := "SHA1: 85ed0817af83a24ad8da68c2b5094de69833983c"
-	codeSha256 := "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
-	sumSha256 := "SHA256: 11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
-	codeMd5 := "624c1abb3664f4b35547e7c73864ad24"
-	sumMd5 := "MD5: 624c1abb3664f4b35547e7c73864ad24"
-	err = parser.parsePairFromPackage2_3("PackageChecksum", sumSha1)
-	if err != nil {
-		t.Errorf("expected nil error, got %v", err)
+	testChecksums := map[common.ChecksumAlgorithm]string{
+		"MD5":    "624c1abb3664f4b35547e7c73864ad24",
+		"SHA1":   "85ed0817af83a24ad8da68c2b5094de69833983c",
+		"SHA256": "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd",
+		"SHA512": "4ced3267f5ed38df65ceebc43e97aa6c2948cc7ef3288c2e5074e7df7fab544cc93339604513ea5f65616f9ed1c48581465043c8a9b693ef20fd4fddaf25e1b9",
 	}
-	err = parser.parsePairFromPackage2_3("PackageChecksum", sumSha256)
-	if err != nil {
-		t.Errorf("expected nil error, got %v", err)
+
+	for algo, tc := range testChecksums {
+		if err := parser.parsePairFromPackage2_3(
+			"PackageChecksum", fmt.Sprintf("%s: %s", algo, tc)); err != nil {
+			t.Errorf("expected error, got %v", err)
+		}
 	}
-	err = parser.parsePairFromPackage2_3("PackageChecksum", sumMd5)
-	if err != nil {
-		t.Errorf("expected nil error, got %v", err)
-	}
+
 	for _, checksum := range parser.pkg.PackageChecksums {
-		switch checksum.Algorithm {
-		case common.SHA1:
-			if checksum.Value != codeSha1 {
-				t.Errorf("expected %s for FileChecksumSHA1, got %s", codeSha1, checksum.Value)
-			}
-		case common.SHA256:
-			if checksum.Value != codeSha256 {
-				t.Errorf("expected %s for FileChecksumSHA1, got %s", codeSha256, checksum.Value)
-			}
-		case common.MD5:
-			if checksum.Value != codeMd5 {
-				t.Errorf("expected %s for FileChecksumSHA1, got %s", codeMd5, checksum.Value)
-			}
+		if checksum.Value != testChecksums[checksum.Algorithm] {
+			t.Errorf(
+				"expected %s for PackageChecksum%s, got %s",
+				testChecksums[checksum.Algorithm], checksum.Algorithm, checksum.Value,
+			)
 		}
 	}
 


### PR DESCRIPTION
This PR updates the 2.2 and 2.3 parsers to support files and packages checksummed with all valid algorithms. 

This PR updates the packages parsers, file parsers, and all test cases to support all valid [2.2](https://spdx.github.io/spdx-spec/v2.2.2/package-information/#710-package-checksum-field) and [2.3](https://spdx.github.io/spdx-spec/v2.3/package-information/#710-package-checksum-field) hashing algorithms:

| SPDX 2.2 | SPDX 2.3 |
| --- | --- |
| SHA1 | SHA1 |
| SHA224 | SHA224 |
| SHA256 | SHA256 |
| SHA384 | SHA384 |
| SHA512 | SHA512 |
| MD2 | MD2 |
| MD4 | MD4 |
| MD5 | MD5 |
| MD6 | MD6 |
|  | SHA3_256 |
|  | SHA3_384 |
|  | SHA3_512 |
|  | BLAKE2b_256 |
|  | BLAKE2b_384 |
|  | BLAKE2b_512 |
|  | BLAKE3 |
|  | ADLER32 |

/cc @lumjjb 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>
