### PR TITLE
Ensure consistency between JSON struct tags across different SPDX versions

### DIFF
--- a/spdx/v2_1/creation_info.go
+++ b/spdx/v2_1/creation_info.go
@@ -22,5 +22,5 @@ type CreationInfo struct {
 
 	// 2.10: Creator Comment
 	// Cardinality: optional, one
-	CreatorComment string `json:"comment"`
+	CreatorComment string `json:"comment,omitempty"`
 }

--- a/spdx/v2_1/document.go
+++ b/spdx/v2_1/document.go
@@ -53,12 +53,12 @@ type Document struct {
 	DocumentComment string `json:"comment,omitempty"`
 
 	CreationInfo  *CreationInfo   `json:"creationInfo"`
-	Packages      []*Package      `json:"packages"`
-	Files         []*File         `json:"files"`
-	OtherLicenses []*OtherLicense `json:"hasExtractedLicensingInfos"`
-	Relationships []*Relationship `json:"relationships"`
-	Annotations   []*Annotation   `json:"annotations"`
-	Snippets      []Snippet       `json:"snippets"`
+	Packages      []*Package      `json:"packages,omitempty"`
+	Files         []*File         `json:"files,omitempty"`
+	OtherLicenses []*OtherLicense `json:"hasExtractedLicensingInfos,omitempty"`
+	Relationships []*Relationship `json:"relationships,omitempty"`
+	Annotations   []*Annotation   `json:"annotations,omitempty"`
+	Snippets      []Snippet       `json:"snippets,omitempty"`
 
 	// DEPRECATED in version 2.0 of spec
 	Reviews []*Review `json:"-"`

--- a/spdx/v2_1/document.go
+++ b/spdx/v2_1/document.go
@@ -61,5 +61,5 @@ type Document struct {
 	Snippets      []Snippet       `json:"snippets"`
 
 	// DEPRECATED in version 2.0 of spec
-	Reviews []*Review
+	Reviews []*Review `json:"-"`
 }

--- a/spdx/v2_1/file.go
+++ b/spdx/v2_1/file.go
@@ -66,7 +66,7 @@ type File struct {
 	// defined here -- so this should just be an ElementID.
 	Snippets map[common.ElementID]*Snippet `json:"-"`
 
-	Annotations []Annotation `json:"annotations"`
+	Annotations []Annotation `json:"annotations,omitempty"`
 }
 
 // ArtifactOfProject is a DEPRECATED collection of data regarding

--- a/spdx/v2_1/package.go
+++ b/spdx/v2_1/package.go
@@ -95,7 +95,7 @@ type Package struct {
 	PackageExternalReferences []*PackageExternalReference `json:"externalRefs,omitempty"`
 
 	// Files contained in this Package
-	Files []*File
+	Files []*File `json:"files,omitempty"`
 
 	Annotations []Annotation `json:"annotations,omitempty"`
 }

--- a/spdx/v2_1/package.go
+++ b/spdx/v2_1/package.go
@@ -116,5 +116,5 @@ type PackageExternalReference struct {
 
 	// 3.22: Package External Reference Comment
 	// Cardinality: conditional (optional, one) for each External Reference
-	ExternalRefComment string `json:"comment"`
+	ExternalRefComment string `json:"comment,omitempty"`
 }

--- a/spdx/v2_2/creation_info.go
+++ b/spdx/v2_2/creation_info.go
@@ -22,5 +22,5 @@ type CreationInfo struct {
 
 	// 6.10: Creator Comment
 	// Cardinality: optional, one
-	CreatorComment string `json:"comment"`
+	CreatorComment string `json:"comment,omitempty"`
 }

--- a/spdx/v2_2/document.go
+++ b/spdx/v2_2/document.go
@@ -53,12 +53,12 @@ type Document struct {
 	DocumentComment string `json:"comment,omitempty"`
 
 	CreationInfo  *CreationInfo   `json:"creationInfo"`
-	Packages      []*Package      `json:"packages"`
-	Files         []*File         `json:"files"`
-	OtherLicenses []*OtherLicense `json:"hasExtractedLicensingInfos"`
-	Relationships []*Relationship `json:"relationships"`
-	Annotations   []*Annotation   `json:"annotations"`
-	Snippets      []Snippet       `json:"snippets"`
+	Packages      []*Package      `json:"packages,omitempty"`
+	Files         []*File         `json:"files,omitempty"`
+	OtherLicenses []*OtherLicense `json:"hasExtractedLicensingInfos,omitempty"`
+	Relationships []*Relationship `json:"relationships,omitempty"`
+	Annotations   []*Annotation   `json:"annotations,omitempty"`
+	Snippets      []Snippet       `json:"snippets,omitempty"`
 
 	// DEPRECATED in version 2.0 of spec
 	Reviews []*Review `json:"-"`

--- a/spdx/v2_2/document.go
+++ b/spdx/v2_2/document.go
@@ -61,5 +61,5 @@ type Document struct {
 	Snippets      []Snippet       `json:"snippets"`
 
 	// DEPRECATED in version 2.0 of spec
-	Reviews []*Review
+	Reviews []*Review `json:"-"`
 }

--- a/spdx/v2_2/package.go
+++ b/spdx/v2_2/package.go
@@ -129,5 +129,5 @@ type PackageExternalReference struct {
 
 	// 7.22: Package External Reference Comment
 	// Cardinality: conditional (optional, one) for each External Reference
-	ExternalRefComment string `json:"comment"`
+	ExternalRefComment string `json:"comment,omitempty"`
 }

--- a/spdx/v2_2/package.go
+++ b/spdx/v2_2/package.go
@@ -9,7 +9,7 @@ type Package struct {
 	// NOT PART OF SPEC
 	// flag: does this "package" contain files that were in fact "unpackaged",
 	// e.g. included directly in the Document without being in a Package?
-	IsUnpackaged bool
+	IsUnpackaged bool `json:"-"`
 
 	// 7.1: Package Name
 	// Cardinality: mandatory, one
@@ -45,7 +45,7 @@ type Package struct {
 	// Cardinality: optional, one; default value is "true" if omitted
 	FilesAnalyzed bool `json:"filesAnalyzed,omitempty"`
 	// NOT PART OF SPEC: did FilesAnalyzed tag appear?
-	IsFilesAnalyzedTagPresent bool
+	IsFilesAnalyzedTagPresent bool `json:"-"`
 
 	// 7.9: Package Verification Code
 	PackageVerificationCode common.PackageVerificationCode `json:"packageVerificationCode"`

--- a/spdx/v2_2/package.go
+++ b/spdx/v2_2/package.go
@@ -52,7 +52,7 @@ type Package struct {
 
 	// 7.10: Package Checksum: may have keys for SHA1, SHA256 and/or MD5
 	// Cardinality: optional, one or many
-	PackageChecksums []common.Checksum `json:"checksums"`
+	PackageChecksums []common.Checksum `json:"checksums,omitempty"`
 
 	// 7.11: Package Home Page
 	// Cardinality: optional, one
@@ -108,9 +108,9 @@ type Package struct {
 	PackageAttributionTexts []string `json:"attributionTexts,omitempty"`
 
 	// Files contained in this Package
-	Files []*File
+	Files []*File `json:"files,omitempty"`
 
-	Annotations []Annotation `json:"annotations"`
+	Annotations []Annotation `json:"annotations,omitempty"`
 }
 
 // PackageExternalReference is an External Reference to additional info

--- a/spdx/v2_3/creation_info.go
+++ b/spdx/v2_3/creation_info.go
@@ -22,5 +22,5 @@ type CreationInfo struct {
 
 	// 6.10: Creator Comment
 	// Cardinality: optional, one
-	CreatorComment string `json:"comment"`
+	CreatorComment string `json:"comment,omitempty"`
 }

--- a/spdx/v2_3/package.go
+++ b/spdx/v2_3/package.go
@@ -147,5 +147,5 @@ type PackageExternalReference struct {
 
 	// 7.22: Package External Reference Comment
 	// Cardinality: conditional (optional, one) for each External Reference
-	ExternalRefComment string `json:"comment"`
+	ExternalRefComment string `json:"comment,omitempty"`
 }


### PR DESCRIPTION
Related to #156.

It looks like some of the struct tags between different SPDX versions (v2.1, v2.2 and v2.3) were slightly out-of-sync. This results in some of the deprecated fields, non-spec compliant fields being exported by the `json.Save` family of functions, but inconsistently between versions. Additionally, some optional comment fields were not marked with `omitempty`, resulting in unnecessary JSON output.

This PR fixes these various inconsistencies.