### PR TITLE
refactor(verification): don't create empty `ExcludedFiles` array

### DIFF
--- a/utils/verification.go
+++ b/utils/verification.go
@@ -44,9 +44,14 @@ func GetVerificationCode(files []*spdx.File, excludeFile string) (common.Package
 	hsha1.Write([]byte(shasConcat))
 	bs := hsha1.Sum(nil)
 
+	var excludedFiles []string
+	if excludeFile != "" {
+		excludedFiles = []string{excludeFile}
+	}
+
 	code := common.PackageVerificationCode{
 		Value:         fmt.Sprintf("%x", bs),
-		ExcludedFiles: []string{excludeFile},
+		ExcludedFiles: excludedFiles,
 	}
 
 	return code, nil


### PR DESCRIPTION
## Description
`excludeFile` for `GetVerificationCode` function is optional field.
We can avoid creating an empty array for`ExcludedFiles` if `excludeFile` is empty.

Before:
```json
      "packageVerificationCode": {
        "packageVerificationCodeValue": "a30b237d03b2e0ae8df0801c0bc0f519d2cac6c0",
        "packageVerificationCodeExcludedFiles": [
          ""
        ]
      },
```

After:
```json
      "packageVerificationCode": {
        "packageVerificationCodeValue": "a30b237d03b2e0ae8df0801c0bc0f519d2cac6c0"
      },
```