### PR TITLE
fix duplicate shorthand relationships for opposite case

### DIFF
--- a/spdx/v2/v2_2/document.go
+++ b/spdx/v2/v2_2/document.go
@@ -101,7 +101,23 @@ func (d *Document) UnmarshalJSON(b []byte) error {
 
 	relationshipExists := map[string]bool{}
 	serializeRel := func(r *Relationship) string {
-		return fmt.Sprintf("%v-%v->%v", common.RenderDocElementID(r.RefA), r.Relationship, common.RenderDocElementID(r.RefB))
+		refA := r.RefA
+		refB := r.RefB
+		rel := r.Relationship
+
+		// we need to serialize the opposite for CONTAINED_BY and DESCRIBED_BY
+		// so that it will match when we try to de-duplicate during deserialization.
+		switch r.Relationship {
+		case common.TypeRelationshipContainedBy:
+			rel = common.TypeRelationshipContains
+			refA = r.RefB
+			refB = r.RefA
+		case common.TypeRelationshipDescribeBy:
+			rel = common.TypeRelationshipDescribe
+			refA = r.RefB
+			refB = r.RefA
+		}
+		return fmt.Sprintf("%v-%v->%v", common.RenderDocElementID(refA), rel, common.RenderDocElementID(refB))
 	}
 
 	// index current list of relationships to ensure no duplication

--- a/spdx/v2/v2_2/json/json_test.go
+++ b/spdx/v2/v2_2/json/json_test.go
@@ -227,9 +227,9 @@ func Test_ShorthandFieldsNoDuplicates(t *testing.T) {
 		   "relatedSpdxElement": "SPDXRef-File-1"
 		  },
 		  {
-		   "spdxElementId": "SPDXRef-Package-1",
-		   "relationshipType": "CONTAINS",
-		   "relatedSpdxElement": "SPDXRef-File-2"
+		   "spdxElementId": "SPDXRef-File-2",
+		   "relationshipType": "CONTAINED_BY",
+		   "relatedSpdxElement": "SPDXRef-Package-1"
 		  }
 		]
 	}`
@@ -291,9 +291,9 @@ func Test_ShorthandFieldsNoDuplicates(t *testing.T) {
 				Relationship: common.TypeRelationshipContains,
 			},
 			{
-				RefA:         id("Package-1"),
-				RefB:         id("File-2"),
-				Relationship: common.TypeRelationshipContains,
+				RefA:         id("File-2"),
+				RefB:         id("Package-1"),
+				Relationship: common.TypeRelationshipContainedBy,
 			},
 		},
 	}

--- a/spdx/v2/v2_3/document.go
+++ b/spdx/v2/v2_3/document.go
@@ -100,7 +100,23 @@ func (d *Document) UnmarshalJSON(b []byte) error {
 
 	relationshipExists := map[string]bool{}
 	serializeRel := func(r *Relationship) string {
-		return fmt.Sprintf("%v-%v->%v", common.RenderDocElementID(r.RefA), r.Relationship, common.RenderDocElementID(r.RefB))
+		refA := r.RefA
+		refB := r.RefB
+		rel := r.Relationship
+
+		// we need to serialize the opposite for CONTAINED_BY and DESCRIBED_BY
+		// so that it will match when we try to de-duplicate during deserialization.
+		switch r.Relationship {
+		case common.TypeRelationshipContainedBy:
+			rel = common.TypeRelationshipContains
+			refA = r.RefB
+			refB = r.RefA
+		case common.TypeRelationshipDescribeBy:
+			rel = common.TypeRelationshipDescribe
+			refA = r.RefB
+			refB = r.RefA
+		}
+		return fmt.Sprintf("%v-%v->%v", common.RenderDocElementID(refA), rel, common.RenderDocElementID(refB))
 	}
 
 	// index current list of relationships to ensure no duplication

--- a/spdx/v2/v2_3/json/json_test.go
+++ b/spdx/v2/v2_3/json/json_test.go
@@ -245,9 +245,9 @@ func Test_ShorthandFieldsNoDuplicates(t *testing.T) {
 		   "relatedSpdxElement": "SPDXRef-File-1"
 		  },
 		  {
-		   "spdxElementId": "SPDXRef-Package-1",
-		   "relationshipType": "CONTAINS",
-		   "relatedSpdxElement": "SPDXRef-File-2"
+		   "spdxElementId": "SPDXRef-File-2",
+		   "relationshipType": "CONTAINED_BY",
+		   "relatedSpdxElement": "SPDXRef-Package-1"
 		  }
 		]
 	}`
@@ -309,9 +309,9 @@ func Test_ShorthandFieldsNoDuplicates(t *testing.T) {
 				Relationship: common.TypeRelationshipContains,
 			},
 			{
-				RefA:         id("Package-1"),
-				RefB:         id("File-2"),
-				Relationship: common.TypeRelationshipContains,
+				RefA:         id("File-2"),
+				RefB:         id("Package-1"),
+				Relationship: common.TypeRelationshipContainedBy,
 			},
 		},
 	}


### PR DESCRIPTION
Really fix #208 :). We forgot to check for the opposite relationships (e.g. CONTAINS_BY and CONTAINED_BY are both considered the same and a new CONTAINS relationship shouldn't be added by shorthand field)