### PR TITLE
Fail parsing if the required prefix isn't present for IDs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.18'
+          go-version: '1.22'
       - name: Run tests
         run: make test
       - name: Send coverage report to coveralls

--- a/spdx/v2/common/identifier.go
+++ b/spdx/v2/common/identifier.go
@@ -30,7 +30,11 @@ func (d *DocumentID) UnmarshalJSON(data []byte) error {
 	idStr := string(data)
 	idStr = strings.Trim(idStr, "\"")
 
-	*d = trimDocumentIdPrefix(idStr)
+	documentID, err := trimDocumentIdPrefix(idStr)
+	if err != nil {
+		return err
+	}
+	*d = documentID
 	return nil
 }
 
@@ -43,9 +47,14 @@ func prefixDocumentId(id DocumentID) string {
 	return val
 }
 
-// trimDocumentIdPrefix removes the DocumentRef- prefix from an document ID string
-func trimDocumentIdPrefix(id string) DocumentID {
-	return DocumentID(strings.TrimPrefix(id, documentRefPrefix))
+// trimDocumentIdPrefix removes the DocumentRef- prefix from an document ID string and
+// returns an error if the prefix isn't present or if the resulting ID is empty.
+func trimDocumentIdPrefix(id string) (DocumentID, error) {
+	idWithoutPrefix, found := strings.CutPrefix(id, documentRefPrefix)
+	if !found || idWithoutPrefix == "" {
+		return DocumentID(""), fmt.Errorf("failed to parse DocumentID: %s", id)
+	}
+	return DocumentID(idWithoutPrefix), nil
 }
 
 // ElementID represents the identifier string portion of an SPDX element
@@ -65,7 +74,11 @@ func (d *ElementID) UnmarshalJSON(data []byte) error {
 	idStr := string(data)
 	idStr = strings.Trim(idStr, "\"")
 
-	*d = trimElementIdPrefix(idStr)
+	elementID, err := trimElementIdPrefix(idStr)
+	if err != nil {
+		return err
+	}
+	*d = elementID
 	return nil
 }
 
@@ -78,9 +91,14 @@ func prefixElementId(id ElementID) string {
 	return val
 }
 
-// trimElementIdPrefix removes the SPDXRef- prefix from an element ID string
-func trimElementIdPrefix(id string) ElementID {
-	return ElementID(strings.TrimPrefix(id, spdxRefPrefix))
+// trimElementIdPrefix removes the SPDXRef- prefix from an element ID string and
+// returns an error if the prefix isn't present or if the resulting ID is empty.
+func trimElementIdPrefix(id string) (ElementID, error) {
+	idWithoutPrefix, found := strings.CutPrefix(id, spdxRefPrefix)
+	if !found || idWithoutPrefix == "" {
+		return ElementID(""), fmt.Errorf("failed to parse ElementID: %s", id)
+	}
+	return ElementID(idWithoutPrefix), nil
 }
 
 // DocElementID represents an SPDX element identifier that could be defined
@@ -138,7 +156,11 @@ func (d *DocElementID) UnmarshalJSON(data []byte) error {
 		// an SPDXRef can appear after a DocumentRef, separated by a colon
 		idFields = strings.SplitN(idStr, ":", 2)
 
-		d.DocumentRefID = trimDocumentIdPrefix(idFields[0])
+		documentRefID, err := trimDocumentIdPrefix(idFields[0])
+		if err != nil {
+			return err
+		}
+		d.DocumentRefID = documentRefID
 		if len(idFields) == 2 {
 			idStr = idFields[1]
 		} else {
@@ -146,7 +168,11 @@ func (d *DocElementID) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	d.ElementRefID = trimElementIdPrefix(idStr)
+	elementRefID, err := trimElementIdPrefix(idStr)
+	if err != nil {
+		return err
+	}
+	d.ElementRefID = elementRefID
 	return nil
 }
 

--- a/spdx/v2/common/identifier_test.go
+++ b/spdx/v2/common/identifier_test.go
@@ -103,19 +103,24 @@ func Test_DocElementIDDecoding(t *testing.T) {
 			},
 		},
 		{
+			name:  "DocumentRef with empty suffix",
+			value: "DocumentRef-",
+			err:   true,
+		},
+		{
 			name:  "DocumentRefID:ElementRefID without spdxref prefix",
 			value: "DocumentRef-a-doc:some-id",
-			expected: DocElementID{
-				DocumentRefID: "a-doc",
-				ElementRefID:  "some-id",
-			},
+			err:   true,
+		},
+		{
+			name:  "DocumentRefID:ElementRefID with empty ElementRefID suffix",
+			value: "DocumentRef-a-doc:SPDXRef-",
+			err:   true,
 		},
 		{
 			name:  "without spdxref prefix",
 			value: "some-id-without-spdxref",
-			expected: DocElementID{
-				ElementRefID: "some-id-without-spdxref",
-			},
+			err:   true,
 		},
 		{
 			name:  "SpecialID NONE",
@@ -208,9 +213,14 @@ func Test_ElementIDDecoding(t *testing.T) {
 			expected: ElementID("some-id"),
 		},
 		{
+			name:  "empty id suffix",
+			value: "SPDXRef-",
+			err:   true,
+		},
+		{
 			name:  "without prefix",
 			value: "some-id-without-spdxref",
-			expected: ElementID("some-id-without-spdxref"),
+			err:   true,
 		},
 	}
 
@@ -298,10 +308,8 @@ func Test_ElementIDStructDecoding(t *testing.T) {
 		},
 		{
 			name:  "without prefix",
-			expected: typ{
-				Id: ElementID("some-id"),
-			},
 			value: `{"id":"some-id"}`,
+			err:   true,
 		},
 	}
 
@@ -379,9 +387,14 @@ func Test_DocumentIDDecoding(t *testing.T) {
 			expected: DocumentID("some-id"),
 		},
 		{
+			name:  "empty id suffix",
+			value: "DocumentRef-",
+			err:   true,
+		},
+		{
 			name:  "without prefix",
 			value: "some-id-without-documentref",
-			expected: DocumentID("some-id-without-documentref"),
+			err:   true,
 		},
 	}
 
@@ -468,11 +481,14 @@ func Test_DocumentIDStructDecoding(t *testing.T) {
 			value: `{"id":"DocumentRef-some-id"}`,
 		},
 		{
+			name:  "empty suffix",
+			value: `{"id":"DocumentRef-"}`,
+			err:   true,
+		},
+		{
 			name:  "without prefix",
-			expected: typ{
-				Id: DocumentID("some-id"),
-			},
 			value: `{"id":"some-id"}`,
+			err:   true,
 		},
 	}
 


### PR DESCRIPTION
If the `SPDXRef-` or `DocumentRef-` prefix isn't present in an ID, then fail parsing. In addition, if stripping the prefix leaves an empty ID then also fail.

This is in line with the spec:

https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#6.3
https://spdx.github.io/spdx-spec/v2.3/package-information/#7.2
https://spdx.github.io/spdx-spec/v2.3/file-information/#8.2

See https://github.com/spdx/tools-golang/issues/274 for more details about the issue being fixed.