### PR TITLE
implement documentDescribes for json/yaml schema

### DIFF
--- a/examples/sample-docs/json/SPDXJSONExample-v2.3.spdx.json
+++ b/examples/sample-docs/json/SPDXJSONExample-v2.3.spdx.json
@@ -3,6 +3,7 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "SPDX-Tools-v2.0",
+  "documentDescribes" : [ "SPDXRef-File", "SPDXRef-Package" ],
   "documentNamespace": "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301",
   "externalDocumentRefs": [
     {

--- a/examples/sample-docs/yaml/SPDXYAMLExample-2.3.spdx.yaml
+++ b/examples/sample-docs/yaml/SPDXYAMLExample-2.3.spdx.yaml
@@ -26,6 +26,9 @@ creationInfo:
   - 'Person: Jane Doe ()'
   licenseListVersion: "3.9"
 dataLicense: CC0-1.0
+documentDescribes:
+- "SPDXRef-File"
+- "SPDXRef-Package"
 documentNamespace: http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
 externalDocumentRefs:
 - checksum:

--- a/json/writer.go
+++ b/json/writer.go
@@ -6,11 +6,30 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/spdx/tools-golang/convert"
+	"github.com/spdx/tools-golang/spdx"
 	"github.com/spdx/tools-golang/spdx/common"
+	"github.com/spdx/tools-golang/spdxlib"
 )
 
 // Write takes an SPDX Document and an io.Writer, and writes the document to the writer in JSON format.
 func Write(doc common.AnyDocument, w io.Writer) error {
+	var targetDoc spdx.Document
+	err := convert.Document(doc, &targetDoc)
+	if err != nil {
+		return err
+	}
+
+	err = spdxlib.PopulateJsonSchemaFields(&targetDoc)
+	if err != nil {
+		return err
+	}
+
+	err = convert.Document(&targetDoc, doc)
+	if err != nil {
+		return err
+	}
+
 	buf, err := json.Marshal(doc)
 	if err != nil {
 		return err

--- a/spdx/v2/v2_2/document.go
+++ b/spdx/v2/v2_2/document.go
@@ -4,7 +4,7 @@
 package v2_2
 
 import (
-	"github.com/anchore/go-struct-converter"
+	converter "github.com/anchore/go-struct-converter"
 
 	"github.com/spdx/tools-golang/spdx/v2/common"
 )
@@ -69,6 +69,10 @@ type Document struct {
 
 	// DEPRECATED in version 2.0 of spec
 	Reviews []*Review `json:"-"`
+
+	// DocumentDescribes is part of JSON spec to list relationships.
+	// This field should ONLY be used when exporting an SPDX document
+	DocumentDescribesJSON []string `json:"documentDescribes,omitempty"`
 }
 
 func (d *Document) ConvertFrom(_ interface{}) error {

--- a/spdx/v2/v2_2/example/example.go
+++ b/spdx/v2/v2_2/example/example.go
@@ -19,6 +19,16 @@ func Copy() spdx.Document {
 	return out
 }
 
+// TvCopy provides a deep copy of the example for TV format (minus JSON schema fields)
+func TvCopy() spdx.Document {
+	out := spdx.Document{}
+	err := converter.Convert(example, &out)
+	if err != nil {
+		panic(fmt.Errorf("unable to convert example doc: %w", err))
+	}
+	return out
+}
+
 // Example is handwritten translation of an official example SPDX document into a Go struct.
 // We expect that the result of parsing the official document should be this value.
 // We expect that the result of writing this struct should match the official example document.
@@ -409,5 +419,9 @@ var example = spdx.Document{
 			RefB:         common.MakeDocElementID("", "fromDoap-0"),
 			Relationship: "GENERATED_FROM",
 		},
+	},
+	DocumentDescribesJSON: []string{
+		common.RenderDocElementID(common.MakeDocElementID("", "File")),
+		common.RenderDocElementID(common.MakeDocElementID("", "Package")),
 	},
 }

--- a/spdx/v2/v2_2/json/json_test.go
+++ b/spdx/v2/v2_2/json/json_test.go
@@ -31,7 +31,7 @@ func TestLoad(t *testing.T) {
 	}
 
 	if !cmp.Equal(want, got) {
-		t.Errorf("got incorrect struct after parsing YAML example: %s", cmp.Diff(want, got))
+		t.Errorf("got incorrect struct after parsing JSON example: %s", cmp.Diff(want, got))
 		return
 	}
 }

--- a/spdx/v2/v2_2/yaml/yaml_test.go
+++ b/spdx/v2/v2_2/yaml/yaml_test.go
@@ -40,7 +40,7 @@ func Test_Write(t *testing.T) {
 	want := example.Copy()
 
 	w := &bytes.Buffer{}
-	if err := yaml.Write(want, w); err != nil {
+	if err := yaml.Write(&want, w); err != nil {
 		t.Errorf("Save() error = %v", err.Error())
 		return
 	}

--- a/spdx/v2/v2_3/document.go
+++ b/spdx/v2/v2_3/document.go
@@ -4,7 +4,7 @@
 package v2_3
 
 import (
-	"github.com/anchore/go-struct-converter"
+	converter "github.com/anchore/go-struct-converter"
 
 	"github.com/spdx/tools-golang/spdx/v2/common"
 )
@@ -68,6 +68,10 @@ type Document struct {
 
 	// DEPRECATED in version 2.0 of spec
 	Reviews []*Review `json:"-" yaml:"-"`
+
+	// DocumentDescribes is part of JSON spec to list relationships.
+	// This field should ONLY be used when exporting an SPDX document
+	DocumentDescribesJSON []string `json:"documentDescribes,omitempty"`
 }
 
 func (d *Document) ConvertFrom(_ interface{}) error {

--- a/spdx/v2/v2_3/example/example.go
+++ b/spdx/v2/v2_3/example/example.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spdx/tools-golang/spdx/v2/common"
 	spdx "github.com/spdx/tools-golang/spdx/v2/v2_3"
+	"github.com/spdx/tools-golang/spdxlib"
 )
 
 // Copy provides a deep copy of the example
@@ -16,6 +17,21 @@ func Copy() spdx.Document {
 	if err != nil {
 		panic(fmt.Errorf("unable to convert example doc: %w", err))
 	}
+	return out
+}
+
+// TvCopy provides a deep copy of the example for TV format (minus JSON schema fields)
+func TvCopy() spdx.Document {
+	out := spdx.Document{}
+	err := converter.Convert(example, &out)
+	if err != nil {
+		panic(fmt.Errorf("unable to convert example doc: %w", err))
+	}
+	err = spdxlib.StripJsonSchemaFields(&out)
+	if err != nil {
+		panic(fmt.Errorf("unable to strip JSON fields: %w", err))
+	}
+
 	return out
 }
 
@@ -426,6 +442,10 @@ var example = spdx.Document{
 			RefB:         common.MakeDocElementID("", "fromDoap-0"),
 			Relationship: "GENERATED_FROM",
 		},
+	},
+	DocumentDescribesJSON: []string{
+		common.RenderDocElementID(common.MakeDocElementID("", "File")),
+		common.RenderDocElementID(common.MakeDocElementID("", "Package")),
 	},
 	// omitted: Reviews: []*spdx.Review{
 	//	{

--- a/spdx/v2/v2_3/tagvalue/tagvalue_test.go
+++ b/spdx/v2/v2_3/tagvalue/tagvalue_test.go
@@ -22,7 +22,7 @@ var update = *flag.Bool("update-snapshots", false, "update the example snapshot"
 func Test_Read(t *testing.T) {
 	fileName := "../../../../examples/sample-docs/tv/SPDXTagExample-v2.3.spdx"
 
-	want := example.Copy()
+	want := example.TvCopy()
 
 	if update {
 		f, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
@@ -61,7 +61,7 @@ func Test_Read(t *testing.T) {
 }
 
 func Test_ReadWrite(t *testing.T) {
-	want := example.Copy()
+	want := example.TvCopy()
 
 	w := &bytes.Buffer{}
 	// get a copy of the handwritten struct so we don't mutate it on accident

--- a/spdxlib/documents.go
+++ b/spdxlib/documents.go
@@ -37,3 +37,32 @@ func ValidateDocument(doc *spdx.Document) error {
 
 	return nil
 }
+
+// PopulateJsonSchemaFields populates the JSON schema specific fields (such as those providing a convenience fields aliasing
+// relationships (like documentDescribes that represents all identifiers identified by the document).
+func PopulateJsonSchemaFields(doc *spdx.Document) error {
+	// TODO: do the same for other similar JSON schema fields like "hasFiles"
+	documentDescribes := []string{}
+	for _, r := range doc.Relationships {
+		switch r.Relationship {
+		case common.TypeRelationshipDescribe:
+			if r.RefA.ElementRefID == doc.SPDXIdentifier {
+				documentDescribes = append(documentDescribes, common.RenderDocElementID(r.RefB))
+			}
+		case common.TypeRelationshipDescribeBy:
+			if r.RefB.ElementRefID == doc.SPDXIdentifier {
+				documentDescribes = append(documentDescribes, common.RenderDocElementID(r.RefA))
+			}
+		}
+	}
+
+	doc.DocumentDescribesJSON = documentDescribes
+
+	return nil
+}
+
+// StripJsonSchemaFields strips the JSON schema specific fields
+func StripJsonSchemaFields(doc *spdx.Document) error {
+	doc.DocumentDescribesJSON = nil
+	return nil
+}

--- a/spdxlib/documents_test.go
+++ b/spdxlib/documents_test.go
@@ -3,6 +3,7 @@
 package spdxlib
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/spdx/tools-golang/spdx"
@@ -90,5 +91,190 @@ func TestInvalidDocumentFailsValidation(t *testing.T) {
 	err := ValidateDocument(doc)
 	if err == nil {
 		t.Fatalf("expected non-nil error, got nil")
+	}
+}
+
+func TestPopulateJsonSchemaFields(t *testing.T) {
+	// set up document and some packages and relationships
+	doc := &spdx.Document{
+		SPDXVersion:    spdx.Version,
+		DataLicense:    spdx.DataLicense,
+		SPDXIdentifier: common.ElementID("DOCUMENT"),
+		CreationInfo:   &spdx.CreationInfo{},
+		Packages: []*spdx.Package{
+			{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+			{PackageName: "pkg2", PackageSPDXIdentifier: "p2"},
+			{PackageName: "pkg3", PackageSPDXIdentifier: "p3"},
+			{PackageName: "pkg4", PackageSPDXIdentifier: "p4"},
+			{PackageName: "pkg5", PackageSPDXIdentifier: "p5"},
+		},
+		Relationships: []*spdx.Relationship{
+			{
+				RefA:         common.MakeDocElementID("", "DOCUMENT"),
+				RefB:         common.MakeDocElementID("", "p1"),
+				Relationship: "DESCRIBES",
+			},
+			{
+				RefA:         common.MakeDocElementID("", "DOCUMENT"),
+				RefB:         common.MakeDocElementID("", "p5"),
+				Relationship: "DESCRIBES",
+			},
+			// inverse relationship -- should also get detected
+			{
+				RefA:         common.MakeDocElementID("", "p4"),
+				RefB:         common.MakeDocElementID("", "DOCUMENT"),
+				Relationship: "DESCRIBED_BY",
+			},
+			// different relationship
+			{
+				RefA:         common.MakeDocElementID("", "p1"),
+				RefB:         common.MakeDocElementID("", "p2"),
+				Relationship: "DEPENDS_ON",
+			},
+		},
+	}
+
+	expectedDoc := &spdx.Document{
+		SPDXVersion:    spdx.Version,
+		DataLicense:    spdx.DataLicense,
+		SPDXIdentifier: common.ElementID("DOCUMENT"),
+		CreationInfo:   &spdx.CreationInfo{},
+		Packages: []*spdx.Package{
+			{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+			{PackageName: "pkg2", PackageSPDXIdentifier: "p2"},
+			{PackageName: "pkg3", PackageSPDXIdentifier: "p3"},
+			{PackageName: "pkg4", PackageSPDXIdentifier: "p4"},
+			{PackageName: "pkg5", PackageSPDXIdentifier: "p5"},
+		},
+		Relationships: []*spdx.Relationship{
+			{
+				RefA:         common.MakeDocElementID("", "DOCUMENT"),
+				RefB:         common.MakeDocElementID("", "p1"),
+				Relationship: "DESCRIBES",
+			},
+			{
+				RefA:         common.MakeDocElementID("", "DOCUMENT"),
+				RefB:         common.MakeDocElementID("", "p5"),
+				Relationship: "DESCRIBES",
+			},
+			// inverse relationship -- should also get detected
+			{
+				RefA:         common.MakeDocElementID("", "p4"),
+				RefB:         common.MakeDocElementID("", "DOCUMENT"),
+				Relationship: "DESCRIBED_BY",
+			},
+			// different relationship
+			{
+				RefA:         common.MakeDocElementID("", "p1"),
+				RefB:         common.MakeDocElementID("", "p2"),
+				Relationship: "DEPENDS_ON",
+			},
+		},
+		DocumentDescribesJSON: []string{
+			common.RenderDocElementID(common.MakeDocElementID("", "p1")),
+			common.RenderDocElementID(common.MakeDocElementID("", "p5")),
+			common.RenderDocElementID(common.MakeDocElementID("", "p4")),
+		},
+	}
+
+	err := PopulateJsonSchemaFields(doc)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %s", err.Error())
+	}
+
+	if !reflect.DeepEqual(doc, expectedDoc) {
+		t.Fatalf("expected %v, got %v", expectedDoc, doc)
+	}
+}
+
+func TestStripJsonSchemaFields(t *testing.T) {
+	doc := &spdx.Document{
+		SPDXVersion:    spdx.Version,
+		DataLicense:    spdx.DataLicense,
+		SPDXIdentifier: common.ElementID("DOCUMENT"),
+		CreationInfo:   &spdx.CreationInfo{},
+		Packages: []*spdx.Package{
+			{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+			{PackageName: "pkg2", PackageSPDXIdentifier: "p2"},
+			{PackageName: "pkg3", PackageSPDXIdentifier: "p3"},
+			{PackageName: "pkg4", PackageSPDXIdentifier: "p4"},
+			{PackageName: "pkg5", PackageSPDXIdentifier: "p5"},
+		},
+		Relationships: []*spdx.Relationship{
+			{
+				RefA:         common.MakeDocElementID("", "DOCUMENT"),
+				RefB:         common.MakeDocElementID("", "p1"),
+				Relationship: "DESCRIBES",
+			},
+			{
+				RefA:         common.MakeDocElementID("", "DOCUMENT"),
+				RefB:         common.MakeDocElementID("", "p5"),
+				Relationship: "DESCRIBES",
+			},
+			// inverse relationship -- should also get detected
+			{
+				RefA:         common.MakeDocElementID("", "p4"),
+				RefB:         common.MakeDocElementID("", "DOCUMENT"),
+				Relationship: "DESCRIBED_BY",
+			},
+			// different relationship
+			{
+				RefA:         common.MakeDocElementID("", "p1"),
+				RefB:         common.MakeDocElementID("", "p2"),
+				Relationship: "DEPENDS_ON",
+			},
+		},
+		DocumentDescribesJSON: []string{
+			common.RenderDocElementID(common.MakeDocElementID("", "p1")),
+			common.RenderDocElementID(common.MakeDocElementID("", "p5")),
+			common.RenderDocElementID(common.MakeDocElementID("", "p4")),
+		},
+	}
+
+	// set up document and some packages and relationships
+	expectedDoc := &spdx.Document{
+		SPDXVersion:    spdx.Version,
+		DataLicense:    spdx.DataLicense,
+		SPDXIdentifier: common.ElementID("DOCUMENT"),
+		CreationInfo:   &spdx.CreationInfo{},
+		Packages: []*spdx.Package{
+			{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+			{PackageName: "pkg2", PackageSPDXIdentifier: "p2"},
+			{PackageName: "pkg3", PackageSPDXIdentifier: "p3"},
+			{PackageName: "pkg4", PackageSPDXIdentifier: "p4"},
+			{PackageName: "pkg5", PackageSPDXIdentifier: "p5"},
+		},
+		Relationships: []*spdx.Relationship{
+			{
+				RefA:         common.MakeDocElementID("", "DOCUMENT"),
+				RefB:         common.MakeDocElementID("", "p1"),
+				Relationship: "DESCRIBES",
+			},
+			{
+				RefA:         common.MakeDocElementID("", "DOCUMENT"),
+				RefB:         common.MakeDocElementID("", "p5"),
+				Relationship: "DESCRIBES",
+			},
+			// inverse relationship -- should also get detected
+			{
+				RefA:         common.MakeDocElementID("", "p4"),
+				RefB:         common.MakeDocElementID("", "DOCUMENT"),
+				Relationship: "DESCRIBED_BY",
+			},
+			// different relationship
+			{
+				RefA:         common.MakeDocElementID("", "p1"),
+				RefB:         common.MakeDocElementID("", "p2"),
+				Relationship: "DEPENDS_ON",
+			},
+		},
+	}
+	err := StripJsonSchemaFields(doc)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %s", err.Error())
+	}
+
+	if !reflect.DeepEqual(doc, expectedDoc) {
+		t.Fatalf("expected %v, got %v", expectedDoc, doc)
 	}
 }

--- a/yaml/writer.go
+++ b/yaml/writer.go
@@ -7,11 +7,29 @@ import (
 
 	"sigs.k8s.io/yaml"
 
+	"github.com/spdx/tools-golang/convert"
+	"github.com/spdx/tools-golang/spdx"
 	"github.com/spdx/tools-golang/spdx/common"
+	"github.com/spdx/tools-golang/spdxlib"
 )
 
 // Write takes an SPDX Document and an io.Writer, and writes the document to the writer in YAML format.
 func Write(doc common.AnyDocument, w io.Writer) error {
+	var targetDoc spdx.Document
+	err := convert.Document(doc, &targetDoc)
+	if err != nil {
+		return err
+	}
+
+	err = spdxlib.PopulateJsonSchemaFields(&targetDoc)
+	if err != nil {
+		return err
+	}
+
+	err = convert.Document(&targetDoc, doc)
+	if err != nil {
+		return err
+	}
 	buf, err := yaml.Marshal(doc)
 	if err != nil {
 		return err


### PR DESCRIPTION
Addressing https://github.com/spdx/tools-golang/issues/166
- Update json document examples for 2.2 and 2.3 to include documentDescribes as updated in upstream schema.
- Add field DocumentDescribesJSON field to document struct for 2.2 and 2.3 to match JSON schema
- Implement populating of documentDescribes field based on relationships
- Added TODO to do this for all similar fields like documentDescribes

Drive-bys:
- fix small bug in sdpx/v2/v2_2/yaml test
