### PR TITLE
prototype: v3 → v2.3 package conversion (name and ID mapping)

### DIFF
--- a/spdx/v3/v3_0/convert_to_v23.go
+++ b/spdx/v3/v3_0/convert_to_v23.go
@@ -1,0 +1,49 @@
+package v3_0
+
+import (
+	"github.com/spdx/tools-golang/spdx/v2/common" 
+	"github.com/spdx/tools-golang/spdx/v2/v2_3"
+	"fmt"
+)
+
+//we want conversion from v3.0 -> v2.3 for name specifically v3.GetName -> v2PackageName
+
+// Extract Name from v3 package and place it in v2 package
+func ConvertPackageNameToV23(p AnyPackage) *v2_3.Package {
+	if p == nil {
+		return nil
+	}
+	name := p.GetName()
+	return &v2_3.Package{
+		PackageName: name,
+	}
+}
+
+//Extract V3ID -> Check mapping -> Generate NewID -> StoreMapping -> Assign To v2
+
+func ConvertPackageToV23(p AnyPackage, idMap map[string]common.ElementID, idx int) *v2_3.Package {
+	if p == nil {
+		return nil
+	}
+
+	v3ID := p.GetID()
+
+	// Check if already mapped
+	if existing, ok := idMap[v3ID]; ok {
+		return &v2_3.Package{
+			PackageName:           p.GetName(),
+			PackageSPDXIdentifier: existing,
+		}
+	}
+
+	// Generate new SPDX ID
+	spdxID := fmt.Sprintf("SPDXRef-Package-%d", idx+1)
+
+	// Store mapping
+	idMap[v3ID] = common.ElementID(spdxID)
+
+	return &v2_3.Package{
+		PackageName:           p.GetName(),
+		PackageSPDXIdentifier: common.ElementID(spdxID),
+	}
+}

--- a/spdx/v3/v3_0/convert_to_v23_test.go
+++ b/spdx/v3/v3_0/convert_to_v23_test.go
@@ -1,0 +1,82 @@
+package v3_0
+
+import (
+	"testing"
+	"github.com/spdx/tools-golang/spdx/v2/common"
+)
+
+func TestConvertPackageNameToV23(t *testing.T) {
+
+	t.Run("basic name mapping", func(t *testing.T) {
+		pkg := &AIPackage{
+			ID:   "pkg-1",
+			Name: "example1",
+		}
+
+		result := ConvertPackageNameToV23(pkg)
+
+		if result == nil {
+			t.Fatalf("expected non-nil result")
+		}
+
+		if result.PackageName != "example1" {
+			t.Fatalf("expected 'example1', got '%s'", result.PackageName)
+		}
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		result := ConvertPackageNameToV23(nil)
+
+		if result != nil {
+			t.Fatalf("expected nil result for nil input")
+		}
+	})
+}
+
+func TestConvertV3ElementIDtoV2ElementID(t *testing.T) {
+
+	t.Run("basic ID mapping", func(t *testing.T) {
+		idMap := make(map[string]common.ElementID)
+
+		pkg := &AIPackage{
+			ID:   "pkg-1",
+			Name: "example",
+		}
+
+		result := ConvertPackageToV23(pkg, idMap, 0)
+
+		if result.PackageSPDXIdentifier != "SPDXRef-Package-1" {
+			t.Fatalf("expected SPDXRef-Package-1, got %s", result.PackageSPDXIdentifier)
+		}
+	})
+
+	t.Run("reuse existing ID mapping", func(t *testing.T) {
+		idMap := make(map[string]common.ElementID)
+
+		pkg := &AIPackage{
+			ID:   "pkg-1",
+			Name: "example",
+		}
+
+		first := ConvertPackageToV23(pkg, idMap, 0)
+		second := ConvertPackageToV23(pkg, idMap, 1)
+
+		if first.PackageSPDXIdentifier != second.PackageSPDXIdentifier {
+			t.Fatalf("expected same SPDXID, got %s and %s", first.PackageSPDXIdentifier, second.PackageSPDXIdentifier)
+		}
+	})
+
+	t.Run("multiple packages get unique IDs", func(t *testing.T) {
+		idMap := make(map[string]common.ElementID)
+
+		pkg1 := &AIPackage{ID: "pkg-1", Name: "one"}
+		pkg2 := &AIPackage{ID: "pkg-2", Name: "two"}
+
+		res1 := ConvertPackageToV23(pkg1, idMap, 0)
+		res2 := ConvertPackageToV23(pkg2, idMap, 1)
+
+		if res1.PackageSPDXIdentifier == res2.PackageSPDXIdentifier {
+			t.Fatalf("expected different SPDXIDs, got %s", res1.PackageSPDXIdentifier)
+		}
+	})
+}


### PR DESCRIPTION
Part of #237 

This PR adds a small prototype for SPDX v3 → v2.3 backward conversion, focusing on package name and element ID.

From exploring the v3 model and existing forward conversion, it seems:
- v3 elements expose generic fields like name and ID
- v2.3 requires structured fields like PackageName and SPDXRef-*

This PR maps:
- v3 name → v2.3 PackageName
- v3 ID → v2.3 PackageSPDXIdentifier

For IDs, a simple mapping (v3ID → SPDXRef-*) is introduced to:
- keep identifiers stable
- allow reuse across multiple conversions

This is intentionally a small slice to validate the approach before moving to more complex parts .