### PR TITLE
Fix GetAllFilePaths slash prefix issue and resolve test failures from #263

### DIFF
--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -41,6 +41,10 @@ func GetAllFilePaths(dirRoot string, pathsIgnored []string) ([]string, error) {
 
 		path = filepath.ToSlash(path)
 		shortPath := strings.TrimPrefix(path, prefix)
+		if !strings.HasPrefix(shortPath, "/") {
+			//This happens if the dirRoot is "."
+			shortPath = "/" + shortPath
+		}
 
 		// don't include path if it should be ignored
 		if pathsIgnored != nil && ShouldIgnore(shortPath, pathsIgnored) {

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -24,9 +24,14 @@ func GetAllFilePaths(dirRoot string, pathsIgnored []string) ([]string, error) {
 	// this is so that it can be appropriately modified by append
 	// in the sub-function.
 	paths := &[]string{}
+	absRoot, err := filepath.Abs(dirRoot)
+	if err != nil {
+		return nil, err
+	}
+	dirRoot = absRoot
 	prefix := strings.TrimSuffix(filepath.ToSlash(dirRoot), "/")
 
-	err := filepath.Walk(dirRoot, func(path string, fi os.FileInfo, err error) error {
+	err = filepath.Walk(dirRoot, func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -41,10 +46,7 @@ func GetAllFilePaths(dirRoot string, pathsIgnored []string) ([]string, error) {
 
 		path = filepath.ToSlash(path)
 		shortPath := strings.TrimPrefix(path, prefix)
-		if !strings.HasPrefix(shortPath, "/") {
-			//This happens if the dirRoot is "."
-			shortPath = "/" + shortPath
-		}
+		shortPath = "/" + strings.TrimPrefix(shortPath, "/")
 
 		// don't include path if it should be ignored
 		if pathsIgnored != nil && ShouldIgnore(shortPath, pathsIgnored) {

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -46,7 +46,10 @@ func GetAllFilePaths(dirRoot string, pathsIgnored []string) ([]string, error) {
 
 		path = filepath.ToSlash(path)
 		shortPath := strings.TrimPrefix(path, prefix)
-		shortPath = "/" + strings.TrimPrefix(shortPath, "/")
+
+		if !strings.HasPrefix(shortPath, "/") {
+			shortPath = "/" + shortPath
+		}
 
 		// don't include path if it should be ignored
 		if pathsIgnored != nil && ShouldIgnore(shortPath, pathsIgnored) {

--- a/utils/filesystem_test.go
+++ b/utils/filesystem_test.go
@@ -42,6 +42,40 @@ func TestFilesystemCanGetSliceOfFolderContents(t *testing.T) {
 	}
 }
 
+func TestFilesystemCanGetSliceOfFolderContentsFromRelativeDir(t *testing.T) {
+	t.Chdir("../testdata/project1/")
+
+	filePaths, err := GetAllFilePaths(".", nil)
+	if err != nil {
+		t.Fatalf("expected filePaths, got error: %v", err)
+	}
+	if filePaths == nil {
+		t.Fatalf("expected non-nil filePaths, got nil")
+	}
+	// should only be 5 files
+	// symbolic link in project1/symbolic-link should be ignored
+	if len(filePaths) != 5 {
+		t.Fatalf("expected %v, got %v", 5, len(filePaths))
+	}
+
+	// should be in alphabetical order, with files prefixed with '/'
+	if filePaths[0] != "/emptyfile.testdata.txt" {
+		t.Errorf("expected %v, got %v", "/emptyfile.testdata.txt", filePaths[0])
+	}
+	if filePaths[1] != "/file1.testdata.txt" {
+		t.Errorf("expected %v, got %v", "/file1.testdata.txt", filePaths[1])
+	}
+	if filePaths[2] != "/file3.testdata.txt" {
+		t.Errorf("expected %v, got %v", "/file3.testdata.txt", filePaths[2])
+	}
+	if filePaths[3] != "/folder1/file4.testdata.txt" {
+		t.Errorf("expected %v, got %v", "/folder1/file4.testdata.txt", filePaths[3])
+	}
+	if filePaths[4] != "/lastfile.testdata.txt" {
+		t.Errorf("expected %v, got %v", "/lastfile.testdata.txt", filePaths[4])
+	}
+}
+
 func TestFilesystemGetAllFilePathsFailsForNonExistentDirectory(t *testing.T) {
 	dirRoot := "./does/not/exist/"
 

--- a/utils/filesystem_test.go
+++ b/utils/filesystem_test.go
@@ -3,6 +3,7 @@
 package utils
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -43,7 +44,18 @@ func TestFilesystemCanGetSliceOfFolderContents(t *testing.T) {
 }
 
 func TestFilesystemCanGetSliceOfFolderContentsFromRelativeDir(t *testing.T) {
-	t.Chdir("../testdata/project1/")
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working dir: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(oldWd)
+	}()
+
+	err = os.Chdir("../testdata/project1/")
+	if err != nil {
+		t.Fatalf("failed to change dir: %v", err)
+	}
 
 	filePaths, err := GetAllFilePaths(".", nil)
 	if err != nil {


### PR DESCRIPTION
Fixes #262

Normalize dirRoot using filepath.Abs before walking the directory to ensure
consistent path prefix handling for relative inputs such as ".".

Also updates tests by replacing t.Chdir with os.Chdir for compatibility with
older Go versions while preserving behavior.

Builds upon discussion in #263 and the earlier fix proposed by @OhioDschungel6.