### PR TITLE
Fixing some optional params: copyrightText, licenseListVersion, packageVerificationCode

### DIFF
--- a/spdx/v2/v2_1/creation_info.go
+++ b/spdx/v2/v2_1/creation_info.go
@@ -11,7 +11,7 @@ import (
 type CreationInfo struct {
 	// 2.7: License List Version
 	// Cardinality: optional, one
-	LicenseListVersion string `json:"licenseListVersion"`
+	LicenseListVersion string `json:"licenseListVersion,omitempty"`
 
 	// 2.8: Creators: may have multiple keys for Person, Organization
 	//      and/or Tool

--- a/spdx/v2/v2_1/package.go
+++ b/spdx/v2/v2_1/package.go
@@ -45,7 +45,7 @@ type Package struct {
 	IsFilesAnalyzedTagPresent bool `json:"-"`
 
 	// 3.9: Package Verification Code
-	PackageVerificationCode common.PackageVerificationCode `json:"packageVerificationCode"`
+	PackageVerificationCode common.PackageVerificationCode `json:"packageVerificationCode,omitempty"`
 
 	// 3.10: Package Checksum: may have keys for SHA1, SHA256 and/or MD5
 	// Cardinality: optional, one or many

--- a/spdx/v2/v2_2/creation_info.go
+++ b/spdx/v2/v2_2/creation_info.go
@@ -11,7 +11,7 @@ import (
 type CreationInfo struct {
 	// 6.7: License List Version
 	// Cardinality: optional, one
-	LicenseListVersion string `json:"licenseListVersion"`
+	LicenseListVersion string `json:"licenseListVersion,omitempty"`
 
 	// 6.8: Creators: may have multiple keys for Person, Organization
 	//      and/or Tool

--- a/spdx/v2/v2_2/package.go
+++ b/spdx/v2/v2_2/package.go
@@ -53,7 +53,7 @@ type Package struct {
 	IsFilesAnalyzedTagPresent bool `json:"-"`
 
 	// 7.9: Package Verification Code
-	PackageVerificationCode common.PackageVerificationCode `json:"packageVerificationCode"`
+	PackageVerificationCode common.PackageVerificationCode `json:"packageVerificationCode,omitempty"`
 
 	// 7.10: Package Checksum: may have keys for SHA1, SHA256, SHA512 and/or MD5
 	// Cardinality: optional, one or many

--- a/spdx/v2/v2_3/creation_info.go
+++ b/spdx/v2/v2_3/creation_info.go
@@ -10,7 +10,7 @@ import (
 type CreationInfo struct {
 	// 6.7: License List Version
 	// Cardinality: optional, one
-	LicenseListVersion string `json:"licenseListVersion"`
+	LicenseListVersion string `json:"licenseListVersion,omitempty"`
 
 	// 6.8: Creators: may have multiple keys for Person, Organization
 	//      and/or Tool

--- a/spdx/v2/v2_3/package.go
+++ b/spdx/v2/v2_3/package.go
@@ -86,8 +86,8 @@ type Package struct {
 	PackageLicenseComments string `json:"licenseComments,omitempty"`
 
 	// 7.17: Copyright Text: copyright notice(s) text, "NONE" or "NOASSERTION"
-	// Cardinality: mandatory, one
-	PackageCopyrightText string `json:"copyrightText"`
+	// Cardinality: optional, zero or one
+	PackageCopyrightText string `json:"copyrightText,omitempty"`
 
 	// 7.18: Package Summary Description
 	// Cardinality: optional, one


### PR DESCRIPTION
- Package copyrightText field (optional starting in 2.3 - PR includes change)
  - 2.3: https://spdx.github.io/spdx-spec/v2.3/package-information/#717-copyright-text-field

- LicenseListFIeld field (optional  - PR includes change)
  - 2.3: https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#67-license-list-version-field
  - 2.2: https://spdx.github.io/spdx-spec/v2.2.2/document-creation-information/#67-license-list-version-field
  - 2.1: Clause 2.7 in https://spdx.dev/spdx-specification-21-web-version/

- packageVerificationCode, looks like this is the same for 2.2 and 2.1 as it is for 2.3, 2.1 and 2.2 need to be updated (PR includes change)
