### PR TITLE
fix(windows): crash on out of bounds for root path cleanup

### DIFF
--- a/builder/build_package.go
+++ b/builder/build_package.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 
 	"github.com/spdx/tools-golang/spdx"
 	"github.com/spdx/tools-golang/spdx/v2/common"
@@ -42,7 +43,11 @@ func BuildPackageSection(packageName string, dirRoot string, pathsIgnore []strin
 	for _, fp := range filepaths {
 		newFilePatch := ""
 		if osType == "windows" {
-			newFilePatch = filepath.FromSlash("." + fp[dirRootLen:])
+			if strings.HasPrefix(fp, dirRoot) {
+				newFilePatch = filepath.FromSlash("." + fp[dirRootLen:])
+			} else {
+				newFilePatch = filepath.FromSlash("." + fp)
+			}
 		} else {
 			newFilePatch = filepath.FromSlash("./" + fp)
 		}

--- a/builder/build_package.go
+++ b/builder/build_package.go
@@ -48,6 +48,10 @@ func BuildPackageSection(packageName string, dirRoot string, pathsIgnore []strin
 			} else {
 				newFilePatch = filepath.FromSlash(".\\" + fp)
 			}
+
+			if strings.HasPrefix(".\\\\", newFilePatch) {
+				newFilePatch = fmt.Sprintf(".\\%s", newFilePatch[3:])
+			}
 		} else {
 			newFilePatch = filepath.FromSlash("./" + fp)
 		}

--- a/builder/build_package.go
+++ b/builder/build_package.go
@@ -44,9 +44,9 @@ func BuildPackageSection(packageName string, dirRoot string, pathsIgnore []strin
 		newFilePatch := ""
 		if osType == "windows" {
 			if strings.HasPrefix(fp, dirRoot) {
-				newFilePatch = filepath.FromSlash("." + fp[dirRootLen:])
+				newFilePatch = filepath.FromSlash(".\\" + fp[dirRootLen:])
 			} else {
-				newFilePatch = filepath.FromSlash("." + fp)
+				newFilePatch = filepath.FromSlash(".\\" + fp)
 			}
 		} else {
 			newFilePatch = filepath.FromSlash("./" + fp)


### PR DESCRIPTION
I am using this lib in a tool I've been contributing to. 

```go
import builder_common "github.com/spdx/tools-golang/builder"

cwd, err := os.Getwd()
if err != nil {
	return nil, err
}

...
ref := &builder.Config{
		NamespacePrefix: "https://spdx.org/spdxdocs/",
		CreatorType:     "Tool",
		Creator:         "me",
}


builder_common.Build("mypackage", cwd, ref)
```

On Linux - no issues. 
On Windows - I get out of bounds. Also, I tried running tests (without any modifications), but they fail (due to Windows path issues). 
I tried my best to test it in the given state.

Also, note that I changed `"."` to `".\\"` .
if a root path has "/" for suffix (ie. my\path\ ) this will not impose a problem ( .\\my\file.txt equals '.\my\file.txt ). having only "." is problematic for cases where the root path includes `\` and the rel path is just .file.txt and not .\file.txt

Im not a Windows Pro but this seems right
