### PR TITLE
chore: update document conversion test to use conversion chain

### DIFF
--- a/convert/spdx_document_conversion_test.go
+++ b/convert/spdx_document_conversion_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/anchore/go-struct-converter"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spdx/tools-golang/spdx"
@@ -2114,7 +2113,9 @@ func Test_ConvertSPDXDocuments(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			outType := reflect.TypeOf(test.expected)
 			outInstance := reflect.New(outType).Interface()
-			err := converter.Convert(test.source, outInstance)
+
+			// convert the start document to the target document using the conversion chain
+			err := Document(test.source, outInstance)
 			if err != nil {
 				t.Fatalf("error converting: %v", err)
 			}


### PR DESCRIPTION
This PR updates the `spdx_document_conversion_test.go` to use the `convert.Document` function, which exercises the full conversion chain on SPDX document objects instead of just calling the `go-struct-converter Convert` function.