### PR TITLE
fix(tagvalue): handle ExternalDocumentRef in CreationInfo

### DIFF
--- a/spdx/v2/v2_1/tagvalue/reader/parser.go
+++ b/spdx/v2/v2_1/tagvalue/reader/parser.go
@@ -91,6 +91,7 @@ func (parser *tvParser) parsePairFromStart(tag string, value string) error {
 			Checksum:      common.Checksum{Algorithm: common.ChecksumAlgorithm(alg), Value: checksum},
 		}
 		parser.doc.ExternalDocumentReferences = append(parser.doc.ExternalDocumentReferences, edr)
+		return nil
 	case "DocumentComment":
 		parser.doc.DocumentComment = value
 	default:

--- a/spdx/v2/v2_2/tagvalue/reader/parser.go
+++ b/spdx/v2/v2_2/tagvalue/reader/parser.go
@@ -90,6 +90,7 @@ func (parser *tvParser) parsePairFromStart(tag string, value string) error {
 			Checksum:      common.Checksum{Algorithm: common.ChecksumAlgorithm(alg), Value: checksum},
 		}
 		parser.doc.ExternalDocumentReferences = append(parser.doc.ExternalDocumentReferences, edr)
+		return nil
 	default:
 		// move to Creation Info parser state
 		parser.st = psCreationInfo

--- a/spdx/v2/v2_3/tagvalue/reader/parser.go
+++ b/spdx/v2/v2_3/tagvalue/reader/parser.go
@@ -89,6 +89,7 @@ func (parser *tvParser) parsePairFromStart(tag string, value string) error {
 			Checksum:      common.Checksum{Algorithm: common.ChecksumAlgorithm(alg), Value: checksum},
 		}
 		parser.doc.ExternalDocumentReferences = append(parser.doc.ExternalDocumentReferences, edr)
+		return nil
 	default:
 		// move to Creation Info parser state
 		parser.st = psCreationInfo

--- a/spdx/v2/v2_3/tagvalue/tagvalue_test.go
+++ b/spdx/v2/v2_3/tagvalue/tagvalue_test.go
@@ -84,6 +84,44 @@ func Test_ReadWrite(t *testing.T) {
 	}
 }
 
+// Verifies that ExternalDocumentRef entries are correctly parsed when appearing after CreationInfo.
+func TestExternalDocumentRefAfterCreationInfo(t *testing.T) {
+	input := `SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: test-doc
+DocumentNamespace: http://example.com/spdx/test-doc
+
+Creator: Organization: TestOrg
+Created: 2025-12-10T14:36:14Z
+
+ExternalDocumentRef: DocumentRef-test http://example.com/test SHA1: 1234567890abcdef1234567890abcdef12345678
+`
+
+	doc, err := tagvalue.Read(bytes.NewBufferString(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(doc.ExternalDocumentReferences) != 1 {
+		t.Fatalf("expected 1 ExternalDocumentRef, got %d", len(doc.ExternalDocumentReferences))
+	}
+
+	ref := doc.ExternalDocumentReferences[0]
+
+	if ref.DocumentRefID != "test" {
+		t.Errorf("unexpected DocumentRefID: %s", ref.DocumentRefID)
+	}
+
+	if ref.URI != "http://example.com/test" {
+		t.Errorf("unexpected URI: %s", ref.URI)
+	}
+
+	if ref.Checksum.Value != "1234567890abcdef1234567890abcdef12345678" {
+		t.Errorf("unexpected checksum: %s", ref.Checksum.Value)
+	}
+}
+
 var ignores = []cmp.Option{
 	cmpopts.IgnoreUnexported(spdx.Package{}),
 	cmpopts.IgnoreFields(spdx.Document{}, "Snippets"),

--- a/spdx/v2/v2_3/tagvalue/tagvalue_test.go
+++ b/spdx/v2/v2_3/tagvalue/tagvalue_test.go
@@ -96,8 +96,9 @@ Creator: Organization: TestOrg
 Created: 2025-12-10T14:36:14Z
 
 ExternalDocumentRef: DocumentRef-test http://example.com/test SHA1: 1234567890abcdef1234567890abcdef12345678
-`
 
+DocumentComment: This is a test
+`
 	doc, err := tagvalue.Read(bytes.NewBufferString(input))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -119,6 +120,10 @@ ExternalDocumentRef: DocumentRef-test http://example.com/test SHA1: 1234567890ab
 
 	if ref.Checksum.Value != "1234567890abcdef1234567890abcdef12345678" {
 		t.Errorf("unexpected checksum: %s", ref.Checksum.Value)
+	}
+
+	if doc.DocumentComment != "This is a test" {
+		t.Errorf("unexpected DocumentComment: %s", doc.DocumentComment)
 	}
 }
 


### PR DESCRIPTION
Fixes: #273

- Handle ExternalDocumentRef directly in CreationInfo parsing instead of delegating via state transition to psStart.
- This ensures ExternalDocumentRef entries are correctly stored in Document.ExternalDocumentReferences.
- Add unit test to verify parsing behavior.
