### PR TITLE
fix: Fix prefixDocumentId() to use correct prefix

### DIFF
--- a/spdx/v2/common/identifier.go
+++ b/spdx/v2/common/identifier.go
@@ -37,7 +37,7 @@ func (d *DocumentID) UnmarshalJSON(data []byte) error {
 // prefixDocumentId adds the DocumentRef- prefix to an document ID if it does not have one
 func prefixDocumentId(id DocumentID) string {
 	val := string(id)
-	if !strings.HasPrefix(val, spdxRefPrefix) {
+	if !strings.HasPrefix(val, documentRefPrefix) {
 		return documentRefPrefix + val
 	}
 	return val

--- a/spdx/v2/common/identifier_test.go
+++ b/spdx/v2/common/identifier_test.go
@@ -323,3 +323,174 @@ func Test_ElementIDStructDecoding(t *testing.T) {
 		})
 	}
 }
+
+func Test_DocumentIDEncoding(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    DocumentID
+		expected string
+		err      bool
+	}{
+		{
+			name:     "appends documentref",
+			value:    DocumentID("some-id"),
+			expected: "DocumentRef-some-id",
+		},
+		{
+			name:     "appends documentref",
+			value:    DocumentID("DocumentRef-some-id"),
+			expected: "DocumentRef-some-id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := marshal.JSON(test.value)
+			switch {
+			case !test.err && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			case test.err && err == nil:
+				t.Fatalf("expected error but got none")
+			case test.err:
+				return
+			}
+			s := string(result)
+			if !strings.HasPrefix(s, `"`) || !strings.HasSuffix(s, `"`) {
+				t.Fatalf("string was not returned: %s", s)
+			}
+			s = strings.Trim(s, `"`)
+			if test.expected != s {
+				t.Fatalf("%s != %s", test.expected, s)
+			}
+		})
+	}
+}
+
+func Test_DocumentIDDecoding(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected DocumentID
+		err      bool
+	}{
+		{
+			name:     "valid id",
+			value:    "DocumentRef-some-id",
+			expected: DocumentID("some-id"),
+		},
+		{
+			name:  "without prefix",
+			value: "some-id-without-documentref",
+			expected: DocumentID("some-id-without-documentref"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var out DocumentID
+			s := fmt.Sprintf(`"%s"`, test.value)
+			err := json.Unmarshal([]byte(s), &out)
+			switch {
+			case !test.err && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			case test.err && err == nil:
+				t.Fatalf("expected error but got none")
+			case test.err:
+				return
+			}
+			if !reflect.DeepEqual(test.expected, out) {
+				t.Fatalf("unexpected value: %v != %v", test.expected, out)
+			}
+		})
+	}
+}
+
+func Test_DocumentIDStructEncoding(t *testing.T) {
+	type typ struct {
+		Id DocumentID `json:"id"`
+	}
+	tests := []struct {
+		name     string
+		value    typ
+		expected string
+		err      bool
+	}{
+		{
+			name: "appends spdxref",
+			value: typ{
+				Id: DocumentID("some-id"),
+			},
+			expected: `{"id":"DocumentRef-some-id"}`,
+		},
+		{
+			name: "appends spdxref",
+			value: typ{
+				Id: DocumentID("DocumentRef-some-id"),
+			},
+			expected: `{"id":"DocumentRef-some-id"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := marshal.JSON(test.value)
+			switch {
+			case !test.err && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			case test.err && err == nil:
+				t.Fatalf("expected error but got none")
+			case test.err:
+				return
+			}
+			s := string(result)
+			if test.expected != s {
+				t.Fatalf("%s != %s", test.expected, s)
+			}
+		})
+	}
+}
+
+func Test_DocumentIDStructDecoding(t *testing.T) {
+	type typ struct {
+		Id DocumentID `json:"id"`
+	}
+	tests := []struct {
+		name     string
+		value    string
+		expected typ
+		err      bool
+	}{
+		{
+			name: "valid id",
+			expected: typ{
+				Id: DocumentID("some-id"),
+			},
+			value: `{"id":"DocumentRef-some-id"}`,
+		},
+		{
+			name:  "without prefix",
+			expected: typ{
+				Id: DocumentID("some-id"),
+			},
+			value: `{"id":"some-id"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := typ{}
+			err := json.Unmarshal([]byte(test.value), &out)
+			switch {
+			case !test.err && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			case test.err && err == nil:
+				t.Fatalf("expected error but got none")
+			case test.err:
+				return
+			}
+			if !reflect.DeepEqual(test.expected, out) {
+				t.Fatalf("unexpected value: %v != %v", test.expected, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
prefixDocumentId() uses "spdxRefPrefix" in its prefix check.
But that was wrong. "documentRefPrefix" is the correct one.

And, Tests for DocumentID itself were not implemented. So, I've implemented it.

(This was my mistake in #269 , I'm very sorry... )