### PR TITLE
Set up Dependabot for Go modules and GitHub Actions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
- Add Dependabot workflows for Go modules and GitHub Actions
- Ensure dependencies are up-to-date with the latest security patches

[.github/workflows/dependabot.yml]
- Add a Dependabot workflow for Go modules
- Add a Dependabot workflow for GitHub Actions

Signed-off-by: Neil Naveen <42328488+neilnaveen@users.noreply.github.com>