### PR TITLE
feat: add external reference category "OTHER"

### DIFF
--- a/spdx/model.go
+++ b/spdx/model.go
@@ -85,6 +85,9 @@ const (
 	TypePersistentIdSwh    = common.TypePersistentIdSwh
 	TypePersistentIdGitoid = common.TypePersistentIdGitoid
 
+	// F.5 Other
+	CategoryOther = common.CategoryOther
+
 	// 11.1 Relationship field types
 	RelationshipDescribes                 = common.TypeRelationshipDescribe
 	RelationshipDescribedBy               = common.TypeRelationshipDescribeBy

--- a/spdx/v2/common/external.go
+++ b/spdx/v2/common/external.go
@@ -21,10 +21,14 @@ const (
 	TypePackageManagerNuGet        string = "nuget"
 	TypePackageManagerBower        string = "bower"
 	TypePackageManagerPURL         string = "purl"
+
 	// F.4 Persistent-Id types
 	CategoryPersistentId   string = "PERSISTENT-ID"
 	TypePersistentIdSwh    string = "swh"
 	TypePersistentIdGitoid string = "gitoid"
+
+	// F.5 Other
+	CategoryOther string = "OTHER"
 
 	// 11.1 Relationship field types
 	TypeRelationshipDescribe                  string = "DESCRIBES"


### PR DESCRIPTION
I was missing the External Reference Category "Other" from [Annex F of the 2.3 spec (F.5)](https://spdx.github.io/spdx-spec/v2.3/external-repository-identifiers/). This adds it.