### PR TITLE
Improve SPDX document validation

### DIFF
--- a/spdx/model.go
+++ b/spdx/model.go
@@ -64,7 +64,7 @@ const (
 
 const (
 	// F.2 Security types
-	CatagorySecurity  = common.CategorySecurity
+	CategorySecurity  = common.CategorySecurity
 	SecurityCPE23Type = common.TypeSecurityCPE23Type
 	SecurityCPE22Type = common.TypeSecurityCPE22Type
 	SecurityAdvisory  = common.TypeSecurityAdvisory

--- a/spdxlib/documents_test.go
+++ b/spdxlib/documents_test.go
@@ -23,6 +23,9 @@ func TestValidDocumentPassesValidation(t *testing.T) {
 			{PackageName: "pkg4", PackageSPDXIdentifier: "p4"},
 			{PackageName: "pkg5", PackageSPDXIdentifier: "p5"},
 		},
+		Files: []*spdx.File{
+			{FileName: "file1", FileSPDXIdentifier: "f1"},
+		},
 		Relationships: []*spdx.Relationship{
 			{
 				RefA:         common.MakeDocElementID("", "DOCUMENT"),
@@ -88,6 +91,26 @@ func TestInvalidDocumentFailsValidation(t *testing.T) {
 	}
 
 	err := ValidateDocument(doc)
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+
+	doc = &spdx.Document{
+		SPDXVersion:    spdx.Version,
+		DataLicense:    spdx.DataLicense,
+		SPDXIdentifier: common.ElementID("DOCUMENT"),
+		CreationInfo:   &spdx.CreationInfo{},
+
+		Relationships: []*spdx.Relationship{
+			{
+				RefA:         common.MakeDocElementID("", "p1"),
+				RefB:         common.MakeDocElementID("", "p99"),
+				Relationship: "DEPENDS_ON",
+			},
+		},
+	}
+
+	err = ValidateDocument(doc)
 	if err == nil {
 		t.Fatalf("expected non-nil error, got nil")
 	}


### PR DESCRIPTION
- Update the `CatagorySecurity` to `CategorySecurity` in `model.go`
- Add `file1` to the list of files in `documents_test.go` to increase coverage
- Add a validation test for an invalid document with an invalid relationship in `documents_test.go`

[spdx/model.go]
- Change `CatagorySecurity` to `CategorySecurity` [spdxlib/documents_test.go]
- Add `file1` to the list of files
- Change the relationship between `p1` and `p99` to `DEPENDS_ON`
- Add a validation test for an invalid document with an invalid relationship