### PR TITLE
Fix GetAllFilePaths returning paths without slash prefix

### DIFF
--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -41,6 +41,10 @@ func GetAllFilePaths(dirRoot string, pathsIgnored []string) ([]string, error) {
 
 		path = filepath.ToSlash(path)
 		shortPath := strings.TrimPrefix(path, prefix)
+		if !strings.HasPrefix(shortPath, "/") {
+			//This happens if the dirRoot is "."
+			shortPath = "/" + shortPath
+		}
 
 		// don't include path if it should be ignored
 		if pathsIgnored != nil && ShouldIgnore(shortPath, pathsIgnored) {

--- a/utils/filesystem_test.go
+++ b/utils/filesystem_test.go
@@ -42,6 +42,40 @@ func TestFilesystemCanGetSliceOfFolderContents(t *testing.T) {
 	}
 }
 
+func TestFilesystemCanGetSliceOfFolderContentsFromRelativeDir(t *testing.T) {
+	t.Chdir("../testdata/project1/")
+
+	filePaths, err := GetAllFilePaths(".", nil)
+	if err != nil {
+		t.Fatalf("expected filePaths, got error: %v", err)
+	}
+	if filePaths == nil {
+		t.Fatalf("expected non-nil filePaths, got nil")
+	}
+	// should only be 5 files
+	// symbolic link in project1/symbolic-link should be ignored
+	if len(filePaths) != 5 {
+		t.Fatalf("expected %v, got %v", 5, len(filePaths))
+	}
+
+	// should be in alphabetical order, with files prefixed with '/'
+	if filePaths[0] != "/emptyfile.testdata.txt" {
+		t.Errorf("expected %v, got %v", "/emptyfile.testdata.txt", filePaths[0])
+	}
+	if filePaths[1] != "/file1.testdata.txt" {
+		t.Errorf("expected %v, got %v", "/file1.testdata.txt", filePaths[1])
+	}
+	if filePaths[2] != "/file3.testdata.txt" {
+		t.Errorf("expected %v, got %v", "/file3.testdata.txt", filePaths[2])
+	}
+	if filePaths[3] != "/folder1/file4.testdata.txt" {
+		t.Errorf("expected %v, got %v", "/folder1/file4.testdata.txt", filePaths[3])
+	}
+	if filePaths[4] != "/lastfile.testdata.txt" {
+		t.Errorf("expected %v, got %v", "/lastfile.testdata.txt", filePaths[4])
+	}
+}
+
 func TestFilesystemGetAllFilePathsFailsForNonExistentDirectory(t *testing.T) {
 	dirRoot := "./does/not/exist/"
 


### PR DESCRIPTION
This PR should fix https://github.com/spdx/tools-golang/issues/262