### PR TITLE
typo: Fix license filename mentions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ of Code 2020 project.
 
 ## Licenses
 
-As indicated in `LICENSE-code`, tools-golang **source code files** are
+As indicated in `LICENSE.code`, tools-golang **source code files** are
 provided and may be used, at your option, under *either*:
 * Apache License, version 2.0 (**Apache-2.0**), **OR**
 * GNU General Public License, version 2.0 or later (**GPL-2.0-or-later**).
 
-As indicated in `LICENSE-docs`, tools-golang **documentation files** are
+As indicated in `LICENSE.docs`, tools-golang **documentation files** are
 provided and may be used under the Creative Commons Attribution
 4.0 International license (**CC-BY-4.0**).
 


### PR DESCRIPTION
- LICENSE-code --> LICENSE.code
- LICENSE-docs --> LICENSE.docs