### PR TITLE
docs: Remove outdated statement about requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,6 @@ tools-golang doesn't currently do any of the following:
 We are working towards adding functionality for all of these. Code contributions
 are welcome!
 
-## Requirements
-
-tools-golang uses https://github.com/spdx/gordf to manage RDF input and output.
-
-Other than that, tools-golang does not require anything outside the Go standard
-library.
-
 ## Documentation
 
 SPDX tools-golang documentation is available on the pkg.go.dev website at https://pkg.go.dev/github.com/spdx/tools-golang.


### PR DESCRIPTION
The README file currently states that tools-golang has no dependencies other than spdx/gordf and the Go standard library.

With the addition of the YAML functionality and usage of go-cmp, this is no longer an accurate statement. Rather than calling out the specific dependencies, this commit just removes that section. Users are able to check go.mod and go.sum if they want to know which dependencies are required.

Signed-off-by: Steve Winslow <steve@swinslow.net>