### PR TITLE
feat: normalize external reference category when reading JSON and YAML

### DIFF
--- a/spdx/v2/v2_2/example/example.go
+++ b/spdx/v2/v2_2/example/example.go
@@ -203,7 +203,7 @@ var example = spdx.Document{
 			PackageDownloadLocation: "https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz",
 			PackageExternalReferences: []*spdx.PackageExternalReference{
 				{
-					Category: "PACKAGE_MANAGER",
+					Category: "PACKAGE-MANAGER",
 					RefType:  "purl",
 					Locator:  "pkg:maven/org.apache.jena/apache-jena@3.12.0",
 				},

--- a/spdx/v2/v2_2/package.go
+++ b/spdx/v2/v2_2/package.go
@@ -4,6 +4,7 @@ package v2_2
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/spdx/tools-golang/spdx/v2/common"
 )
@@ -164,3 +165,20 @@ type PackageExternalReference struct {
 	// Cardinality: conditional (optional, one) for each External Reference
 	ExternalRefComment string `json:"comment,omitempty"`
 }
+
+func (r *PackageExternalReference) UnmarshalJSON(b []byte) error {
+	type ref PackageExternalReference
+
+	var r2 ref
+	if err := json.Unmarshal(b, &r2); err != nil {
+		return err
+	}
+
+	r2.Category = strings.ReplaceAll(r2.Category, "_", "-")
+
+	*r = PackageExternalReference(r2)
+
+	return nil
+}
+
+var _ json.Unmarshaler = (*PackageExternalReference)(nil)

--- a/spdx/v2/v2_3/package.go
+++ b/spdx/v2/v2_3/package.go
@@ -4,6 +4,7 @@ package v2_3
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/spdx/tools-golang/spdx/v2/common"
 )
@@ -167,7 +168,7 @@ var _ json.Unmarshaler = (*Package)(nil)
 // PackageExternalReference is an External Reference to additional info
 // about a Package, as defined in section 7.21
 type PackageExternalReference struct {
-	// category is "SECURITY", "PACKAGE-MANAGER" or "OTHER"
+	// category is "SECURITY", "PACKAGE-MANAGER", "PERSISTENT-ID" or "OTHER"
 	Category string `json:"referenceCategory"`
 
 	// type is an [idstring] as defined in Appendix VI;
@@ -182,3 +183,20 @@ type PackageExternalReference struct {
 	// Cardinality: conditional (optional, one) for each External Reference
 	ExternalRefComment string `json:"comment,omitempty"`
 }
+
+func (r *PackageExternalReference) UnmarshalJSON(b []byte) error {
+	type ref PackageExternalReference
+
+	var r2 ref
+	if err := json.Unmarshal(b, &r2); err != nil {
+		return err
+	}
+
+	r2.Category = strings.ReplaceAll(r2.Category, "_", "-")
+
+	*r = PackageExternalReference(r2)
+
+	return nil
+}
+
+var _ json.Unmarshaler = (*PackageExternalReference)(nil)


### PR DESCRIPTION
This PR normalizes the `referenceCategory` for external references when reading JSON and YAML to read the alternate values with underscores, like `PERSISTENT_ID` and `PACKAGE_MANAGER` and translate these [to the values in the SPDX spec](https://spdx.github.io/spdx-spec/v2.3/package-information/#7211-description), which instead have dashes: `PERSISTENT-ID` and `PACKAGE-MANAGER`, respectively. This allows tools reading and writing SPDX to simply use the spec values with dashes.

Fixes #196 