### PR TITLE
chore: update makefile to include bootstrap and go mod tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 .PHONY: test
 test: unit fuzz
 
+.PHONY: bootstrap
+bootstrap:
+	go install github.com/rinchsan/gosimports/cmd/gosimports@v0.3.8
+
 .PHONY: format
 format:
 	gofmt -w .
+	go mod tidy
 	gosimports -w -local github.com/spdx .
 
 .PHONY: unit


### PR DESCRIPTION
While working on a new machine without some of the existing tools like `gosimports`, and when I looked at bumping the go version, there was a friction running `make format`, this just updates the Makefile to be slightly more convenient.