### PR TITLE
feat: add required document describes field

### DIFF
--- a/spdx/v2_3/document.go
+++ b/spdx/v2_3/document.go
@@ -44,6 +44,11 @@ type Document struct {
 	// Cardinality: mandatory, one
 	DocumentNamespace string `json:"documentNamespace"`
 
+	// 6.x: Document Descibes
+	// Cardinality: mandatory
+	// Packages, files and/or Snippets described by this SPDX document
+	DocumentDescribes []string `json:"documentDescribes"`
+
 	// 6.6: External Document References
 	// Cardinality: optional, one or many
 	ExternalDocumentReferences []ExternalDocumentRef `json:"externalDocumentRefs,omitempty"`


### PR DESCRIPTION
While it's not described in the documentation, the `DocumentDescribes` field can be found in the schema here:
https://github.com/spdx/spdx-spec/blob/efa69656db9db4fcc871de563cbbd104fc1e33c3/schemas/spdx-schema.json#L219-L226

As of this commit it's considered a required field. Tools like the java-tools, python-tools, and online validator will prompt the user that documents generated without this field are invalid:

https://github.com/spdx/spdx-spec/commit/efa69656db9db4fcc871de563cbbd104fc1e33c3

Adding this field for the v2_3 document will allow tools like [syft](https://github.com/anchore/syft) which use this library to produce valid documents.

Thanks a million for all the work and effort on this library!

Fixes: #166 

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>