### PR TITLE
fix: convert license expressions, fix conversion issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/piprate/json-gold v0.7.0
-	github.com/pmezard/go-difflib v1.0.0
 	github.com/spdx/gordf v0.0.0-20201111095634-7098f93598fb
 	github.com/stretchr/testify v1.11.1
 	mvdan.cc/gofumpt v0.7.0
@@ -26,6 +25,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deiu/gon3 v0.0.0-20241212124032-93153c038193 // indirect
 	github.com/linkeddata/gojsonld v0.0.0-20170418210642-4f5db6791326 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/rychipman/easylex v0.0.0-20160129204217-49ee7767142f // indirect
 	golang.org/x/mod v0.14.0 // indirect

--- a/spdx/v3/internal/ld/graph_builder.go
+++ b/spdx/v3/internal/ld/graph_builder.go
@@ -95,7 +95,7 @@ func (b *graphBuilder) serialize(v reflect.Value) (any, []error) {
 		if v.IsNil() {
 			return nil, nil
 		}
-		if debug {
+		if Debug {
 			ptr := fmt.Sprintf("%v", v.Pointer())
 			fmt.Printf("got pointer: %v\n", ptr)
 		}
@@ -194,17 +194,14 @@ func (b *graphBuilder) serializeProps(context *serializationContext, tc *typeCon
 			id := ""
 			if isUnset(fieldV) {
 				id = b.getID(ptrV)
-				if debug {
+				if Debug {
 					val := ptrV.Interface()
 					fmt.Printf("%#v\n", val)
 				}
 			} else {
 				id = fieldV.String()
-				//if !strings.HasPrefix(id, "_:") {
-				//	id = "_:" + id
-				//}
 			}
-			if debug {
+			if Debug {
 				ptr := fmt.Sprintf("%v", ptrV.Pointer())
 				fmt.Printf("setting id for pointer: %v\n", ptr)
 			}
@@ -230,7 +227,7 @@ func (b *graphBuilder) serializeProps(context *serializationContext, tc *typeCon
 			continue
 		}
 
-		if debug {
+		if Debug {
 			val := fieldV.Interface()
 			str := fmt.Sprintf("serializing prop %v: %#v", f, val)
 			fmt.Println(str)

--- a/spdx/v3/internal/ld/util.go
+++ b/spdx/v3/internal/ld/util.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	debug      = os.Getenv("GO_LD_DEBUG") == "true"
+	Debug      = os.Getenv("DEBUG_SPDX_TOOLS_GOLANG") == "true"
 	emptyValue reflect.Value
 	anyType    = reflect.TypeOf((*any)(nil)).Elem()
 )

--- a/spdx/v3/internal/ld/validation_error.go
+++ b/spdx/v3/internal/ld/validation_error.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 )
 
 // JoinErrors returns errors.Join'd errors, taking into account nested joined errors, flattening these to a single joined set
@@ -40,42 +41,48 @@ func flattenErrors(err error) []error {
 var validatorInterface = reflect.TypeOf((*Validator)(nil)).Elem()
 
 type validationError struct {
-	Path []any
+	Path string
 	Err  error
 }
 
-func (v *validationError) String() string {
-	path := ""
-	for i := 0; i < len(v.Path); i++ {
-		part := v.Path[i]
+func StringifyPath(pathSlice []any) string {
+	path := strings.Builder{}
+	for i := 0; i < len(pathSlice); i++ {
+		part := pathSlice[i]
 		switch p := part.(type) {
 		case int:
-			path += "[" + strconv.Itoa(p) + "]"
+			_, _ = path.WriteString("[")
+			_, _ = path.WriteString(strconv.Itoa(p))
+			_, _ = path.WriteString("]")
 		case reflect.StructField:
 			if !p.Anonymous {
-				path += "." + p.Name
+				_, _ = path.WriteString(".")
+				_, _ = path.WriteString(p.Name)
 			}
 		case reflect.Type:
-			path += "<" + p.Name() + ">"
+			_, _ = path.WriteString("<")
+			_, _ = path.WriteString(p.Name())
+			_, _ = path.WriteString(">")
 		default:
-			path += "/" + fmt.Sprint(p)
+			_, _ = path.WriteString("/")
+			_, _ = path.WriteString(fmt.Sprint(p))
 		}
 	}
-	return path + ": " + v.Err.Error()
+	return path.String()
 }
 
 func (v *validationError) Error() string {
-	return v.String()
+	return v.Path + ": " + v.Err.Error()
 }
 
 func newValidationError(err error, path ...any) *validationError {
 	// if the error is a validation error, prepend the path
 	if vErr, ok := err.(*validationError); ok {
-		vErr.Path = append(path, vErr.Path...)
+		vErr.Path = StringifyPath(path) + " " + vErr.Path
 		return vErr
 	}
 	return &validationError{
-		Path: path,
+		Path: StringifyPath(path),
 		Err:  err,
 	}
 }

--- a/spdx/v3/internal/ld/validations.go
+++ b/spdx/v3/internal/ld/validations.go
@@ -16,17 +16,9 @@ type Validator interface {
 // of all the errors found
 func ValidateGraph(graph any) error {
 	var errs []error
-	err := VisitObjectGraph(graph, func(path []any, value reflect.Value) error {
-		// avoid double-validation, this will be called with both pointer and struct references
-		if elemImplements[Validator](value) {
-			return nil
-		}
-		if value.Type().Implements(validatorInterface) {
-			if validator, ok := value.Interface().(Validator); ok {
-				for _, err := range flattenErrors(validator.Validate()) {
-					errs = append(errs, newValidationError(err, append(path[:], baseType(value.Type()))...))
-				}
-			}
+	err := VisitObjectGraph(graph, func(path []any, validator Validator) error {
+		for _, err := range flattenErrors(validator.Validate()) {
+			errs = append(errs, newValidationError(err, append(path, baseType(reflect.TypeOf(validator)))...)) // ok to append to mutable path here: it is only stringified
 		}
 		return nil
 	})

--- a/spdx/v3/internal/ld/visitor.go
+++ b/spdx/v3/internal/ld/visitor.go
@@ -48,7 +48,8 @@ func visitObjectGraph(visited map[reflect.Value]struct{}, path []any, v reflect.
 			return nil // stdlib packages
 		}
 
-		panic(fmt.Errorf("can't interface: %v %#v", typeName(t), v))
+		// for debugging: panic(fmt.Errorf("can't interface: %v %#v", typeName(t), v))
+		return nil
 	}
 
 	t := v.Type()
@@ -99,7 +100,7 @@ func visitObjectGraph(visited map[reflect.Value]struct{}, path []any, v reflect.
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
 		reflect.Float32, reflect.Float64:
 	default:
-		panic(fmt.Errorf("unexpected type: %v %#v", typeName(t), v))
+		// for debugging: panic(fmt.Errorf("unexpected type: %v %#v", typeName(t), v))
 	}
 	return nil
 }

--- a/spdx/v3/internal/ld/visitor.go
+++ b/spdx/v3/internal/ld/visitor.go
@@ -1,73 +1,112 @@
 package ld
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"reflect"
-	"strings"
+	"runtime"
 )
 
-var StopTraversing = fmt.Errorf("stop-traversing-graph")
+var (
+	StopTraversing      = fmt.Errorf("stop-traversing-graph")
+	defaultVisitorDepth = 32 // make some reasonable visit defaults to avoid _always_ reallocating
+	defaultVisitorSize  = 1024
+)
 
 // VisitObjectGraph traverses the object graph, taking into account cycles, calling the visitor function for each
-// step along the traversal, including field properties, pointer and subsequent struct values, elements in
-// slices and both keys and values of maps, as well as some context such as the path within the graph and any
-// containing struct field. The value is always able to have Interface() and Set() called.
-func VisitObjectGraph(graph any, visitor func(path []any, value reflect.Value) error) error {
-	t := reflect.TypeOf(graph)
-	return visitObjectGraph(map[reflect.Value]struct{}{}, []any{baseType(t)}, reflect.ValueOf(graph), visitor)
+// applicable type along the traversal, including field properties, pointer and subsequent struct values, elements in
+// slices and values of maps, as well as some context such as the path to the field within a struct.
+// NOTE: visitFunc will be called with a mutable path, if you need to use it, make a copy or process in the visitor
+func VisitObjectGraph[T any](graph any, visitFunc visitFunc[T]) error {
+	v := reflect.ValueOf(graph)
+	if !v.IsValid() {
+		return fmt.Errorf("error: invalid reflect.Value: %v", graph)
+	}
+	if rv, ok := graph.(reflect.Value); ok {
+		v = rv
+	}
+	path := make([]any, 1, defaultVisitorDepth)
+	path[0] = baseType(v.Type())
+	o := visitor[T]{
+		path:      path,
+		visited:   make(map[key]struct{}, defaultVisitorSize),
+		visitFunc: visitFunc,
+	}
+	err := o.visit(v, false)
+	if errors.Is(err, StopTraversing) {
+		return nil
+	}
+	return err
 }
 
-func visitObjectGraph(visited map[reflect.Value]struct{}, path []any, v reflect.Value, visitor func([]any, reflect.Value) error) error {
+type visitFunc[T any] func(path []any, value T) error
+
+type visitor[T any] struct {
+	path      []any
+	visited   map[key]struct{}
+	visitFunc visitFunc[T]
+}
+
+type key struct {
+	typ reflect.Type
+	ptr uintptr
+}
+
+func (o *visitor[T]) visit(v reflect.Value, calledWithPointer bool) error {
 	if !v.IsValid() {
 		return nil
 	}
-	if _, ok := visited[v]; ok {
-		return nil
+
+	if v.Kind() == reflect.Interface {
+		return o.visit(v.Elem(), false)
 	}
-	visited[v] = struct{}{}
 
-	var err error
+	k, ok := makeKey(v)
+	if ok {
+		if _, ok = o.visited[k]; ok {
+			return nil
+		}
+		o.visited[k] = struct{}{}
+	}
+
 	if v.CanInterface() {
-		err = visitor(path, v)
-		if err == StopTraversing {
-			return nil
-		} else if err != nil {
-			return err
+		if Debug {
+			debugLog("visiting:", o.path, v)
 		}
-	} else {
-		t := v.Type()
-		if t.Size() == 0 || isPrimitive(t) {
-			// expected for fields like ld.Type, we should not reference zero-sized fields
-			return nil
+		val, ok := v.Interface().(T)
+		if ok {
+			if !calledWithPointer && !isNil(v) {
+				err := o.visitFunc(o.path, val)
+				if err != nil {
+					return err
+				}
+				if v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
+					calledWithPointer = true
+				}
+			}
 		}
-		if t.Kind() == reflect.Pointer || t.Kind() == reflect.Interface {
-			t = t.Elem()
-		}
-		p := t.PkgPath()
-		if p != "" && !strings.Contains(p, ".") {
-			return nil // stdlib packages
-		}
-
-		// for debugging: panic(fmt.Errorf("can't interface: %v %#v", typeName(t), v))
-		return nil
 	}
 
 	t := v.Type()
 
 	switch t.Kind() {
-	case reflect.Interface:
-		return visitObjectGraph(visited, path, v.Elem(), visitor)
 	case reflect.Pointer:
-		return visitObjectGraph(visited, path, v.Elem(), visitor)
+		return o.visit(v.Elem(), calledWithPointer)
 	case reflect.Struct:
 		for i := 0; i < v.NumField(); i++ {
 			f := t.Field(i)
-			subPath := path[:]
 			if !f.Anonymous {
-				subPath = append(subPath, f)
+				o.path = append(o.path, f)
 			}
 			fv := v.Field(i)
-			err = visitObjectGraph(visited, subPath, fv, visitor)
+			if fv.Kind() == reflect.Struct && v.CanAddr() { // go allows calling pointer methods on struct fields of structs
+				fv = fv.Addr()
+			}
+			err := o.visit(fv, false)
+			if !f.Anonymous {
+				o.path = o.path[:len(o.path)-1]
+			}
 			if err != nil {
 				return err
 			}
@@ -78,19 +117,24 @@ func visitObjectGraph(visited map[reflect.Value]struct{}, path []any, v reflect.
 			return nil
 		}
 		for iter.Next() {
-			path := append(path[:], fmt.Sprintf("%v", iter.Key().Interface()))
-			err = visitObjectGraph(visited, path, iter.Key(), visitor)
-			if err != nil {
-				return err
-			}
-			err = visitObjectGraph(visited, path, iter.Value(), visitor)
+			o.path = append(o.path, iter.Key())
+			iv := iter.Value()
+			// maps _cannot_ treat structs as pointers, so these do not .Addr() the same way slices and structs do
+			err := o.visit(iv, false)
+			o.path = o.path[:len(o.path)-1]
 			if err != nil {
 				return err
 			}
 		}
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		for i := 0; i < v.Len(); i++ {
-			err = visitObjectGraph(visited, append(path[:], i), v.Index(i), visitor)
+			o.path = append(o.path, i)
+			iv := v.Index(i)
+			if iv.Kind() == reflect.Struct && iv.CanAddr() { // go allows calling pointer methods on slices of structs
+				iv = iv.Addr()
+			}
+			err := o.visit(iv, false)
+			o.path = o.path[:len(o.path)-1]
 			if err != nil {
 				return err
 			}
@@ -103,4 +147,45 @@ func visitObjectGraph(visited map[reflect.Value]struct{}, path []any, v reflect.
 		// for debugging: panic(fmt.Errorf("unexpected type: %v %#v", typeName(t), v))
 	}
 	return nil
+}
+
+func isNil(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Chan, reflect.Map, reflect.Slice:
+		return v.IsNil()
+	case reflect.Interface:
+		return v.IsNil() || isNil(v.Elem())
+	default:
+	}
+	return !v.IsValid()
+}
+
+func makeKey(v reflect.Value) (key, bool) {
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Chan, reflect.Map, reflect.Slice:
+		if v.IsNil() {
+			return key{}, false
+		}
+		return key{v.Type(), v.Pointer()}, true
+	default:
+		return key{}, false
+	}
+}
+
+func debugLog(args ...any) {
+	_, file, line, _ := runtime.Caller(1)
+	_, _ = fmt.Fprint(os.Stderr, file)
+	_, _ = fmt.Fprint(os.Stderr, "@")
+	_, _ = fmt.Fprintf(os.Stderr, "%d", line)
+	_, _ = fmt.Fprint(os.Stderr, " ")
+	for _, arg := range args {
+		if v, ok := arg.(reflect.Value); ok {
+			if v.CanInterface() {
+				arg = fmt.Sprintf("%v %v", typeName(v.Type()), v.Interface())
+			}
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "%v", arg)
+		_, _ = fmt.Fprint(os.Stderr, " ")
+	}
+	_, _ = fmt.Fprintln(os.Stderr)
 }

--- a/spdx/v3/internal/ld/visitor.go
+++ b/spdx/v3/internal/ld/visitor.go
@@ -3,6 +3,7 @@ package ld
 import (
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 var StopTraversing = fmt.Errorf("stop-traversing-graph")
@@ -33,6 +34,21 @@ func visitObjectGraph(visited map[reflect.Value]struct{}, path []any, v reflect.
 		} else if err != nil {
 			return err
 		}
+	} else {
+		t := v.Type()
+		if t.Size() == 0 || isPrimitive(t) {
+			// expected for fields like ld.Type, we should not reference zero-sized fields
+			return nil
+		}
+		if t.Kind() == reflect.Pointer || t.Kind() == reflect.Interface {
+			t = t.Elem()
+		}
+		p := t.PkgPath()
+		if p != "" && !strings.Contains(p, ".") {
+			return nil // stdlib packages
+		}
+
+		panic(fmt.Errorf("can't interface: %v %#v", typeName(t), v))
 	}
 
 	t := v.Type()
@@ -78,7 +94,12 @@ func visitObjectGraph(visited map[reflect.Value]struct{}, path []any, v reflect.
 				return err
 			}
 		}
+	case reflect.String, reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
 	default:
+		panic(fmt.Errorf("unexpected type: %v %#v", typeName(t), v))
 	}
 	return nil
 }

--- a/spdx/v3/internal/ld/visitor_test.go
+++ b/spdx/v3/internal/ld/visitor_test.go
@@ -1,50 +1,377 @@
 package ld
 
 import (
-	"fmt"
+	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func Test_visitor(t *testing.T) {
-	type typ struct {
-		Name  string
-		Slice []int
-		Map   map[string]int
-	}
+type value struct {
+	Name string
+}
 
-	v := &typ{
-		Name:  "a name",
-		Slice: []int{2, 4, 6},
-		Map: map[string]int{
-			"key1": 10,
-			"key2": 20,
-		},
-	}
+func Test_VisitObjectGraph(t *testing.T) {
+	t.Run("visits the root pointer", func(t *testing.T) {
+		o := &value{}
+		require.Len(t, collectVisits[*value](t, o), 1)
+	})
 
-	err := VisitObjectGraph(v, func(path []any, value reflect.Value) error {
-		f := path[len(path)-1]
-		if f, ok := f.(reflect.StructField); ok {
-			if f.Name == "Name" {
-				require.Equal(t, value.String(), "a name")
-				value.SetString("a new name")
+	t.Run("visits pointer fields", func(t *testing.T) {
+		type outer struct {
+			Inner *value
+		}
+		inner := &value{Name: "inner"}
+		o := &outer{Inner: inner}
+		require.Len(t, collectVisits[*value](t, o), 1)
+	})
+
+	t.Run("visits pointers to pointers", func(t *testing.T) {
+		type outer struct {
+			PP **value
+		}
+		inner := &value{Name: "inner"}
+		pp := &inner
+		o := &outer{PP: pp}
+		require.Len(t, collectVisits[*value](t, o), 1)
+	})
+
+	t.Run("addrs structs in fields", func(t *testing.T) {
+		type outer struct {
+			Value value
+		}
+		o := &outer{Value: value{Name: "value"}}
+		require.Len(t, collectVisits[*value](t, o), 1)
+	})
+
+	t.Run("addrs structs in slices", func(t *testing.T) {
+		s := []value{{Name: "a"}, {Name: "b"}}
+		err := VisitObjectGraph(s, func(path []any, v any) error {
+			if i, ok := v.(*value); ok {
+				i.Name += "-visited"
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, "a-visited", s[0].Name)
+		require.Equal(t, "b-visited", s[1].Name)
+	})
+
+	t.Run("visits pointers in maps", func(t *testing.T) {
+		inner := &value{Name: "inner"}
+		m := map[string]*value{"k": inner}
+		require.Len(t, collectVisits[*value](t, m), 1)
+	})
+
+	t.Run("visits pointers in interfaces", func(t *testing.T) {
+		type outer struct {
+			Iface any
+		}
+		inner := &value{Name: "inner"}
+		o := &outer{Iface: inner}
+		require.Len(t, collectVisits[*value](t, o), 1)
+	})
+
+	t.Run("visits structs in interfaces", func(t *testing.T) {
+		type outer struct {
+			Iface any
+		}
+		o := &outer{Iface: value{Name: "inner"}}
+		require.Len(t, collectVisits[value](t, o), 1)
+	})
+
+	t.Run("visits pointers within anonymous structs in interfaces", func(t *testing.T) {
+		type outer struct {
+			Iface any
+		}
+		type base struct {
+			Inner *value
+			Name  string
+		}
+		type derived struct {
+			base
+		}
+		inner := &value{Name: "inner"}
+		o := &outer{Iface: derived{base: base{Inner: inner}}}
+		require.Len(t, collectVisits[*value](t, o), 1)
+	})
+
+	t.Run("visits shared pointers once", func(t *testing.T) {
+		enableDebug(t)
+		type outer struct {
+			A, B *value
+		}
+		shared := &value{Name: "shared"}
+		o := &outer{A: shared, B: shared}
+		require.Len(t, collectVisits[*value](t, o), 1)
+	})
+
+	t.Run("handles self-referential pointers", func(t *testing.T) {
+		type node struct {
+			Name string
+			Next *node
+		}
+		n := &node{Name: "self"}
+		n.Next = n
+		require.Len(t, collectVisits[*node](t, n), 1)
+	})
+
+	t.Run("handles pointer cycles", func(t *testing.T) {
+		type node struct {
+			Name string
+			Next *node
+		}
+		a := &node{Name: "a"}
+		b := &node{Name: "b"}
+		a.Next = b
+		b.Next = a
+		require.Len(t, collectVisits[*node](t, a), 2)
+	})
+
+	t.Run("handles self-referential slices", func(t *testing.T) {
+		s := []any{nil}
+		s[0] = s
+		err := VisitObjectGraph(s, func(path []any, value any) error { return nil })
+		require.NoError(t, err)
+	})
+
+	t.Run("handles self-referential maps", func(t *testing.T) {
+		m := map[string]any{}
+		m["self"] = m
+		err := VisitObjectGraph(m, func(path []any, value any) error { return nil })
+		require.NoError(t, err)
+	})
+
+	t.Run("handles cycles through unexported fields", func(t *testing.T) {
+		type unexported struct {
+			next *unexported
+		}
+		u := &unexported{}
+		u.next = u
+		err := VisitObjectGraph(u, func(path []any, value any) error { return nil })
+		require.NoError(t, err)
+	})
+
+	t.Run("does not visit nil pointers", func(t *testing.T) {
+		type outer struct {
+			PtrSlice []*value
+			PtrMap   map[string]*value
+		}
+		o := &outer{
+			PtrSlice: []*value{nil},
+			PtrMap:   map[string]*value{"k": nil},
+		}
+		visits := collectVisits[any](t, o)
+		for _, v := range visits {
+			rv := reflect.ValueOf(v.value)
+			if rv.Kind() == reflect.Pointer {
+				require.False(t, rv.IsNil(), "visited a nil pointer at: %s", v.path)
 			}
 		}
-		//fmt.Println(path)
-		//if intSlice, ok := value.Interface().([]int); ok {
-		//	fmt.Println(intSlice)
-		//	//intSlice = append(intSlice, 12)
-		//	newValue := reflect.Append(value, reflect.ValueOf(12))
-		//	value.Set(newValue)
-		//}
-		if mapVal, ok := value.Interface().(map[string]int); ok {
-			fmt.Println(mapVal)
-			mapVal["new"] = 100
+	})
+
+	t.Run("does not visit nil pointers boxed in interfaces", func(t *testing.T) {
+		type outer struct {
+			Iface any
 		}
+		o := &outer{Iface: (*value)(nil)} // non-nil interface boxing a typed nil pointer
+		err := VisitObjectGraph(o, func(path []any, v *value) error {
+			require.NotNil(t, v, "visitor called with a nil pointer at: %s", StringifyPath(path))
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("does not visit pointers used as map keys", func(t *testing.T) {
+		k := &value{Name: "key"}
+		m := map[*value]string{k: "v"}
+		require.Empty(t, collectVisits[*value](t, m))
+	})
+
+	t.Run("handles a typed nil pointer root", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			require.Empty(t, collectVisits[*value](t, (*value)(nil)))
+		})
+	})
+
+	t.Run("handles nil graph", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			err := VisitObjectGraph(nil, func(path []any, value any) error { return nil })
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("visits pointers reachable from a non-pointer root", func(t *testing.T) {
+		type outer struct {
+			Inner *value
+		}
+		inner := &value{Name: "inner"}
+		o := outer{Inner: inner} // passed by value
+		require.Len(t, collectVisits[*value](t, o), 1)
+	})
+
+	t.Run("stops traversing on StopTraversing", func(t *testing.T) {
+		count := 0
+		type outer struct {
+			Inner    *value
+			PtrSlice []*value
+		}
+		o := &outer{Inner: &value{}, PtrSlice: []*value{{}, {}}}
+		err := VisitObjectGraph(o, func(path []any, value any) error {
+			count++
+			return StopTraversing
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+	})
+
+	t.Run("returns visitor errors", func(t *testing.T) {
+		type outer struct {
+			Inner *value
+		}
+		boom := errors.New("boom")
+		o := &outer{Inner: &value{}}
+		err := VisitObjectGraph(o, func(path []any, value any) error {
+			return boom
+		})
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("records the path to nested fields", func(t *testing.T) {
+		type inner struct {
+			Leaf *value
+		}
+		type outer struct {
+			Mid *inner
+		}
+		o := &outer{Mid: &inner{Leaf: &value{Name: "leaf"}}}
+		visits := collectVisits[*value](t, o)
+		require.Len(t, visits, 1)
+		require.Equal(t, "<outer>.Mid.Leaf", visits[0].path)
+	})
+
+	t.Run("records slice indices in the path", func(t *testing.T) {
+		type outer struct {
+			Items []*value
+		}
+		o := &outer{Items: []*value{{Name: "a"}, {Name: "b"}}}
+		visits := collectVisits[*value](t, o)
+		require.Len(t, visits, 2)
+		require.Equal(t, "<outer>.Items[0]", visits[0].path)
+		require.Equal(t, "<outer>.Items[1]", visits[1].path)
+	})
+
+	t.Run("records map keys in the path", func(t *testing.T) {
+		type outer struct {
+			M map[string]*value
+		}
+		o := &outer{M: map[string]*value{"k": {Name: "v"}}}
+		visits := collectVisits[*value](t, o)
+		require.Len(t, visits, 1)
+		require.Equal(t, "<outer>.M/k", visits[0].path)
+	})
+
+	t.Run("omits anonymous fields from the path", func(t *testing.T) {
+		type base struct {
+			Leaf *value
+		}
+		type derived struct {
+			base
+		}
+		o := &derived{base: base{Leaf: &value{Name: "leaf"}}}
+		visits := collectVisits[*value](t, o)
+		require.Len(t, visits, 1)
+		require.Equal(t, "<derived>.Leaf", visits[0].path)
+	})
+
+	t.Run("visits a pointer but not its target when both match the visitor type", func(t *testing.T) {
+		type leaf struct{} // no fields, so it produces no additional visits
+		l := &leaf{}
+		var pointerVisits, valueVisits int
+		err := VisitObjectGraph(l, func(path []any, v any) error {
+			switch v.(type) {
+			case *leaf:
+				pointerVisits++
+			case leaf:
+				valueVisits++
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, pointerVisits)
+		require.Equal(t, 0, valueVisits)
+	})
+
+	t.Run("supports into arrays", func(t *testing.T) {
+		type outer struct {
+			Arr [2]*value
+		}
+		o := &outer{Arr: [2]*value{{Name: "a"}, {Name: "b"}}}
+		require.Len(t, collectVisits[*value](t, o), 2)
+	})
+
+	t.Run("accepts a reflect.Value as the graph", func(t *testing.T) {
+		inner := &value{Name: "inner"}
+		require.Len(t, collectVisits[*value](t, reflect.ValueOf(inner)), 1)
+	})
+
+	t.Run("handles nil interface fields", func(t *testing.T) {
+		type outer struct {
+			Iface any
+		}
+		o := &outer{Iface: nil}
+		require.NotPanics(t, func() {
+			require.Empty(t, collectVisits[*value](t, o))
+		})
+	})
+
+	t.Run("does not pass values behind unexported fields to the visitor", func(t *testing.T) {
+		type outer struct {
+			hidden *value
+		}
+		o := &outer{hidden: &value{Name: "secret"}}
+		require.Empty(t, collectVisits[*value](t, o))
+	})
+
+	t.Run("visits struct values in maps without addressing them", func(t *testing.T) {
+		m := map[string]value{"k": {Name: "v"}}
+		visits := collectVisits[value](t, m)
+		require.Len(t, visits, 1)
+		require.Equal(t, "v", visits[0].value.(value).Name)
+	})
+
+	t.Run("visits pointers in nested slices", func(t *testing.T) {
+		type outer struct {
+			Grid [][]*value
+		}
+		o := &outer{Grid: [][]*value{{{Name: "a"}}, {{Name: "b"}, {Name: "c"}}}}
+		require.Len(t, collectVisits[*value](t, o), 3)
+	})
+}
+
+func enableDebug(t *testing.T) {
+	t.Helper()
+	defaultDebug := Debug
+	Debug = true
+	t.Cleanup(func() {
+		Debug = defaultDebug
+	})
+}
+
+type visitRecord struct {
+	path  string
+	value any
+}
+
+// collectVisits traverses the graph, recording each visited value with its path rendered at visit time
+func collectVisits[T any](t *testing.T, graph any) []visitRecord {
+	t.Helper()
+	var visits []visitRecord
+	err := VisitObjectGraph(graph, func(path []any, value T) error {
+		visits = append(visits, visitRecord{path: StringifyPath(path), value: value})
 		return nil
 	})
-	fmt.Println(v)
 	require.NoError(t, err)
+	return visits
 }

--- a/spdx/v3/internal/serialize_json.go
+++ b/spdx/v3/internal/serialize_json.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -14,7 +13,7 @@ import (
 	"github.com/spdx/tools-golang/spdx/v3/internal/ld"
 )
 
-var Debug = os.Getenv("SPDX_DEBUG") == "true"
+var Debug = ld.Debug
 
 type ldContextProvider interface {
 	LDContexts() map[string]map[string]any

--- a/spdx/v3/v3_0/convert.go
+++ b/spdx/v3/v3_0/convert.go
@@ -61,6 +61,8 @@ func From_v2_3(doc v2_3.Document, d *Document) {
 	d.DataLicense = c.convert23licenseExpression(doc.DataLicense)
 
 	var converted ElementList
+
+	// other licenses may be referenced (with LicenseRef-... in expressions), so process these first to recreate the proper graph
 	for _, l := range doc.OtherLicenses {
 		converted = append(converted, c.convert23license(l))
 	}
@@ -836,7 +838,37 @@ func (c *documentConverter) convert23licenseExpression(licenseExpression string)
 	if err != nil {
 		c.logDropped(err)
 	}
-	return parsedLicense
+	return c.resolveLicenseRefs(parsedLicense)
+}
+
+// resolveLicenseRefs walks a parsed license expression and replaces the
+// placeholder CustomLicense references the parser produces for LicenseRef-*
+// identifiers with the resolved CustomLicense instances registered in
+// idMap by convert23license.
+func (c *documentConverter) resolveLicenseRefs(license AnyLicenseInfo) AnyLicenseInfo {
+	switch l := license.(type) {
+	case *CustomLicense:
+		if resolved, ok := c.idMap[l.ID].(*CustomLicense); ok {
+			return resolved
+		}
+	case *ConjunctiveLicenseSet:
+		for i, m := range l.Members {
+			l.Members[i] = c.resolveLicenseRefs(m)
+		}
+	case *DisjunctiveLicenseSet:
+		for i, m := range l.Members {
+			l.Members[i] = c.resolveLicenseRefs(m)
+		}
+	case *OrLaterOperator:
+		if resolved, ok := c.resolveLicenseRefs(l.SubjectLicense).(AnyLicense); ok {
+			l.SubjectLicense = resolved
+		}
+	case *WithAdditionOperator:
+		if resolved, ok := c.resolveLicenseRefs(l.SubjectExtendableLicense).(AnyExtendableLicense); ok {
+			l.SubjectExtendableLicense = resolved
+		}
+	}
+	return license
 }
 
 func (c *documentConverter) convert23externalDocumentRef(r v2_3.ExternalDocumentRef) AnyExternalMap {

--- a/spdx/v3/v3_0/convert.go
+++ b/spdx/v3/v3_0/convert.go
@@ -258,7 +258,6 @@ type documentConverter struct {
 	externalRefTypeMap        map[string]ExternalRefType
 	primaryPurposeMap         map[string]SoftwarePurpose
 	emailExtractor            *regexp.Regexp
-	postConvert               []func() error
 	conversionErrors          []error
 }
 

--- a/spdx/v3/v3_0/convert.go
+++ b/spdx/v3/v3_0/convert.go
@@ -243,8 +243,7 @@ func newDocumentConverter(d *Document) *documentConverter {
 }
 
 type documentConverter struct {
-	sbom *SBOM
-	//namespace                 string
+	sbom                      *SBOM
 	idMap                     map[string]any
 	creationInfo              AnyCreationInfo
 	relationshipMap           map[any][]AnyRelationship
@@ -846,8 +845,15 @@ func (c *documentConverter) convert23licenseExpression(licenseExpression string)
 // idMap by convert23license.
 func (c *documentConverter) resolveLicenseRefs(license AnyLicenseInfo) AnyLicenseInfo {
 	switch l := license.(type) {
+	case *ListedLicense:
+		if l.ID != "" {
+			if existing, _ := c.idMap[l.ID].(AnyListedLicense); existing != nil {
+				return existing
+			}
+			c.idMap[l.ID] = l
+		}
 	case *CustomLicense:
-		if resolved, ok := c.idMap[l.ID].(*CustomLicense); ok {
+		if resolved, ok := c.idMap[l.ID].(AnyCustomLicense); ok {
 			return resolved
 		}
 	case *ConjunctiveLicenseSet:

--- a/spdx/v3/v3_0/convert.go
+++ b/spdx/v3/v3_0/convert.go
@@ -58,7 +58,7 @@ func From_v2_3(doc v2_3.Document, d *Document) {
 	d.Comment = doc.DocumentComment
 	d.Imports = list[ExternalMapList](c.convert23externalDocumentRef, doc.ExternalDocumentReferences...)
 	d.Name = doc.DocumentName
-	d.DataLicense = c.convert23licenseString(doc.DataLicense)
+	d.DataLicense = c.convert23licenseExpression(doc.DataLicense)
 
 	var converted ElementList
 	for _, l := range doc.OtherLicenses {
@@ -81,21 +81,28 @@ func From_v2_3(doc v2_3.Document, d *Document) {
 		converted = append(converted, c.convert23snippet(s))
 	}
 
-	var relationships ElementList
 	for _, rel := range doc.Relationships {
-		r := c.convert23relationship(rel)
-		if r != nil {
-			c.sbom.Elements = append(c.sbom.Elements, r)
-			converted = append(relationships, r)
+		c.convert23relationship(rel)
+	}
+
+	// if the user did not add elements to the document via DOCUMENT relationships, just add all elements directly
+	if len(c.sbom.RootElements) == 0 {
+		c.sbom.RootElements = notNil(converted)
+	}
+
+	// in SPDX 2.3, relationships are all directly associated with the top-level document (which is an SBOM, effectively)
+	for _, rels := range c.relationshipMap {
+		for _, r := range rels {
+			if r == nil {
+				continue
+			}
+			c.sbom.RootElements = append(c.sbom.RootElements, r)
 		}
 	}
 
-	// if the user did not add elements to the document via relationships,
-	// just add all elements directly
-	if len(c.sbom.RootElements) == 0 {
-		c.sbom.RootElements = append(notNil(converted), notNil(relationships)...)
-	} else {
-		c.sbom.Elements = append(c.sbom.Elements, notNil(converted)...)
+	// ensure all elements are present in the document Elements list
+	for _, e := range collectAllElements(&d.SpdxDocument) {
+		d.SpdxDocument.Elements = append(d.SpdxDocument.Elements, e)
 	}
 }
 
@@ -247,6 +254,8 @@ type documentConverter struct {
 	externalRefTypeMap        map[string]ExternalRefType
 	primaryPurposeMap         map[string]SoftwarePurpose
 	emailExtractor            *regexp.Regexp
+	postConvert               []func() error
+	conversionErrors          []error
 }
 
 func (c *documentConverter) addRelationship(r *Relationship) {
@@ -444,6 +453,8 @@ func (c *documentConverter) convert23file(f *v2_3.File) AnyFile {
 		Kind:             FileKindType_File,
 	}
 
+	c.idMap[string(f.FileSPDXIdentifier)] = out
+
 	for _, s := range f.Snippets {
 		v3 := c.convert23snippet(*s)
 		c.addRelationship(&Relationship{
@@ -462,7 +473,6 @@ func (c *documentConverter) convert23file(f *v2_3.File) AnyFile {
 		})
 	}
 
-	c.idMap[string(f.FileSPDXIdentifier)] = out
 	return out
 }
 
@@ -534,7 +544,7 @@ func (c *documentConverter) convert23package(pkg *v2_3.Package) AnyPackage {
 	}
 
 	for _, l := range pkg.PackageLicenseInfoFromFiles {
-		d := c.convert23licenseString(l)
+		d := c.convert23licenseExpression(l)
 		if d != nil {
 			c.addRelationship(&Relationship{
 				Type: RelationshipType_HasConcludedLicense,
@@ -543,7 +553,7 @@ func (c *documentConverter) convert23package(pkg *v2_3.Package) AnyPackage {
 			})
 		}
 	}
-	d := c.convert23licenseString(pkg.PackageLicenseDeclared)
+	d := c.convert23licenseExpression(pkg.PackageLicenseDeclared)
 	if d != nil {
 		c.addRelationship(&Relationship{
 			Type: RelationshipType_HasDeclaredLicense,
@@ -552,7 +562,7 @@ func (c *documentConverter) convert23package(pkg *v2_3.Package) AnyPackage {
 		})
 	}
 
-	d = c.convert23licenseString(pkg.PackageLicenseConcluded)
+	d = c.convert23licenseExpression(pkg.PackageLicenseConcluded)
 	if d != nil {
 		c.addRelationship(&Relationship{
 			Type: RelationshipType_HasConcludedLicense,
@@ -597,6 +607,11 @@ func (c *documentConverter) convert23uri(uri string) ld.URI {
 }
 
 func (c *documentConverter) logDropped(value any) {
+	if err, ok := value.(error); ok {
+		c.conversionErrors = append(c.conversionErrors, err)
+	} else {
+		c.conversionErrors = append(c.conversionErrors, fmt.Errorf("%v", value))
+	}
 	if value == nil || !internal.Debug {
 		return
 	}
@@ -655,6 +670,9 @@ func (c *documentConverter) convert23license(l *v2_3.OtherLicense) AnyLicenseInf
 	}
 
 	out := &CustomLicense{
+		// custom licenses in SPDX 3.0 requires an unfortunate workaround:
+		// we must set a custom URI here because SPDX 3.0 only has
+		ID:       l.LicenseIdentifier,
 		Name:     l.LicenseName,
 		Comment:  l.LicenseComment,
 		SeeAlsos: seeAlso,
@@ -666,28 +684,16 @@ func (c *documentConverter) convert23license(l *v2_3.OtherLicense) AnyLicenseInf
 	return out
 }
 
-func (c *documentConverter) convert23licenseString(licenseString string) AnyLicenseInfo {
-	if licenseString == "" {
+func (c *documentConverter) convert23licenseExpression(licenseExpression string) AnyLicenseInfo {
+	if licenseExpression == "" {
 		return nil
 	}
 
-	var out AnyLicenseInfo
-	if strings.HasPrefix(licenseString, "LicenseRef-") {
-		license, _ := c.idMap[licenseString].(AnyLicenseInfo)
-		if license != nil {
-			return license
-		}
-		out = &CustomLicense{
-			Name: licenseString,
-			Text: licenseString,
-		}
-	} else {
-		out = &ListedLicense{
-			Name: licenseString,
-		}
+	parsedLicense, err := ParseLicenseExpression(licenseExpression)
+	if err != nil {
+		c.logDropped(err)
 	}
-
-	return out
+	return parsedLicense
 }
 
 func (c *documentConverter) convert23externalDocumentRef(r v2_3.ExternalDocumentRef) AnyExternalMap {
@@ -748,12 +754,12 @@ func (c *documentConverter) convert23snippet(s v2_3.Snippet) AnyElement {
 	snippetFile, _ := c.idMap[string(s.SnippetFromFileSPDXIdentifier)].(AnyFile)
 
 	var licenses LicenseInfoList
-	d := c.convert23licenseString(s.SnippetLicenseConcluded)
+	d := c.convert23licenseExpression(s.SnippetLicenseConcluded)
 	d.SetComment(s.SnippetLicenseComments)
 	licenses = append(licenses, d)
 
 	for _, licenseInfo := range s.LicenseInfoInSnippet {
-		d = c.convert23licenseString(licenseInfo)
+		d = c.convert23licenseExpression(licenseInfo)
 		if d != nil {
 			d.SetComment(s.SnippetLicenseComments)
 			licenses = append(licenses, d)

--- a/spdx/v3/v3_0/convert.go
+++ b/spdx/v3/v3_0/convert.go
@@ -87,25 +87,24 @@ func From_v2_3(doc v2_3.Document, d *Document) {
 		c.convert23relationship(rel)
 	}
 
-	// add all elements to the sbom elements
+	// add all converted elements to the sbom elements
+	sbomElements := make(map[AnyElement]struct{}, len(c.sbom.Elements)+len(c.relationshipMap)+len(converted))
+	for _, e := range c.sbom.Elements {
+		sbomElements[e] = struct{}{}
+	}
 	for _, rels := range c.relationshipMap {
-		for _, r := range notNil(rels) {
-			if !slices.Contains(c.sbom.Elements, AnyElement(r)) {
-				c.sbom.Elements = append(c.sbom.Elements, r)
-			}
+		for _, r := range rels {
+			sbomElements[r] = struct{}{}
 		}
+	}
+	for _, e := range converted {
+		sbomElements[e] = struct{}{}
 	}
 
-	for _, e := range notNil(converted) {
-		if !slices.Contains(c.sbom.Elements, e) {
-			c.sbom.Elements = append(c.sbom.Elements, e)
-		}
-	}
+	c.sbom.Elements = mapKeys(sbomElements)
 
 	// ensure all elements are present in the document Elements list
-	for _, e := range collectAllElements(&d.SpdxDocument) {
-		d.SpdxDocument.Elements = append(d.SpdxDocument.Elements, e)
-	}
+	d.SpdxDocument.Elements = append(d.SpdxDocument.Elements, collectAllElements(&d.SpdxDocument)...)
 }
 
 func newDocumentConverter(d *Document) *documentConverter {
@@ -813,8 +812,6 @@ func (c *documentConverter) convert23license(l *v2_3.OtherLicense) AnyLicenseInf
 	}
 
 	out := &CustomLicense{
-		// custom licenses in SPDX 3.0 requires an unfortunate workaround:
-		// we must set a custom URI here because SPDX 3.0 only has
 		ID:       l.LicenseIdentifier,
 		Name:     l.LicenseName,
 		Comment:  l.LicenseComment,
@@ -822,9 +819,7 @@ func (c *documentConverter) convert23license(l *v2_3.OtherLicense) AnyLicenseInf
 		Text:     l.ExtractedText,
 	}
 
-	c.idMap[l.LicenseIdentifier] = out
-
-	return out
+	return c.resolveLicenseRefs(out)
 }
 
 func (c *documentConverter) convert23licenseExpression(licenseExpression string) AnyLicenseInfo {
@@ -844,33 +839,33 @@ func (c *documentConverter) convert23licenseExpression(licenseExpression string)
 // identifiers with the resolved CustomLicense instances registered in
 // idMap by convert23license.
 func (c *documentConverter) resolveLicenseRefs(license AnyLicenseInfo) AnyLicenseInfo {
+	if isNil(license) { // avoid interface-to-nil values
+		return nil
+	}
+	if license.GetID() != "" {
+		if existing, _ := c.idMap[license.GetID()].(AnyLicenseInfo); existing != nil {
+			return existing
+		}
+		c.idMap[license.GetID()] = license
+	}
 	switch l := license.(type) {
-	case *ListedLicense:
-		if l.ID != "" {
-			if existing, _ := c.idMap[l.ID].(AnyListedLicense); existing != nil {
-				return existing
-			}
-			c.idMap[l.ID] = l
+	case AnyConjunctiveLicenseSet:
+		members := l.GetMembers()
+		for i, m := range members {
+			members[i] = c.resolveLicenseRefs(m)
 		}
-	case *CustomLicense:
-		if resolved, ok := c.idMap[l.ID].(AnyCustomLicense); ok {
-			return resolved
+	case AnyDisjunctiveLicenseSet:
+		members := l.GetMembers()
+		for i, m := range members {
+			members[i] = c.resolveLicenseRefs(m)
 		}
-	case *ConjunctiveLicenseSet:
-		for i, m := range l.Members {
-			l.Members[i] = c.resolveLicenseRefs(m)
+	case AnyOrLaterOperator:
+		if resolved, ok := c.resolveLicenseRefs(l.GetSubjectLicense()).(AnyLicense); ok {
+			l.SetSubjectLicense(resolved)
 		}
-	case *DisjunctiveLicenseSet:
-		for i, m := range l.Members {
-			l.Members[i] = c.resolveLicenseRefs(m)
-		}
-	case *OrLaterOperator:
-		if resolved, ok := c.resolveLicenseRefs(l.SubjectLicense).(AnyLicense); ok {
-			l.SubjectLicense = resolved
-		}
-	case *WithAdditionOperator:
-		if resolved, ok := c.resolveLicenseRefs(l.SubjectExtendableLicense).(AnyExtendableLicense); ok {
-			l.SubjectExtendableLicense = resolved
+	case AnyWithAdditionOperator:
+		if resolved, ok := c.resolveLicenseRefs(l.GetSubjectExtendableLicense()).(AnyExtendableLicense); ok {
+			l.SetSubjectExtendableLicense(resolved)
 		}
 	}
 	return license

--- a/spdx/v3/v3_0/convert.go
+++ b/spdx/v3/v3_0/convert.go
@@ -85,18 +85,18 @@ func From_v2_3(doc v2_3.Document, d *Document) {
 		c.convert23relationship(rel)
 	}
 
-	// if the user did not add elements to the document via DOCUMENT relationships, just add all elements directly
-	if len(c.sbom.RootElements) == 0 {
-		c.sbom.RootElements = notNil(converted)
+	// add all elements to the sbom elements
+	for _, rels := range c.relationshipMap {
+		for _, r := range notNil(rels) {
+			if !slices.Contains(c.sbom.Elements, AnyElement(r)) {
+				c.sbom.Elements = append(c.sbom.Elements, r)
+			}
+		}
 	}
 
-	// in SPDX 2.3, relationships are all directly associated with the top-level document (which is an SBOM, effectively)
-	for _, rels := range c.relationshipMap {
-		for _, r := range rels {
-			if r == nil {
-				continue
-			}
-			c.sbom.RootElements = append(c.sbom.RootElements, r)
+	for _, e := range notNil(converted) {
+		if !slices.Contains(c.sbom.Elements, e) {
+			c.sbom.Elements = append(c.sbom.Elements, e)
 		}
 	}
 
@@ -114,7 +114,7 @@ func newDocumentConverter(d *Document) *documentConverter {
 	d.RootElements = ElementList{sbom}
 	c := &documentConverter{
 		emailExtractor:  regexp.MustCompile(`(.*)\s*[(<]([^)>]+)[)>]$`),
-		relationshipMap: map[any][]*Relationship{},
+		relationshipMap: map[any][]AnyRelationship{},
 		sbom:            sbom,
 		idMap: duplicateLower(map[string]any{
 			"DOCUMENT":         sbom,
@@ -122,7 +122,7 @@ func newDocumentConverter(d *Document) *documentConverter {
 		}),
 		lifecycleMap: duplicateLower(map[string]LifecycleScopeType{
 			"BUILD_TOOL_OF":         LifecycleScopeType_Build,
-			"DEPENDS_ON":            LifecycleScopeType_Build,
+			"BUILD_DEPENDENCY_OF":   LifecycleScopeType_Build,
 			"DEV_DEPENDENCY_OF":     LifecycleScopeType_Development,
 			"DEV_TOOL_OF":           LifecycleScopeType_Development,
 			"RUNTIME_DEPENDENCY_OF": LifecycleScopeType_Runtime,
@@ -179,7 +179,7 @@ func newDocumentConverter(d *Document) *documentConverter {
 			"DEPENDS_ON":            RelationshipType_DependsOn,
 		}),
 		hashAlgorithmMap: duplicateLower(map[string]HashAlgorithm{
-			"ADLER32":     HashAlgorithm_Other,
+			"ADLER32":     HashAlgorithm_Adler32,
 			"BLAKE2b_256": HashAlgorithm_Blake2b256,
 			"BLAKE2b_384": HashAlgorithm_Blake2b384,
 			"BLAKE2b_512": HashAlgorithm_Blake2b512,
@@ -195,7 +195,7 @@ func newDocumentConverter(d *Document) *documentConverter {
 			"SHA3_256":    HashAlgorithm_Sha3_256,
 			"SHA3_384":    HashAlgorithm_Sha3_384,
 			"SHA3_512":    HashAlgorithm_Sha3_512,
-			"SHA512":      HashAlgorithm_Sha3_512,
+			"SHA512":      HashAlgorithm_Sha512,
 		}),
 		annotationTypeMap: duplicateLower(map[string]AnnotationType{
 			"OTHER":  AnnotationType_Other,
@@ -222,6 +222,7 @@ func newDocumentConverter(d *Document) *documentConverter {
 		}),
 		primaryPurposeMap: duplicateLower(map[string]SoftwarePurpose{
 			"APPLICATION":      SoftwarePurpose_Application,
+			"BINARY":           SoftwarePurpose_Application,
 			"ARCHIVE":          SoftwarePurpose_Archive,
 			"CONTAINER":        SoftwarePurpose_Container,
 			"DEVICE":           SoftwarePurpose_Device,
@@ -230,6 +231,7 @@ func newDocumentConverter(d *Document) *documentConverter {
 			"FRAMEWORK":        SoftwarePurpose_Framework,
 			"INSTALL":          SoftwarePurpose_Install,
 			"LIBRARY":          SoftwarePurpose_Library,
+			"OPERATING-SYSTEM": SoftwarePurpose_OperatingSystem,
 			"OPERATING_SYSTEM": SoftwarePurpose_OperatingSystem,
 			"OTHER":            SoftwarePurpose_Other,
 			"SOURCE":           SoftwarePurpose_Source,
@@ -243,7 +245,7 @@ type documentConverter struct {
 	//namespace                 string
 	idMap                     map[string]any
 	creationInfo              AnyCreationInfo
-	relationshipMap           map[any][]*Relationship
+	relationshipMap           map[any][]AnyRelationship
 	relationshipTypeMap       map[string]RelationshipType
 	inverseRelationshipMap    map[string]RelationshipType
 	lifecycleMap              map[string]LifecycleScopeType
@@ -258,51 +260,71 @@ type documentConverter struct {
 	conversionErrors          []error
 }
 
-func (c *documentConverter) addRelationship(r *Relationship) {
-	rels := c.relationshipMap[r.From]
+func (c *documentConverter) addRelationship(r AnyRelationship) {
+	rels := c.relationshipMap[r.GetFrom()]
 	for _, existing := range rels {
-		if existing.Type == r.Type {
-			if r.Comment != existing.Comment {
+		if reflect.TypeOf(existing) != reflect.TypeOf(r) {
+			// don't merge LifecycleScopedRelationship and Relationship
+			continue
+		}
+		if existing.GetType() == r.GetType() {
+			if r.GetComment() != existing.GetComment() {
 				continue
 			}
-			existing.To = appendUnique(existing.To, r.To...)
+			if ls, ok := existing.(AnyLifecycleScopedRelationship); ok {
+				if rs, ok := r.(AnyLifecycleScopedRelationship); ok {
+					if ls.GetScope() != rs.GetScope() {
+						continue
+					}
+				}
+			}
+			existing.SetTo(appendUnique(existing.GetTo(), r.GetTo()...))
 			return
 		}
 	}
-	c.relationshipMap[r.From] = append(c.relationshipMap[r.From], r)
+	c.relationshipMap[r.GetFrom()] = append(c.relationshipMap[r.GetFrom()], r)
 }
 
-func (c *documentConverter) convert23relationship(rel *v2_3.Relationship) AnyRelationship {
+func (c *documentConverter) convert23relationship(rel *v2_3.Relationship) {
 	if rel == nil {
-		return nil
+		return
 	}
 	from, _ := c.idMap[string(rel.RefA.ElementRefID)].(AnyElement)
 	to, _ := c.idMap[string(rel.RefB.ElementRefID)].(AnyElement)
 	if from == nil || to == nil {
 		c.logDropped(rel)
-		return nil
+		return
 	}
+
+	lifecycleScope, isLifecycle := c.lifecycleMap[rel.Relationship]
 
 	typ, invert := c.convert23relationshipType(rel.Relationship)
 	if invert {
 		to, from = from, to
 	}
 
-	// SPDX 3 direct document elements are in RootElement list, not relationships
-	if from == c.sbom {
-		// TODO are there special cases depending on type?
+	// SPDX 3 direct document DESCRIBES elements are in RootElement list, not relationships
+	if from == c.sbom && typ == RelationshipType_Describes {
 		c.sbom.RootElements = append(c.sbom.RootElements, to)
-		return nil
+		return
 	}
 
-	r := &Relationship{
-		Comment: rel.RelationshipComment,
-		From:    from,
-		Type:    typ,
-		To:      ElementList{to},
+	if isLifecycle {
+		c.addRelationship(&LifecycleScopedRelationship{
+			Comment: rel.RelationshipComment,
+			From:    from,
+			Type:    typ,
+			Scope:   lifecycleScope,
+			To:      ElementList{to},
+		})
+	} else {
+		c.addRelationship(&Relationship{
+			Comment: rel.RelationshipComment,
+			From:    from,
+			Type:    typ,
+			To:      ElementList{to},
+		})
 	}
-	c.addRelationship(r)
-	return r
 }
 
 func (c *documentConverter) convert23relationshipType(typ string) (RelationshipType, bool) {
@@ -328,6 +350,15 @@ func (c *documentConverter) convert23creationInfo(info *v2_3.CreationInfo) AnyCr
 		CreatedBy:    list[AgentList](c.convert23creator, info.Creators...),
 		CreatedUsing: list[ToolList](c.convert23tool, info.Creators...),
 		SpecVersion:  Version, // specVersion is always the current version
+	}
+
+	if info.LicenseListVersion != "" {
+		licenseListComment := fmt.Sprintf("LicenseListVersion: %v", info.LicenseListVersion)
+		if ci.Comment == "" {
+			ci.Comment = licenseListComment
+		} else {
+			ci.Comment = fmt.Sprintf("%v; %v", ci.Comment, licenseListComment)
+		}
 	}
 
 	// update circular references, which will be set to nil by default
@@ -358,6 +389,9 @@ func (c *documentConverter) convert23tool(creator common.Creator) AnyTool {
 }
 
 func (c *documentConverter) convert23creator(creator common.Creator) AnyAgent {
+	if strings.EqualFold(creator.CreatorType, "tool") {
+		return nil // not applicable for creator
+	}
 	return c.convert23agent(creator.CreatorType, creator.Creator)
 }
 
@@ -406,18 +440,22 @@ func (c *documentConverter) convert23agent(typ, name string) AnyAgent {
 		emailValue = strings.TrimSpace(match[2])
 	}
 	var out AnyAgent
-	switch strings.ToLower(typ) {
-	case "person":
+	switch {
+	case strings.EqualFold(typ, "person"):
 		out = &Person{
 			CreationInfo: c.creationInfo,
 			Name:         name,
 		}
-	case "organization", "org":
+	case strings.EqualFold(typ, "organization") || strings.EqualFold(typ, "org"):
 		out = &Organization{
 			CreationInfo: c.creationInfo,
 			Name:         name,
 		}
-	case "tool": // handled elsewhere
+	case strings.EqualFold(typ, "tool"):
+		out = &SoftwareAgent{
+			CreationInfo: c.creationInfo,
+			Name:         name,
+		}
 	default:
 		c.logDropped(fmt.Sprintf("unknown agent type: %v with value: %v", typ, name))
 	}
@@ -436,7 +474,6 @@ func (c *documentConverter) convert23file(f *v2_3.File) AnyFile {
 		ID:               string(f.FileSPDXIdentifier),
 		Comment:          f.FileComment,
 		Name:             f.FileName,
-		Description:      f.FileNotice,
 		ExternalRefs:     nil,
 		Summary:          "",
 		VerifiedUsing:    list[IntegrityMethodList](c.convert23checksum, f.Checksums...),
@@ -453,6 +490,19 @@ func (c *documentConverter) convert23file(f *v2_3.File) AnyFile {
 		Kind:             FileKindType_File,
 	}
 
+	for _, typ := range f.FileTypes {
+		purpose, ok := c.primaryPurposeMap[strings.ToUpper(typ)]
+		if !ok || purpose == SoftwarePurpose_File {
+			continue
+		}
+		emptyPurpose := SoftwarePurpose{}
+		if out.PrimaryPurpose == emptyPurpose {
+			out.PrimaryPurpose = purpose
+		} else {
+			out.AdditionalPurposes = append(out.AdditionalPurposes, purpose)
+		}
+	}
+
 	c.idMap[string(f.FileSPDXIdentifier)] = out
 
 	for _, s := range f.Snippets {
@@ -466,11 +516,49 @@ func (c *documentConverter) convert23file(f *v2_3.File) AnyFile {
 
 	for _, a := range f.Annotations {
 		v3 := c.convert23annotation(&a)
+		v3.SetSubject(out)
 		c.addRelationship(&Relationship{
 			Type: RelationshipType_Describes,
 			From: v3,
 			To:   ElementList{out},
 		})
+	}
+
+	if f.FileNotice != "" {
+		v3 := &Annotation{
+			Type:      AnnotationType_Other,
+			Statement: f.FileNotice,
+		}
+		v3.SetSubject(out)
+		c.addRelationship(&Relationship{
+			Type: RelationshipType_Describes,
+			From: v3,
+			To:   ElementList{out},
+		})
+	}
+
+	licenseComment := f.LicenseComments
+	concluded := c.convert23licenseExpression(f.LicenseConcluded)
+	if concluded != nil {
+		concluded.SetComment(licenseComment)
+		licenseComment = "" // only include in concluded if set
+		c.addRelationship(&Relationship{
+			Type: RelationshipType_HasConcludedLicense,
+			From: out,
+			To:   ElementList{concluded},
+		})
+	}
+
+	for _, l := range f.LicenseInfoInFiles {
+		d := c.convert23licenseExpression(l)
+		if d != nil {
+			d.SetComment(licenseComment)
+			c.addRelationship(&Relationship{
+				Type: RelationshipType_HasDeclaredLicense,
+				From: out,
+				To:   ElementList{d},
+			})
+		}
 	}
 
 	return out
@@ -481,7 +569,17 @@ func (c *documentConverter) convert23package(pkg *v2_3.Package) AnyPackage {
 		return nil
 	}
 
-	verificationCodes := list[IntegrityMethodList](c.convert23packageVerificationCode, pkg.PackageVerificationCode)
+	var verificationCodes IntegrityMethodList
+
+	if pkg.FilesAnalyzed {
+		// verification code only valid if FilesAnalyzed
+		verificationCode := c.convert23packageVerificationCode(pkg.PackageVerificationCode)
+		if verificationCode != nil {
+			verificationCodes = append(verificationCodes, verificationCode)
+		}
+	} else {
+		c.logDropped(pkg.PackageVerificationCode)
+	}
 
 	for _, checksum := range pkg.PackageChecksums {
 		ck := c.convert23checksum(checksum)
@@ -498,6 +596,7 @@ func (c *documentConverter) convert23package(pkg *v2_3.Package) AnyPackage {
 		Comment:             pkg.PackageComment,
 		Description:         pkg.PackageDescription,
 		ExternalIdentifiers: list[ExternalIdentifierList](c.convert23externalIdentifier, pkg.PackageExternalReferences...),
+		ExternalRefs:        list[ExternalRefList](c.convert23externalRef, pkg.PackageExternalReferences...),
 		VerifiedUsing:       verificationCodes,
 		BuiltTime:           c.convert23time(pkg.BuiltDate),
 		OriginatedBy:        list[AgentList](c.convert23originator, pkg.PackageOriginator),
@@ -547,7 +646,7 @@ func (c *documentConverter) convert23package(pkg *v2_3.Package) AnyPackage {
 		d := c.convert23licenseExpression(l)
 		if d != nil {
 			c.addRelationship(&Relationship{
-				Type: RelationshipType_HasConcludedLicense,
+				Type: RelationshipType_HasDeclaredLicense,
 				From: out,
 				To:   ElementList{d},
 			})
@@ -571,15 +670,40 @@ func (c *documentConverter) convert23package(pkg *v2_3.Package) AnyPackage {
 		})
 	}
 
+	hasPackageFile := false
 	for _, f := range pkg.Files {
 		v3file := c.convert23file(f)
 		if v3file == nil {
 			continue
 		}
+		if v3file.GetName() == pkg.PackageName {
+			hasPackageFile = true
+		}
 		c.addRelationship(&Relationship{
 			Type: RelationshipType_Contains,
 			From: out,
 			To:   ElementList{v3file},
+		})
+	}
+
+	if !hasPackageFile && pkg.PackageFileName != "" {
+		v3file := &File{
+			Name: pkg.PackageFileName,
+		}
+		c.addRelationship(&Relationship{
+			Type: RelationshipType_HasDistributionArtifact,
+			From: out,
+			To:   ElementList{v3file},
+		})
+	}
+
+	for _, a := range pkg.Annotations {
+		v3 := c.convert23annotation(&a)
+		v3.SetSubject(out)
+		c.addRelationship(&Relationship{
+			Type: RelationshipType_Describes,
+			From: v3,
+			To:   ElementList{out},
 		})
 	}
 
@@ -649,13 +773,32 @@ func (c *documentConverter) convert23externalIdentifier(r *v2_3.PackageExternalR
 	}
 	typ, ok := c.externalIdentifierTypeMap[r.RefType]
 	if !ok || r.Locator == "" {
-		c.logDropped(r)
+		_, ok = c.externalRefTypeMap[r.RefType]
+		if !ok {
+			c.logDropped(r)
+		}
 		return nil
 	}
 	return &ExternalIdentifier{
 		Comment:    r.ExternalRefComment,
 		Type:       typ,
 		Identifier: r.Locator,
+	}
+}
+
+func (c *documentConverter) convert23externalRef(r *v2_3.PackageExternalReference) AnyExternalRef {
+	if r == nil {
+		return nil
+	}
+	typ, ok := c.externalRefTypeMap[r.RefType]
+	if !ok || r.Locator == "" {
+		// logged during convert23externalIdentifier
+		return nil
+	}
+	return &ExternalRef{
+		Comment:  r.ExternalRefComment,
+		Type:     typ,
+		Locators: []string{r.Locator},
 	}
 }
 
@@ -735,12 +878,14 @@ func (c *documentConverter) convert23annotation(a *v2_3.Annotation) AnyAnnotatio
 			Created:   c.convert23time(a.AnnotationDate),
 			CreatedBy: list[AgentList](c.convert23annotator, &a.Annotator),
 		},
-		Type:      typ,
+		// V3 Statement is "Commentary on an assertion that an annotator has made"
 		Statement: a.AnnotationComment,
+		Type:      typ,
 	}
 
 	to, _ := c.idMap[string(a.AnnotationSPDXIdentifier.ElementRefID)].(AnyElement)
 	if to != nil {
+		out.Subject = to
 		c.addRelationship(&Relationship{
 			Type: RelationshipType_Describes,
 			From: out,
@@ -753,20 +898,24 @@ func (c *documentConverter) convert23annotation(a *v2_3.Annotation) AnyAnnotatio
 func (c *documentConverter) convert23snippet(s v2_3.Snippet) AnyElement {
 	snippetFile, _ := c.idMap[string(s.SnippetFromFileSPDXIdentifier)].(AnyFile)
 
-	var licenses LicenseInfoList
-	d := c.convert23licenseExpression(s.SnippetLicenseConcluded)
-	d.SetComment(s.SnippetLicenseComments)
-	licenses = append(licenses, d)
+	concludedLicense := c.convert23licenseExpression(s.SnippetLicenseConcluded)
 
+	var declaredLicenses LicenseInfoList
 	for _, licenseInfo := range s.LicenseInfoInSnippet {
-		d = c.convert23licenseExpression(licenseInfo)
+		d := c.convert23licenseExpression(licenseInfo)
 		if d != nil {
-			d.SetComment(s.SnippetLicenseComments)
-			licenses = append(licenses, d)
+			declaredLicenses = append(declaredLicenses, d)
 		}
 	}
 
-	var allSnippets ElementList
+	out := &Snippet{
+		ID:               string(s.SnippetSPDXIdentifier),
+		Comment:          s.SnippetComment,
+		Name:             s.SnippetName,
+		CopyrightText:    s.SnippetCopyrightText,
+		AttributionTexts: s.SnippetAttributionTexts,
+		FromFile:         snippetFile,
+	}
 
 	for _, r := range s.Ranges {
 		// there are 2 spots that might hold references to the file, try to handle them both:
@@ -776,55 +925,43 @@ func (c *documentConverter) convert23snippet(s v2_3.Snippet) AnyElement {
 		}
 		if snippetFile == nil {
 			snippetFile = f
+			out.FromFile = f
 		}
-		newSnippet := &Snippet{
-			ID:               string(s.SnippetSPDXIdentifier),
-			Comment:          s.SnippetComment,
-			Name:             s.SnippetName,
-			CopyrightText:    s.SnippetCopyrightText,
-			AttributionTexts: s.SnippetAttributionTexts,
-			FromFile:         f,
-			LineRange: &PositiveIntegerRange{
-				BeginIntegerRange: ld.PositiveInt(r.StartPointer.LineNumber),
-				EndIntegerRange:   ld.PositiveInt(r.EndPointer.LineNumber),
-			},
-			ByteRange: &PositiveIntegerRange{
+		if r.StartPointer.Offset > 0 || r.EndPointer.Offset > 0 {
+			out.ByteRange = &PositiveIntegerRange{
 				BeginIntegerRange: ld.PositiveInt(r.StartPointer.Offset),
 				EndIntegerRange:   ld.PositiveInt(r.EndPointer.Offset),
-			},
+			}
 		}
-
-		for _, l := range licenses {
-			c.addRelationship(&Relationship{
-				Type: RelationshipType_HasConcludedLicense,
-				From: newSnippet,
-				To:   ElementList{l},
-			})
+		if r.StartPointer.LineNumber > 0 || r.EndPointer.LineNumber > 0 {
+			out.LineRange = &PositiveIntegerRange{
+				BeginIntegerRange: ld.PositiveInt(r.StartPointer.LineNumber),
+				EndIntegerRange:   ld.PositiveInt(r.EndPointer.LineNumber),
+			}
 		}
-
-		allSnippets = append(allSnippets, newSnippet)
 	}
 
-	var out AnyElement
-	switch len(allSnippets) {
-	case 0:
-	case 1:
-		out = allSnippets[0]
-	default:
-		out = &Bundle{
-			Elements: allSnippets,
+	if concludedLicense != nil {
+		concludedLicense.SetComment(s.SnippetLicenseComments)
+		c.addRelationship(&Relationship{
+			Type: RelationshipType_HasConcludedLicense,
+			From: out,
+			To:   ElementList{concludedLicense},
+		})
+	}
+
+	for _, l := range declaredLicenses {
+		if concludedLicense == nil {
+			l.SetComment(s.SnippetLicenseComments)
 		}
+		c.addRelationship(&Relationship{
+			Type: RelationshipType_HasDeclaredLicense,
+			From: out,
+			To:   ElementList{l},
+		})
 	}
 
 	c.idMap[string(s.SnippetSPDXIdentifier)] = out
-
-	if snippetFile != nil {
-		c.addRelationship(&Relationship{
-			Type: RelationshipType_Describes,
-			From: out,
-			To:   ElementList{snippetFile},
-		})
-	}
 
 	return out
 }

--- a/spdx/v3/v3_0/convert_test.go
+++ b/spdx/v3/v3_0/convert_test.go
@@ -3,6 +3,7 @@ package v3_0
 import (
 	"fmt"
 	"maps"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -10,6 +11,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
+	"github.com/spdx/tools-golang/spdx"
 )
 
 func Test_convertElements(t *testing.T) {
@@ -80,6 +83,122 @@ func Test_convertElements(t *testing.T) {
 			},
 		},
 		{
+			name: "small document with packages",
+			expected: func() *Document {
+				p1 := &Package{
+					ID:   "pkg-1",
+					Name: "pkg-1",
+				}
+				p2 := &Package{
+					ID:   "pkg-2",
+					Name: "pkg-2",
+				}
+				r1 := &Relationship{
+					Type: RelationshipType_Contains,
+					From: p1,
+					To:   ElementList{p2},
+				}
+				sbom := &SBOM{
+					Elements: ElementList{
+						p1,
+						p2,
+						r1,
+					},
+					RootElements: ElementList{
+						p1,
+					},
+				}
+				return &Document{
+					SpdxDocument: SpdxDocument{
+						NamespaceMaps:       NamespaceMapList{&NamespaceMap{Namespace: "https://spdx.org/spdxdocs/#", Prefix: "SPDXRef"}},
+						ProfileConformances: []ProfileIdentifierType{ProfileIdentifierType_Core, ProfileIdentifierType_Software},
+						RootElements: ElementList{
+							sbom,
+						},
+						// all collected elements:
+						Elements: ElementList{
+							sbom,
+							p1,
+							p2,
+							r1,
+						},
+					},
+				}
+			}(),
+			convert: func(c *documentConverter) any {
+				d := &Document{}
+				From_v2_3(spdx.Document{
+					Packages: []*spdx.Package{
+						{
+							PackageSPDXIdentifier: "pkg-1",
+							PackageName:           "pkg-1",
+						},
+						{
+							PackageSPDXIdentifier: "pkg-2",
+							PackageName:           "pkg-2",
+						},
+					},
+					Relationships: []*spdx.Relationship{
+						{
+							Relationship: spdx.RelationshipDescribes,
+							RefA:         spdx.DocElementID{ElementRefID: "DOCUMENT"},
+							RefB:         spdx.DocElementID{ElementRefID: "pkg-1"},
+						},
+						{
+							Relationship: spdx.RelationshipContains,
+							RefA:         spdx.DocElementID{ElementRefID: "pkg-1"},
+							RefB:         spdx.DocElementID{ElementRefID: "pkg-2"},
+						},
+					},
+				}, d)
+				return d
+			},
+		},
+		{
+			name: "small document with annotations",
+			expected: func() *Document {
+				a1 := &Annotation{
+					ID:        "annotation-1",
+					Type:      AnnotationType_Review,
+					Statement: "annotation-comment-1",
+				}
+				sbom := &SBOM{
+					Elements: ElementList{
+						a1,
+					},
+					RootElements: nil,
+				}
+				return &Document{
+					SpdxDocument: SpdxDocument{
+						NamespaceMaps:       NamespaceMapList{&NamespaceMap{Namespace: "https://spdx.org/spdxdocs/#", Prefix: "SPDXRef"}},
+						ProfileConformances: []ProfileIdentifierType{ProfileIdentifierType_Core, ProfileIdentifierType_Software},
+						RootElements: ElementList{
+							sbom,
+						},
+						// all collected elements:
+						Elements: ElementList{
+							sbom,
+							a1,
+						},
+					},
+				}
+			}(),
+			convert: func(c *documentConverter) any {
+				d := &Document{}
+				From_v2_3(spdx.Document{
+					Annotations: []*spdx.Annotation{
+						{
+							AnnotationSPDXIdentifier: spdx.DocElementID{ElementRefID: "annotation-1"},
+							AnnotationType:           "REVIEW",
+							AnnotationComment:        "annotation-comment-1",
+						},
+					},
+					Relationships: []*spdx.Relationship{},
+				}, d)
+				return d
+			},
+		},
+		{
 			name:     "full document",
 			expected: v301doc(),
 			convert: func(c *documentConverter) any {
@@ -115,45 +234,36 @@ func Test_documentConversion(t *testing.T) {
 
 	opts := diffOpts()
 
-	collected := collectAllElements(&converted.SpdxDocument)
-	convertedElements := ElementList(slices.Collect(maps.Values(collected)))
+	convertedElements := ElementList(slices.Collect(maps.Values(collectAllElements(&converted.SpdxDocument))))
 	expectedElements := ElementList(slices.Collect(maps.Values(collectAllElements(&expected.SpdxDocument))))
 	tests := []struct {
 		name     string
 		expected any
 		got      any
 	}{
-		{"Packages", sorted(expectedElements.Packages()), sorted(convertedElements.Packages())},
-		{"Files", sorted(expectedElements.Files()), sorted(convertedElements.Files())},
-		{"Snippets", sorted(expectedElements.Snippets()), sorted(convertedElements.Snippets())},
-		{"Annotations", sorted(expectedElements.Annotations()), sorted(convertedElements.Annotations())},
-		{"Relationships", sorted(expectedElements.Relationships()), sorted(convertedElements.Relationships())},
-		{"CustomLicenses", sorted(expectedElements.CustomLicenses()), sorted(convertedElements.CustomLicenses())},
-		{"ListedLicenses", sorted(expectedElements.ListedLicenses()), sorted(convertedElements.ListedLicenses())},
-		{"DisjunctiveLicenseSets", sorted(expectedElements.DisjunctiveLicenseSets()), sorted(convertedElements.DisjunctiveLicenseSets())},
-		{"ConjunctiveLicenseSets", sorted(expectedElements.ConjunctiveLicenseSets()), sorted(convertedElements.ConjunctiveLicenseSets())},
-		{"WithAdditionOperators", sorted(expectedElements.WithAdditionOperators()), sorted(convertedElements.WithAdditionOperators())},
-		{"ListedLicenseExceptions", sorted(expectedElements.ListedLicenseExceptions()), sorted(convertedElements.ListedLicenseExceptions())},
-		{"OrLaterOperators", sorted(expectedElements.OrLaterOperators()), sorted(convertedElements.OrLaterOperators())},
+		{"Packages", expectedElements.Packages(), convertedElements.Packages()},
+		{"Files", expectedElements.Files(), convertedElements.Files()},
+		{"Snippets", expectedElements.Snippets(), convertedElements.Snippets()},
+		{"Annotations", expectedElements.Annotations(), convertedElements.Annotations()},
+		{"Relationships", expectedElements.Relationships(), convertedElements.Relationships()},
+		{"CustomLicenses", expectedElements.CustomLicenses(), convertedElements.CustomLicenses()},
+		{"ListedLicenses", expectedElements.ListedLicenses(), convertedElements.ListedLicenses()},
+		{"DisjunctiveLicenseSets", expectedElements.DisjunctiveLicenseSets(), convertedElements.DisjunctiveLicenseSets()},
+		{"ConjunctiveLicenseSets", expectedElements.ConjunctiveLicenseSets(), convertedElements.ConjunctiveLicenseSets()},
+		{"WithAdditionOperators", expectedElements.WithAdditionOperators(), convertedElements.WithAdditionOperators()},
+		{"ListedLicenseExceptions", expectedElements.ListedLicenseExceptions(), convertedElements.ListedLicenseExceptions()},
+		{"OrLaterOperators", expectedElements.OrLaterOperators(), convertedElements.OrLaterOperators()},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			require.NotEmpty(t, tt.expected)
 			require.NotEmpty(t, tt.got)
 			if diff := cmp.Diff(tt.expected, tt.got, opts...); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
-}
-
-func sorted[T any, E ~[]T](elements E) E {
-	slices.SortFunc(elements, func(a, b T) int {
-		_a := fmt.Sprintf("%#v", a)
-		_b := fmt.Sprintf("%#v", b)
-		return strings.Compare(_a, _b)
-	})
-	return elements
 }
 
 func diffOpts() []cmp.Option {
@@ -168,6 +278,7 @@ func diffOpts() []cmp.Option {
 		Tool{},
 		Person{},
 		Organization{},
+		SoftwareAgent{},
 		CustomLicense{},
 		ListedLicense{},
 		OrLaterOperator{},
@@ -184,16 +295,10 @@ func diffOpts() []cmp.Option {
 			cmpopts.IgnoreFields(t, "ID", "CreationInfo"),
 		)
 	}
-	for _, t := range []any{
-		SpdxDocument{},
-		SBOM{},
-		Bundle{},
-	} {
-		out = append(out,
-			cmpopts.IgnoreFields(t, "Elements"),
-		)
-	}
 	out = append(out,
+		cmpopts.SortSlices(func(a, b any) int {
+			return strings.Compare(sortKey(a), sortKey(b))
+		}),
 		cmpopts.IgnoreFields(Document{}, "LDContext"),
 		cmpopts.EquateComparable(
 			ExternalIdentifierType{},
@@ -207,6 +312,7 @@ func diffOpts() []cmp.Option {
 			AnnotationType{},
 			ProfileIdentifierType{},
 			ExternalIRI{},
+			LifecycleScopeType{},
 		),
 	)
 	return out
@@ -217,6 +323,60 @@ func newTestConverter() *documentConverter {
 		LDContext: context(),
 	}
 	return newDocumentConverter(&d)
+}
+
+func sortKey(v any) string {
+	return elementSortKey(v, 0)
+}
+
+func elementSortKey(v any, depth int) string {
+	if depth > 4 {
+		return reflect.TypeOf(v).String()
+	}
+	rv := reflect.ValueOf(v)
+	for rv.Kind() == reflect.Ptr && !rv.IsNil() {
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return fmt.Sprintf("%v", v)
+	}
+	typeName := rv.Type().Name()
+	var parts []string
+	for i := 0; i < rv.NumField(); i++ {
+		ft := rv.Type().Field(i)
+		if !ft.IsExported() || ft.Name == "ID" || ft.Name == "CreationInfo" {
+			continue
+		}
+		f := rv.Field(i)
+		if f.IsZero() {
+			continue
+		}
+		switch f.Kind() {
+		case reflect.String:
+			parts = append(parts, ft.Name+"="+f.String())
+		case reflect.Struct:
+			parts = append(parts, ft.Name+"="+fmt.Sprintf("%v", f.Interface()))
+		case reflect.Interface:
+			if !f.IsNil() {
+				parts = append(parts, ft.Name+"="+elementSortKey(f.Interface(), depth+1))
+			}
+		case reflect.Slice:
+			if f.Len() > 0 {
+				var elems []string
+				for j := 0; j < f.Len(); j++ {
+					elems = append(elems, elementSortKey(f.Index(j).Interface(), depth+1))
+				}
+				parts = append(parts, ft.Name+"=["+strings.Join(elems, ",")+"]")
+			}
+		case reflect.Ptr:
+			if !f.IsNil() {
+				parts = append(parts, ft.Name+"="+elementSortKey(f.Interface(), depth+1))
+			}
+		default:
+			parts = append(parts, fmt.Sprintf("%s=%v", ft.Name, f.Interface()))
+		}
+	}
+	return typeName + "{" + strings.Join(parts, ",") + "}"
 }
 
 func first[T1, T2 any](v1 T1, _ T2) T1 {

--- a/spdx/v3/v3_0/convert_test.go
+++ b/spdx/v3/v3_0/convert_test.go
@@ -219,9 +219,7 @@ func Test_convertElements(t *testing.T) {
 			}
 			require.NotNil(t, got)
 			diff := cmp.Diff(tt.expected, got, diffOpts()...)
-			if diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
+			require.Emptyf(t, diff, "mismatch (-want +got):\n%s", diff)
 		})
 	}
 }
@@ -259,9 +257,8 @@ func Test_documentConversion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.NotEmpty(t, tt.expected)
 			require.NotEmpty(t, tt.got)
-			if diff := cmp.Diff(tt.expected, tt.got, opts...); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
+			diff := cmp.Diff(tt.expected, tt.got, opts...)
+			require.Emptyf(t, diff, "mismatch (-want +got):\n%s", diff)
 		})
 	}
 }

--- a/spdx/v3/v3_0/convert_test.go
+++ b/spdx/v3/v3_0/convert_test.go
@@ -2,9 +2,7 @@ package v3_0
 
 import (
 	"fmt"
-	"maps"
 	"reflect"
-	"slices"
 	"strings"
 	"testing"
 
@@ -232,8 +230,8 @@ func Test_documentConversion(t *testing.T) {
 
 	opts := diffOpts()
 
-	convertedElements := ElementList(slices.Collect(maps.Values(collectAllElements(&converted.SpdxDocument))))
-	expectedElements := ElementList(slices.Collect(maps.Values(collectAllElements(&expected.SpdxDocument))))
+	convertedElements := ElementList(collectAllElements(&converted.SpdxDocument))
+	expectedElements := ElementList(collectAllElements(&expected.SpdxDocument))
 	tests := []struct {
 		name     string
 		expected any

--- a/spdx/v3/v3_0/convert_test.go
+++ b/spdx/v3/v3_0/convert_test.go
@@ -1,6 +1,10 @@
 package v3_0
 
 import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -47,6 +51,18 @@ func Test_convertElements(t *testing.T) {
 			expected: v301customLicense1(),
 			convert: func(c *documentConverter) any {
 				return c.convert23license(v23customLicense1())
+			},
+		},
+		{
+			name: "licenseExpression",
+			expected: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&ListedLicense{Name: "Apache-2.0"},
+				},
+			},
+			convert: func(c *documentConverter) any {
+				return c.convert23licenseExpression("MIT OR Apache-2.0")
 			},
 		},
 		{
@@ -97,17 +113,47 @@ func Test_documentConversion(t *testing.T) {
 	converted := &Document{}
 	From_v2_3(*v23doc(), converted)
 
-	startPkgs := expected.Elements.Packages()
-	gotPkgs := converted.Elements.Packages()
-	if diff := cmp.Diff(startPkgs, gotPkgs, diffOpts()...); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+	opts := diffOpts()
+
+	collected := collectAllElements(&converted.SpdxDocument)
+	convertedElements := ElementList(slices.Collect(maps.Values(collected)))
+	expectedElements := ElementList(slices.Collect(maps.Values(collectAllElements(&expected.SpdxDocument))))
+	tests := []struct {
+		name     string
+		expected any
+		got      any
+	}{
+		{"Packages", sorted(expectedElements.Packages()), sorted(convertedElements.Packages())},
+		{"Files", sorted(expectedElements.Files()), sorted(convertedElements.Files())},
+		{"Snippets", sorted(expectedElements.Snippets()), sorted(convertedElements.Snippets())},
+		{"Annotations", sorted(expectedElements.Annotations()), sorted(convertedElements.Annotations())},
+		{"Relationships", sorted(expectedElements.Relationships()), sorted(convertedElements.Relationships())},
+		{"CustomLicenses", sorted(expectedElements.CustomLicenses()), sorted(convertedElements.CustomLicenses())},
+		{"ListedLicenses", sorted(expectedElements.ListedLicenses()), sorted(convertedElements.ListedLicenses())},
+		{"DisjunctiveLicenseSets", sorted(expectedElements.DisjunctiveLicenseSets()), sorted(convertedElements.DisjunctiveLicenseSets())},
+		{"ConjunctiveLicenseSets", sorted(expectedElements.ConjunctiveLicenseSets()), sorted(convertedElements.ConjunctiveLicenseSets())},
+		{"WithAdditionOperators", sorted(expectedElements.WithAdditionOperators()), sorted(convertedElements.WithAdditionOperators())},
+		{"ListedLicenseExceptions", sorted(expectedElements.ListedLicenseExceptions()), sorted(convertedElements.ListedLicenseExceptions())},
+		{"OrLaterOperators", sorted(expectedElements.OrLaterOperators()), sorted(convertedElements.OrLaterOperators())},
 	}
 
-	startRels := expected.Elements.Relationships()
-	gotRels := converted.Elements.Relationships()
-	if diff := cmp.Diff(startRels, gotRels, diffOpts()...); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotEmpty(t, tt.got)
+			if diff := cmp.Diff(tt.expected, tt.got, opts...); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
+}
+
+func sorted[T any, E ~[]T](elements E) E {
+	slices.SortFunc(elements, func(a, b T) int {
+		_a := fmt.Sprintf("%#v", a)
+		_b := fmt.Sprintf("%#v", b)
+		return strings.Compare(_a, _b)
+	})
+	return elements
 }
 
 func diffOpts() []cmp.Option {
@@ -124,6 +170,12 @@ func diffOpts() []cmp.Option {
 		Organization{},
 		CustomLicense{},
 		ListedLicense{},
+		OrLaterOperator{},
+		DisjunctiveLicenseSet{},
+		ConjunctiveLicenseSet{},
+		WithAdditionOperator{},
+		ListedLicenseException{},
+		CustomLicenseAddition{},
 		SpdxDocument{},
 		SBOM{},
 	} {

--- a/spdx/v3/v3_0/convert_v23_test.go
+++ b/spdx/v3/v3_0/convert_v23_test.go
@@ -161,7 +161,7 @@ func v23package2() *v2_3.Package {
 		},
 		PackageHomePage:         "https://tools.com/utility",
 		PackageLicenseConcluded: "Apache-2.0",
-		PackageLicenseDeclared:  "AGPL OR (GPL-2.0-only with Classpath-Exception OR LicenceRef-CustomLicense1)",
+		PackageLicenseDeclared:  "AGPL OR (GPL-2.0-only with Classpath-Exception OR LicenseRef-CustomLicense1)",
 		PackageCopyrightText:    "Copyright 2023 Tools Inc",
 		PackageSummary:          "Collection of utility tools",
 		PackageDescription:      "A comprehensive set of utility tools for developers.",

--- a/spdx/v3/v3_0/convert_v23_test.go
+++ b/spdx/v3/v3_0/convert_v23_test.go
@@ -48,7 +48,7 @@ func v23doc() *v2_3.Document {
 			{
 				RefA:                common.DocElementID{ElementRefID: "SPDXRef-Package-ExampleLib"},
 				RefB:                common.DocElementID{ElementRefID: "SPDXRef-Package-UtilityTools"},
-				Relationship:        common.TypeRelationshipDependsOn,
+				Relationship:        common.TypeRelationshipBuildToolOf,
 				RelationshipComment: "Main package depends on utility tools",
 			},
 			{
@@ -77,7 +77,7 @@ func v23creationInfo() *v2_3.CreationInfo {
 func v23package1() *v2_3.Package {
 	return &v2_3.Package{
 		Annotations: []v2_3.Annotation{
-			*v23annotation1(),
+			*v23annotation3(),
 		},
 		PackageName:           "example-library",
 		PackageSPDXIdentifier: "SPDXRef-Package-ExampleLib",
@@ -94,7 +94,7 @@ func v23package1() *v2_3.Package {
 		PackageDownloadLocation: "https://github.com/example/library/archive/v1.2.3.tar.gz",
 		FilesAnalyzed:           true,
 		Files: []*v2_3.File{
-			v23file1(),
+			v23file3(),
 		},
 		IsFilesAnalyzedTagPresent: true,
 		PackageVerificationCode: &common.PackageVerificationCode{
@@ -154,7 +154,7 @@ func v23package2() *v2_3.Package {
 			SupplierType: "Person",
 		},
 		PackageDownloadLocation:   "https://tools.com/download/utility-tools-2.1.0.zip",
-		FilesAnalyzed:             false,
+		FilesAnalyzed:             true,
 		IsFilesAnalyzedTagPresent: true,
 		PackageChecksums: []common.Checksum{
 			{Algorithm: common.SHA256, Value: "ffaabbcc11223344"},
@@ -215,10 +215,10 @@ func v23file1() *v2_3.File {
 		},
 		//FileDependencies: nil, // skipped
 		Snippets: map[common.ElementID]*v2_3.Snippet{
-			"SPDXRef-Snippet1": v23snippet1(),
+			"SPDXRef-Snippet3": v23snippet3(),
 		},
 		Annotations: []v2_3.Annotation{
-			*v23annotation1(),
+			*v23annotation4(),
 		},
 		FileDependencies: []string{"dep1", "dep2"},
 	}
@@ -231,7 +231,7 @@ func v23file2() *v2_3.File {
 		Checksums: []common.Checksum{
 			{Algorithm: common.SHA256, Value: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
 		},
-		LicenseConcluded:   "MIT",
+		LicenseConcluded:   "MIT AND Apache-2.0",
 		LicenseInfoInFiles: []string{"MIT"},
 		FileCopyrightText:  "Copyright 2023 Example Corp",
 		FileComment:        "Header file with function declarations",
@@ -264,7 +264,7 @@ func v23externalDocumentRef2() *v2_3.ExternalDocumentRef {
 func v23annotation1() *v2_3.Annotation {
 	return &v2_3.Annotation{
 		Annotator: common.Annotator{
-			Annotator:     "Person: Security Team (security@example.com)",
+			Annotator:     "Security Team (security@example.com)",
 			AnnotatorType: "Person",
 		},
 		AnnotationType:           "REVIEW",
@@ -277,7 +277,7 @@ func v23annotation1() *v2_3.Annotation {
 func v23annotation2() *v2_3.Annotation {
 	return &v2_3.Annotation{
 		Annotator: common.Annotator{
-			Annotator:     "Tool: vulnerability-scanner-v1.5",
+			Annotator:     "vulnerability-scanner-v1.5",
 			AnnotatorType: "Tool",
 		},
 		AnnotationType:           "OTHER",
@@ -327,10 +327,77 @@ func v23snippet2() *v2_3.Snippet {
 				EndPointer:   common.SnippetRangePointer{LineNumber: 8},
 			},
 		},
-		SnippetLicenseConcluded: "MIT",
+		SnippetLicenseConcluded: "MIT+",
 		LicenseInfoInSnippet:    []string{"MIT"},
 		SnippetCopyrightText:    "Copyright 2023 Example Corp",
 		SnippetComment:          "Function declarations",
 		SnippetName:             "API Declarations",
+	}
+}
+
+func v23file3() *v2_3.File {
+	return &v2_3.File{
+		FileName:           "./src/utils.c",
+		FileSPDXIdentifier: common.ElementID("SPDXRef-File-Utils"),
+		FileTypes:          []string{"SOURCE"},
+		Checksums: []common.Checksum{
+			{Algorithm: common.SHA256, Value: "aabb1234aabb1234aabb1234aabb1234aabb1234aabb1234aabb1234aabb1234"},
+		},
+		LicenseConcluded:   "Apache-2.0",
+		LicenseInfoInFiles: []string{"Apache-2.0"},
+		FileCopyrightText:  "Copyright 2023 Example Corp",
+		FileComment:        "Utility functions for the library",
+	}
+}
+
+func v23annotation3() *v2_3.Annotation {
+	return &v2_3.Annotation{
+		Annotator: common.Annotator{
+			Annotator:     "Code Review Bot (bot@example.com)",
+			AnnotatorType: "Person",
+		},
+		AnnotationType:           "OTHER",
+		AnnotationSPDXIdentifier: common.DocElementID{ElementRefID: "SPDXRef-Package-ExampleLib"},
+		AnnotationDate:           "2023-02-01T10:00:00Z",
+		AnnotationComment:        "Package structure review completed",
+	}
+}
+
+func v23annotation4() *v2_3.Annotation {
+	return &v2_3.Annotation{
+		Annotator: common.Annotator{
+			Annotator:     "Code Reviewer (reviewer@example.com)",
+			AnnotatorType: "Person",
+		},
+		AnnotationType:           "REVIEW",
+		AnnotationSPDXIdentifier: common.DocElementID{ElementRefID: "SPDXRef-File-Main"},
+		AnnotationDate:           "2023-02-05T16:00:00Z",
+		AnnotationComment:        "File review completed - code quality approved",
+	}
+}
+
+func v23snippet3() *v2_3.Snippet {
+	return &v2_3.Snippet{
+		SnippetSPDXIdentifier:         common.ElementID("SPDXRef-Snippet3"),
+		SnippetFromFileSPDXIdentifier: common.ElementID("SPDXRef-File-Main"),
+		Ranges: []common.SnippetRange{
+			{
+				StartPointer: common.SnippetRangePointer{
+					Offset:     300,
+					LineNumber: 20,
+				},
+				EndPointer: common.SnippetRangePointer{
+					Offset:     400,
+					LineNumber: 30,
+				},
+			},
+		},
+		SnippetLicenseConcluded: "Apache-2.0",
+		LicenseInfoInSnippet:    []string{"Apache-2.0"},
+		SnippetLicenseComments:  "License for helper routine",
+		SnippetCopyrightText:    "Copyright 2023 Example Corp",
+		SnippetComment:          "Helper routine implementation",
+		SnippetName:             "Helper Routine",
+		SnippetAttributionTexts: []string{"Inspired by open source utilities"},
 	}
 }

--- a/spdx/v3/v3_0/convert_v23_test.go
+++ b/spdx/v3/v3_0/convert_v23_test.go
@@ -161,7 +161,7 @@ func v23package2() *v2_3.Package {
 		},
 		PackageHomePage:         "https://tools.com/utility",
 		PackageLicenseConcluded: "Apache-2.0",
-		PackageLicenseDeclared:  "Apache-2.0",
+		PackageLicenseDeclared:  "AGPL OR (GPL-2.0-only with Classpath-Exception OR LicenceRef-CustomLicense1)",
 		PackageCopyrightText:    "Copyright 2023 Tools Inc",
 		PackageSummary:          "Collection of utility tools",
 		PackageDescription:      "A comprehensive set of utility tools for developers.",
@@ -195,8 +195,8 @@ func v23customLicense2() *v2_3.OtherLicense {
 
 func v23file1() *v2_3.File {
 	return &v2_3.File{
-		FileName:           "./src/other.c",
-		FileSPDXIdentifier: common.ElementID("SPDXRef-File-Other"),
+		FileName:           "./src/main.c",
+		FileSPDXIdentifier: common.ElementID("SPDXRef-File-Main"),
 		FileTypes:          []string{"FILE"},
 		Checksums: []common.Checksum{
 			{Algorithm: common.SHA1, Value: "da39a3ee5e6b4b0d3255bfef95601890afd80709"},

--- a/spdx/v3/v3_0/convert_v301_test.go
+++ b/spdx/v3/v3_0/convert_v301_test.go
@@ -272,7 +272,7 @@ func v301package2(customLicense1 AnyLicense) (*Package, ElementList) {
 			&ListedLicense{Name: "AGPL"},
 			&WithAdditionOperator{
 				SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
-				SubjectAddition:          &ListedLicenseException{Name: "Classpath-Exception"},
+				SubjectAddition:          &ListedLicenseException{AdditionText: "Classpath-Exception"},
 			},
 			customLicense1,
 		},

--- a/spdx/v3/v3_0/convert_v301_test.go
+++ b/spdx/v3/v3_0/convert_v301_test.go
@@ -1,6 +1,7 @@
 package v3_0
 
 import (
+	"slices"
 	"time"
 
 	"github.com/spdx/tools-golang/spdx/v2/v2_3"
@@ -39,49 +40,60 @@ func v301doc() *Document {
 		v301externalMap2(),
 	}
 
-	sbom.Elements = append(sbom.Elements,
-		v301customLicense1(),
-		v301customLicense2(),
-	)
+	addToSBOM := func(elements ...AnyElement) {
+		for _, e := range elements {
+			if !slices.Contains(sbom.Elements, e) {
+				sbom.Elements = append(sbom.Elements, e)
+			}
+		}
+	}
 
-	pkg1, extraElems := v301package1()
-	sbom.Elements = append(sbom.Elements, extraElems...)
-	sbom.Elements = append(sbom.Elements, pkg1)
+	pkg1, pkg1Elems := v301package1()
+	pkg2, pkg2Elems := v301package2()
+	file1, file1Elems := v301file1()
+	file2, file2Elems := v301file2()
+	snippet1, snippet1Elems := v301snippet1(file1)
+	snippet2, snippet2Elems := v301snippet2(file2)
+	ann1 := v301annotation1(pkg1)
+	ann2 := v301annotation2(pkg2)
 
 	// pkg1 is the only thing referenced directly as a document root element
 	sbom.RootElements = append(sbom.RootElements, pkg1)
 
-	pkg2, extraElems := v301package2()
-	sbom.Elements = append(sbom.Elements, extraElems...)
-	sbom.Elements = append(sbom.Elements, pkg2)
-
-	file1, extraElems := v301file1()
-	sbom.Elements = append(sbom.Elements, file1)
-	sbom.Elements = append(sbom.Elements, extraElems...)
-
-	file2, extraElems := v301file2()
-	sbom.Elements = append(sbom.Elements, file2)
-	sbom.Elements = append(sbom.Elements, extraElems...)
-
-	sbom.Elements = append(sbom.Elements,
-		v301annotation1(pkg1),
-		v301annotation2(pkg2),
+	// top-level converted elements go directly in sbom.Elements
+	// (matching converter behavior: packages, files, annotations, snippets, custom licenses)
+	addToSBOM(
+		v301customLicense1(),
+		v301customLicense2(),
+		pkg1, pkg2,
+		AnyElement(file1), AnyElement(file2),
+		ann1, ann2,
+		AnyElement(snippet1), AnyElement(snippet2),
 	)
 
-	snippet1, extraElems := v301snippet1(file1)
-	sbom.Elements = append(sbom.Elements, snippet1)
-	sbom.Elements = append(sbom.Elements, extraElems...)
-
-	snippet2, extraElems := v301snippet2(file2)
-	sbom.Elements = append(sbom.Elements, snippet2)
-	sbom.Elements = append(sbom.Elements, extraElems...)
-
-	sbom.Elements = append(sbom.Elements,
-		// SpdxRef-DOCUMENT relationships are handled by object structure
+	// all relationships go in sbom.Elements
+	for _, elems := range []ElementList{pkg1Elems, pkg2Elems, file1Elems, file2Elems, snippet1Elems, snippet2Elems} {
+		for _, r := range elems.Relationships() {
+			addToSBOM(r)
+		}
+	}
+	addToSBOM(
 		&Relationship{
-			From:    pkg1,
-			To:      ElementList{pkg2},
-			Type:    RelationshipType_DependsOn,
+			Type: RelationshipType_Describes,
+			From: ann1,
+			To:   ElementList{pkg1},
+		},
+		&Relationship{
+			Type: RelationshipType_Describes,
+			From: ann2,
+			To:   ElementList{pkg2},
+		},
+		// SpdxRef-DOCUMENT relationships are handled by object structure
+		&LifecycleScopedRelationship{
+			From:    pkg2,
+			To:      ElementList{pkg1},
+			Type:    RelationshipType_UsesTool,
+			Scope:   LifecycleScopeType_Build,
 			Comment: "Main package depends on utility tools",
 		},
 		&Relationship{
@@ -92,9 +104,9 @@ func v301doc() *Document {
 		},
 	)
 
-	// add all relationships to RootElements
-	for _, r := range sbom.Elements.Relationships() {
-		sbom.RootElements = append(sbom.RootElements, r)
+	// collect all reachable elements into the document Elements list
+	for _, e := range collectAllElements(&d.SpdxDocument) {
+		d.SpdxDocument.Elements = append(d.SpdxDocument.Elements, e)
 	}
 
 	return d
@@ -116,8 +128,8 @@ func v301creationInfo() *CreationInfo {
 			},
 		},
 
-		//LicenseListVersion: "3.19",
-		Comment: "Created during automated build process",
+		Comment: "Created during automated build process" +
+			"; LicenseListVersion: 3.19",
 	}
 }
 
@@ -187,31 +199,45 @@ func v301package1() (*Package, ElementList) {
 
 	// comment was appended to pkg comment: "License determined from LICENSE file"
 
-	l := &ListedLicense{}
-	l.Name = "MIT"
-
-	l2 := &ListedLicense{}
-	l2.Name = "Apache-2.0"
+	// converter creates separate license objects for each expression
+	lInfoMIT := &ListedLicense{Name: "MIT"}           // from LicenseInfoFromFiles
+	lInfoApache := &ListedLicense{Name: "Apache-2.0"} // from LicenseInfoFromFiles
+	lConcluded := &ListedLicense{Name: "MIT"}         // from LicenseConcluded
+	lDeclared := &ListedLicense{Name: "MIT"}          // from LicenseDeclared
 
 	r1 := &Relationship{
-		Type: RelationshipType_HasConcludedLicense,
-		To:   ElementList{l},
+		Type: RelationshipType_HasDeclaredLicense,
+		To:   ElementList{lInfoMIT, lInfoApache, lDeclared},
 		From: p,
 	}
 
 	r2 := &Relationship{
-		Type: RelationshipType_HasDeclaredLicense,
-		To:   ElementList{l},
-		From: p,
-	}
-
-	r3 := &Relationship{
 		Type: RelationshipType_HasConcludedLicense,
-		To:   ElementList{l2},
+		To:   ElementList{lConcluded},
 		From: p,
 	}
 
-	return p, ElementList{l, r1, r2, l2, r3}
+	// file associated with this package (mirrors v23package1 embedded file)
+	file3, fileElems := v301file3()
+
+	// annotation associated with this package (mirrors v23package1 embedded annotation)
+	annotation3 := v301annotation3(p)
+
+	containsFile := &Relationship{
+		Type: RelationshipType_Contains,
+		From: p,
+		To:   ElementList{file3},
+	}
+	describesPkg := &Relationship{
+		Type: RelationshipType_Describes,
+		From: annotation3,
+		To:   ElementList{p},
+	}
+
+	extras := ElementList{lInfoMIT, lInfoApache, lConcluded, lDeclared, r1, r2, file3, annotation3, containsFile, describesPkg}
+	extras = append(extras, fileElems...)
+
+	return p, extras
 }
 
 func v301package2() (*Package, ElementList) {
@@ -297,7 +323,7 @@ func v301customLicense2() AnyLicense {
 
 func v301file1() (AnyFile, ElementList) {
 	f := &File{
-		ID:   "SPDXRef-File-Other",
+		ID:   "SPDXRef-File-Main",
 		Name: "./src/main.c",
 		VerifiedUsing: IntegrityMethodList{
 			&Hash{
@@ -309,8 +335,7 @@ func v301file1() (AnyFile, ElementList) {
 				Algorithm: HashAlgorithm_Md5,
 			},
 		},
-		Comment:     "Other application entry point",
-		Description: "This file contains the other function",
+		Comment: "Other application entry point",
 		OriginatedBy: AgentList{
 			&Person{
 				Name:                "Other John Doe",
@@ -326,29 +351,57 @@ func v301file1() (AnyFile, ElementList) {
 		AttributionTexts: []string{
 			"Based on other example code from something",
 		},
-		//FileTypes: []FileType{
-		//	FileType_Source,
-		//},
-		//PrimaryPurpose: SoftwarePurpose_Source,
 		Kind: FileKindType_File,
 	}
 
-	l := &ListedLicense{}
-	l.Name = "MIT"
+	lConcluded := &ListedLicense{Name: "MIT", Comment: "License applies to this file"}
+	lDeclared := &ListedLicense{Name: "MIT"}
 
 	r1 := &Relationship{
 		Type: RelationshipType_HasConcludedLicense,
-		To:   ElementList{l},
+		To:   ElementList{lConcluded},
 		From: f,
 	}
 
 	r2 := &Relationship{
 		Type: RelationshipType_HasDeclaredLicense,
-		To:   ElementList{l},
+		To:   ElementList{lDeclared},
 		From: f,
 	}
 
-	return f, ElementList{l, r1, r2}
+	// snippet associated with this file (mirrors v23file1 embedded snippet)
+	snippet3, snippetElems := v301snippet3(f)
+
+	// annotation associated with this file (mirrors v23file1 embedded annotation)
+	annotation4 := v301annotation4(f)
+
+	containsSnippet := &Relationship{
+		Type: RelationshipType_Contains,
+		From: f,
+		To:   ElementList{snippet3},
+	}
+	describesFile := &Relationship{
+		Type: RelationshipType_Describes,
+		From: annotation4,
+		To:   ElementList{f},
+	}
+
+	// from FileNotice
+	fileNotice := &Annotation{
+		Type:      AnnotationType_Other,
+		Subject:   f,
+		Statement: "This file contains the other function",
+	}
+	fileNoticeRel := &Relationship{
+		Type: RelationshipType_Describes,
+		From: fileNotice,
+		To:   ElementList{f},
+	}
+
+	extras := ElementList{lConcluded, lDeclared, r1, r2, snippet3, annotation4, containsSnippet, describesFile, fileNotice, fileNoticeRel}
+	extras = append(extras, snippetElems...)
+
+	return f, extras
 }
 
 func v301file2() (*File, ElementList) {
@@ -370,22 +423,28 @@ func v301file2() (*File, ElementList) {
 		Kind: FileKindType_File,
 	}
 
-	l := &ListedLicense{}
-	l.Name = "MIT"
+	concludedLicense := &ConjunctiveLicenseSet{
+		Members: LicenseInfoList{
+			&ListedLicense{Name: "MIT"},
+			&ListedLicense{Name: "Apache-2.0"},
+		},
+	}
+
+	declaredLicense := &ListedLicense{Name: "MIT"}
 
 	r1 := &Relationship{
 		Type: RelationshipType_HasConcludedLicense,
-		To:   ElementList{l},
+		To:   ElementList{concludedLicense},
 		From: f,
 	}
 
 	r2 := &Relationship{
 		Type: RelationshipType_HasDeclaredLicense,
-		To:   ElementList{l},
+		To:   ElementList{declaredLicense},
 		From: f,
 	}
 
-	return f, ElementList{l, r1, r2}
+	return f, ElementList{concludedLicense, declaredLicense, r1, r2}
 }
 
 func v301externalMap1() *ExternalMap {
@@ -439,14 +498,120 @@ func v301annotation2(subject AnyElement) *Annotation {
 		CreationInfo: &CreationInfo{
 			Created: parseTime("2023-01-21T09:15:00Z"),
 			CreatedBy: AgentList{
-				&Person{
+				&SoftwareAgent{
 					Name: "vulnerability-scanner-v1.5",
 				},
 			},
 		},
-		Comment: "Automated scan completed - clean",
-		Subject: subject,
+		Statement: "Automated scan completed - clean",
+		Subject:   subject,
 	}
+}
+
+func v301file3() (AnyFile, ElementList) {
+	f := &File{
+		ID:             "SPDXRef-File-Utils",
+		Name:           "./src/utils.c",
+		PrimaryPurpose: SoftwarePurpose_Source,
+		VerifiedUsing: IntegrityMethodList{
+			&Hash{
+				Value:     "aabb1234aabb1234aabb1234aabb1234aabb1234aabb1234aabb1234aabb1234",
+				Algorithm: HashAlgorithm_Sha256,
+			},
+		},
+		Comment:       "Utility functions for the library",
+		CopyrightText: "Copyright 2023 Example Corp",
+		Kind:          FileKindType_File,
+	}
+
+	lConcluded := &ListedLicense{Name: "Apache-2.0"}
+	lDeclared := &ListedLicense{Name: "Apache-2.0"}
+
+	r1 := &Relationship{
+		Type: RelationshipType_HasConcludedLicense,
+		To:   ElementList{lConcluded},
+		From: f,
+	}
+
+	r2 := &Relationship{
+		Type: RelationshipType_HasDeclaredLicense,
+		To:   ElementList{lDeclared},
+		From: f,
+	}
+
+	return f, ElementList{lConcluded, lDeclared, r1, r2}
+}
+
+func v301annotation3(subject AnyElement) *Annotation {
+	return &Annotation{
+		Type: AnnotationType_Other,
+		ID:   "SPDXRef-Annotation-3",
+		CreationInfo: &CreationInfo{
+			Created: parseTime("2023-02-01T10:00:00Z"),
+			CreatedBy: AgentList{
+				&Person{
+					Name:                "Code Review Bot",
+					ExternalIdentifiers: externalIdentifierListEmail("bot@example.com"),
+				},
+			},
+		},
+		Subject:   subject,
+		Statement: "Package structure review completed",
+	}
+}
+
+func v301annotation4(subject AnyElement) *Annotation {
+	return &Annotation{
+		Type: AnnotationType_Review,
+		ID:   "SPDXRef-Annotation-4",
+		CreationInfo: &CreationInfo{
+			Created: parseTime("2023-02-05T16:00:00Z"),
+			CreatedBy: AgentList{
+				&Person{
+					Name:                "Code Reviewer",
+					ExternalIdentifiers: externalIdentifierListEmail("reviewer@example.com"),
+				},
+			},
+		},
+		Subject:   subject,
+		Statement: "File review completed - code quality approved",
+	}
+}
+
+func v301snippet3(fileRef AnyFile) (AnyElement, ElementList) {
+	s := &Snippet{
+		ID:               "SPDXRef-Snippet3",
+		Name:             "Helper Routine",
+		Comment:          "Helper routine implementation",
+		CopyrightText:    "Copyright 2023 Example Corp",
+		AttributionTexts: []string{"Inspired by open source utilities"},
+		FromFile:         fileRef,
+		ByteRange: &PositiveIntegerRange{
+			BeginIntegerRange: 300,
+			EndIntegerRange:   400,
+		},
+		LineRange: &PositiveIntegerRange{
+			BeginIntegerRange: 20,
+			EndIntegerRange:   30,
+		},
+	}
+
+	lConcluded := &ListedLicense{Name: "Apache-2.0", Comment: "License for helper routine"}
+	lDeclared := &ListedLicense{Name: "Apache-2.0", Comment: ""}
+
+	r1 := &Relationship{
+		Type: RelationshipType_HasConcludedLicense,
+		To:   ElementList{lConcluded},
+		From: s,
+	}
+
+	r2 := &Relationship{
+		Type: RelationshipType_HasDeclaredLicense,
+		To:   ElementList{lDeclared},
+		From: s,
+	}
+
+	return s, ElementList{lConcluded, lDeclared, r1, r2}
 }
 
 func v301snippet1(fileRef AnyFile) (AnyElement, ElementList) {
@@ -469,22 +634,22 @@ func v301snippet1(fileRef AnyFile) (AnyElement, ElementList) {
 		//LicenseComments:  "License applies to this code snippet",
 	}
 
-	l := &ListedLicense{}
-	l.Name = "MIT"
+	lConcluded := &ListedLicense{Name: "MIT", Comment: "License applies to this code snippet"}
+	lDeclared := &ListedLicense{Name: "MIT", Comment: ""}
 
 	r1 := &Relationship{
 		Type: RelationshipType_HasConcludedLicense,
-		To:   ElementList{l},
+		To:   ElementList{lConcluded},
 		From: s,
 	}
 
 	r2 := &Relationship{
 		Type: RelationshipType_HasDeclaredLicense,
-		To:   ElementList{l},
+		To:   ElementList{lDeclared},
 		From: s,
 	}
 
-	return s, ElementList{l, r1, r2}
+	return s, ElementList{lConcluded, lDeclared, r1, r2}
 }
 
 func v301snippet2(fileRef AnyFile) (AnySnippet, ElementList) {
@@ -504,22 +669,25 @@ func v301snippet2(fileRef AnyFile) (AnySnippet, ElementList) {
 		},
 	}
 
-	l := &ListedLicense{}
-	l.Name = "MIT"
+	concludedLicense := &OrLaterOperator{
+		SubjectLicense: &ListedLicense{Name: "MIT"},
+	}
+
+	declaredLicense := &ListedLicense{Name: "MIT"}
 
 	r1 := &Relationship{
 		Type: RelationshipType_HasConcludedLicense,
-		To:   ElementList{l},
+		To:   ElementList{concludedLicense},
 		From: s,
 	}
 
 	r2 := &Relationship{
 		Type: RelationshipType_HasDeclaredLicense,
-		To:   ElementList{l},
+		To:   ElementList{declaredLicense},
 		From: s,
 	}
 
-	return s, ElementList{l, r1, r2}
+	return s, ElementList{concludedLicense, declaredLicense, r1, r2}
 }
 
 func parseTime(s string) time.Time {

--- a/spdx/v3/v3_0/convert_v301_test.go
+++ b/spdx/v3/v3_0/convert_v301_test.go
@@ -48,8 +48,9 @@ func v301doc() *Document {
 		}
 	}
 
+	customLicense1 := v301customLicense1()
 	pkg1, pkg1Elems := v301package1()
-	pkg2, pkg2Elems := v301package2()
+	pkg2, pkg2Elems := v301package2(customLicense1)
 	file1, file1Elems := v301file1()
 	file2, file2Elems := v301file2()
 	snippet1, snippet1Elems := v301snippet1(file1)
@@ -63,7 +64,7 @@ func v301doc() *Document {
 	// top-level converted elements go directly in sbom.Elements
 	// (matching converter behavior: packages, files, annotations, snippets, custom licenses)
 	addToSBOM(
-		v301customLicense1(),
+		customLicense1,
 		v301customLicense2(),
 		pkg1, pkg2,
 		AnyElement(file1), AnyElement(file2),
@@ -240,7 +241,7 @@ func v301package1() (*Package, ElementList) {
 	return p, extras
 }
 
-func v301package2() (*Package, ElementList) {
+func v301package2(customLicense1 AnyLicense) (*Package, ElementList) {
 	p := &Package{
 		ID:          "SPDXRef-Package-UtilityTools",
 		Name:        "utility-tools",
@@ -275,7 +276,7 @@ func v301package2() (*Package, ElementList) {
 						SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
 						SubjectAddition:          &ListedLicenseException{Name: "Classpath-Exception"},
 					},
-					&ListedLicense{Name: "LicenceRef-CustomLicense1"},
+					customLicense1,
 				},
 			},
 		},

--- a/spdx/v3/v3_0/convert_v301_test.go
+++ b/spdx/v3/v3_0/convert_v301_test.go
@@ -270,15 +270,11 @@ func v301package2(customLicense1 AnyLicense) (*Package, ElementList) {
 	declaredLicense := &DisjunctiveLicenseSet{
 		Members: LicenseInfoList{
 			&ListedLicense{Name: "AGPL"},
-			&DisjunctiveLicenseSet{
-				Members: LicenseInfoList{
-					&WithAdditionOperator{
-						SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
-						SubjectAddition:          &ListedLicenseException{Name: "Classpath-Exception"},
-					},
-					customLicense1,
-				},
+			&WithAdditionOperator{
+				SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
+				SubjectAddition:          &ListedLicenseException{Name: "Classpath-Exception"},
 			},
+			customLicense1,
 		},
 	}
 

--- a/spdx/v3/v3_0/convert_v301_test.go
+++ b/spdx/v3/v3_0/convert_v301_test.go
@@ -20,7 +20,7 @@ func v301doc() *Document {
 	d.DataLicense = &ListedLicense{
 		Name: v2_3.DataLicense,
 	}
-	d.SpdxDocument.ID = "SPDXRef-DOCUMENT"
+	d.SpdxDocument.ID = "DOCUMENT"
 	d.CreationInfo.(*CreationInfo).Created = parseTime("2023-01-15T10:30:00Z")
 	d.SpdxDocument.Comment = "This is a sample SPDX document for testing purposes."
 	d.NamespaceMaps = NamespaceMapList{
@@ -91,6 +91,11 @@ func v301doc() *Document {
 			Comment: "Package contains main source file",
 		},
 	)
+
+	// add all relationships to RootElements
+	for _, r := range sbom.Elements.Relationships() {
+		sbom.RootElements = append(sbom.RootElements, r)
+	}
 
 	return d
 }
@@ -233,22 +238,36 @@ func v301package2() (*Package, ElementList) {
 		DownloadLocation: ld.URI("https://tools.com/download/utility-tools-2.1.0.zip"),
 	}
 
-	l := &ListedLicense{}
-	l.Name = "Apache-2.0"
+	concludedLicense := &ListedLicense{Name: "Apache-2.0"}
+
+	declaredLicense := &DisjunctiveLicenseSet{
+		Members: LicenseInfoList{
+			&ListedLicense{Name: "AGPL"},
+			&DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&WithAdditionOperator{
+						SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
+						SubjectAddition:          &ListedLicenseException{Name: "Classpath-Exception"},
+					},
+					&ListedLicense{Name: "LicenceRef-CustomLicense1"},
+				},
+			},
+		},
+	}
 
 	r1 := &Relationship{
 		Type: RelationshipType_HasConcludedLicense,
-		To:   ElementList{l},
+		To:   ElementList{concludedLicense},
 		From: p,
 	}
 
 	r2 := &Relationship{
 		Type: RelationshipType_HasDeclaredLicense,
-		To:   ElementList{l},
+		To:   ElementList{declaredLicense},
 		From: p,
 	}
 
-	return p, ElementList{l, r1, r2}
+	return p, ElementList{concludedLicense, r1, declaredLicense, r2}
 }
 
 func v301customLicense1() AnyLicense {
@@ -279,7 +298,7 @@ func v301customLicense2() AnyLicense {
 func v301file1() (AnyFile, ElementList) {
 	f := &File{
 		ID:   "SPDXRef-File-Other",
-		Name: "./src/other.c",
+		Name: "./src/main.c",
 		VerifiedUsing: IntegrityMethodList{
 			&Hash{
 				Value:     "da39a3ee5e6b4b0d3255bfef95601890afd80709",
@@ -348,6 +367,7 @@ func v301file2() (*File, ElementList) {
 		//FileTypes: []FileType{
 		//	FileType_Header,
 		//},
+		Kind: FileKindType_File,
 	}
 
 	l := &ListedLicense{}
@@ -475,12 +495,12 @@ func v301snippet2(fileRef AnyFile) (AnySnippet, ElementList) {
 		CopyrightText: "Copyright 2023 Example Corp",
 		FromFile:      fileRef,
 		ByteRange: &PositiveIntegerRange{
-			EndIntegerRange:   50,
-			BeginIntegerRange: 150,
+			BeginIntegerRange: 50,
+			EndIntegerRange:   150,
 		},
 		LineRange: &PositiveIntegerRange{
-			EndIntegerRange:   5,
-			BeginIntegerRange: 8,
+			BeginIntegerRange: 5,
+			EndIntegerRange:   8,
 		},
 	}
 

--- a/spdx/v3/v3_0/license_parser.go
+++ b/spdx/v3/v3_0/license_parser.go
@@ -19,6 +19,8 @@ import (
 //   - "GPL-2.0-only+" → *OrLaterOperator wrapping *ListedLicense
 //   - "LicenseRef-custom" → *CustomLicense
 //   - "DocumentRef-ext:LicenseRef-custom" → *CustomLicense
+//   - "NONE" → IndividualLicensingInfo_NoneLicense
+//   - "NOASSERTION" → IndividualLicensingInfo_NoAssertionLicense
 func ParseLicenseExpression(expression string) (AnyLicenseInfo, error) {
 	p := &licenseParser{input: strings.TrimSpace(expression)}
 	if len(p.input) == 0 {
@@ -150,6 +152,15 @@ func (p *licenseParser) parseSimple() (AnyLicenseInfo, error) {
 		return nil, fmt.Errorf("expected license identifier at position %d, got %q", p.pos, p.remaining())
 	}
 
+	// NONE and NOASSERTION are individual values rather than licenses and cannot
+	// take an or-later (+) suffix, so they are handled before makeLicense.
+	switch ident {
+	case "NONE":
+		return IndividualLicensingInfo_NoneLicense, nil
+	case "NOASSERTION":
+		return IndividualLicensingInfo_NoAssertionLicense, nil
+	}
+
 	// Check for or-later (+) suffix
 	if p.pos < len(p.input) && p.input[p.pos] == '+' {
 		p.pos++
@@ -160,9 +171,13 @@ func (p *licenseParser) parseSimple() (AnyLicenseInfo, error) {
 }
 
 func (p *licenseParser) skipWhitespace() {
-	for p.pos < len(p.input) && p.input[p.pos] == ' ' {
+	for p.pos < len(p.input) && isWhitespace(p.input[p.pos]) {
 		p.pos++
 	}
+}
+
+func isWhitespace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v'
 }
 
 // peekKeyword checks if the next non-whitespace token is exactly the given keyword,

--- a/spdx/v3/v3_0/license_parser.go
+++ b/spdx/v3/v3_0/license_parser.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 )
 
-// ParseLicenseExpression parses an SPDX license expression string into the
-// corresponding model types. It handles AND, OR, WITH operators, the + (or-later)
-// suffix, LicenseRef and DocumentRef references, and parenthesized sub-expressions.
-//
-// Operator precedence (lowest to highest): OR, AND, WITH, + (or-later)
+// ParseLicenseExpression parses an SPDX license expression string into the corresponding model types.
+// It handles AND, OR, WITH operators, the + (or-later) suffix, LicenseRef and DocumentRef references, and
+// parenthesized sub-expressions with operator precedence (lowest to highest): OR, AND, WITH, + (or-later).
+// This is a lenient parser, which will return all errors encountered and all parseable licenses -- strict users
+// must check for errors.
 //
 // Examples:
 //   - "MIT" → *ListedLicense
@@ -22,228 +22,264 @@ import (
 //   - "NONE" → IndividualLicensingInfo_NoneLicense
 //   - "NOASSERTION" → IndividualLicensingInfo_NoAssertionLicense
 func ParseLicenseExpression(expression string) (AnyLicenseInfo, error) {
-	p := &licenseParser{input: strings.TrimSpace(expression)}
-	if len(p.input) == 0 {
-		return nil, fmt.Errorf("empty license expression")
+	expression = strings.TrimSpace(expression)
+	if len(expression) == 0 {
+		return nil, fmt.Errorf("expression is empty")
 	}
-	result, err := p.parseOr()
-	if err != nil {
-		return nil, err
+	p := licenseParser{
+		in:  expression,
+		pos: 0,
 	}
-	p.skipWhitespace()
-	if p.pos < len(p.input) {
-		return nil, fmt.Errorf("unexpected token at position %d: %q", p.pos, p.remaining())
+	for p.pos != len(expression) { // try to parse until we find a license
+		result := p.parseOr()
+		if result != nil { // a properly specified license will get a result the first iteration with no errors
+			if p.tok != "" && len(p.errs) == 0 {
+				p.err("unexpected trailing token(s)")
+			}
+			return result, collectErrs(&p)
+		}
 	}
-	return result, nil
+	if len(p.errs) > 0 {
+		return nil, collectErrs(&p)
+	}
+	return nil, fmt.Errorf("unable to parse expression: %s", expression)
 }
 
 type licenseParser struct {
-	input string
-	pos   int
+	errs []ParseError
+	in   string
+	tok  string
+	pos  int
 }
 
-func (p *licenseParser) remaining() string {
-	if p.pos >= len(p.input) {
-		return ""
+// err adds a parsing error with position and token captured automatically
+func (p *licenseParser) err(format string, args ...any) {
+	msg := format
+	if len(args) > 0 {
+		msg = fmt.Sprintf(format, args...)
 	}
-	return p.input[p.pos:]
-}
-
-// parseOr handles: and-expr ("OR" and-expr)*
-// Flattens consecutive OR operands into a single DisjunctiveLicenseSet.
-func (p *licenseParser) parseOr() (AnyLicenseInfo, error) {
-	left, err := p.parseAnd()
-	if err != nil {
-		return nil, err
-	}
-
-	members := LicenseInfoList{left}
-	for p.peekKeyword("OR") {
-		p.consumeKeyword("OR")
-		right, err := p.parseAnd()
-		if err != nil {
-			return nil, err
+	// don't report duplicate errors
+	if len(p.errs) > 0 {
+		if p.errs[len(p.errs)-1].Message == msg {
+			return
 		}
-		members = append(members, right)
 	}
-
-	if len(members) == 1 {
-		return left, nil
-	}
-	return &DisjunctiveLicenseSet{Members: members}, nil
+	p.errs = append(p.errs, ParseError{p.pos - len(p.tok), p.tok, msg})
 }
 
-// parseAnd handles: with-expr ("AND" with-expr)*
-// Flattens consecutive AND operands into a single ConjunctiveLicenseSet.
-func (p *licenseParser) parseAnd() (AnyLicenseInfo, error) {
-	left, err := p.parseWith()
-	if err != nil {
-		return nil, err
-	}
-
-	members := LicenseInfoList{left}
-	for p.peekKeyword("AND") {
-		p.consumeKeyword("AND")
-		right, err := p.parseWith()
-		if err != nil {
-			return nil, err
-		}
-		members = append(members, right)
-	}
-
-	if len(members) == 1 {
-		return left, nil
-	}
-	return &ConjunctiveLicenseSet{Members: members}, nil
-}
-
-// parseWith handles: simple-expr ("WITH" exception-id)?
-func (p *licenseParser) parseWith() (AnyLicenseInfo, error) {
-	license, err := p.parseSimple()
-	if err != nil {
-		return nil, err
-	}
-
-	if !p.peekKeyword("WITH") {
-		return license, nil
-	}
-	p.consumeKeyword("WITH")
-
-	extendable, ok := license.(AnyExtendableLicense)
-	if !ok {
-		return nil, fmt.Errorf("WITH operator requires a simple license or or-later expression, got %T", license)
-	}
-
-	exceptionID := p.scanIdent()
-	if exceptionID == "" {
-		return nil, fmt.Errorf("expected license exception identifier after WITH at position %d", p.pos)
-	}
-
-	return &WithAdditionOperator{
-		SubjectExtendableLicense: extendable,
-		SubjectAddition:          makeAddition(exceptionID),
-	}, nil
-}
-
-// parseSimple handles: "(" expression ")" | license-id "+"? | license-ref
-func (p *licenseParser) parseSimple() (AnyLicenseInfo, error) {
-	p.skipWhitespace()
-
-	if p.pos >= len(p.input) {
-		return nil, fmt.Errorf("unexpected end of expression")
-	}
-
-	if p.input[p.pos] == '(' {
-		p.pos++
-		expr, err := p.parseOr()
-		if err != nil {
-			return nil, err
-		}
-		p.skipWhitespace()
-		if p.pos >= len(p.input) || p.input[p.pos] != ')' {
-			return nil, fmt.Errorf("expected ')' at position %d", p.pos)
-		}
-		p.pos++
-		return expr, nil
-	}
-
-	ident := p.scanIdent()
-	if ident == "" {
-		return nil, fmt.Errorf("expected license identifier at position %d, got %q", p.pos, p.remaining())
-	}
-
-	// NONE and NOASSERTION are individual values rather than licenses and cannot
-	// take an or-later (+) suffix, so they are handled before makeLicense.
-	switch ident {
-	case "NONE":
-		return IndividualLicensingInfo_NoneLicense, nil
-	case "NOASSERTION":
-		return IndividualLicensingInfo_NoAssertionLicense, nil
-	}
-
-	// Check for or-later (+) suffix
-	if p.pos < len(p.input) && p.input[p.pos] == '+' {
-		p.pos++
-		return &OrLaterOperator{SubjectLicense: makeLicense(ident)}, nil
-	}
-
-	return makeLicense(ident), nil
-}
-
-func (p *licenseParser) skipWhitespace() {
-	for p.pos < len(p.input) && isWhitespace(p.input[p.pos]) {
+// next consumes whitespace and captures the subsequent token in p.tok
+func (p *licenseParser) next() {
+	for p.pos < len(p.in) && isWhitespace(p.in[p.pos]) {
 		p.pos++
 	}
+	start := p.pos
+	for p.pos < len(p.in) && !isWhitespace(p.in[p.pos]) {
+		c := p.in[p.pos]
+		if c == '(' || c == ')' || c == '+' {
+			if start == p.pos { // capture exactly 1 character
+				p.pos++
+			}
+			break
+		}
+		p.pos++
+	}
+	p.tok = p.in[start:p.pos]
+}
+
+// parseOr handles: expr ("OR" expr)*; flattens consecutive & nested OR operands into a single DisjunctiveLicenseSet.
+func (p *licenseParser) parseOr() AnyLicenseInfo {
+	out := p.parseAnd()
+	if out == nil {
+		return nil // already noted the error; continue trying to parse
+	}
+	if opOr(p.tok) {
+		s, _ := out.(*DisjunctiveLicenseSet)
+		if s == nil {
+			s = &DisjunctiveLicenseSet{}
+			s.Members = append(s.Members, out)
+		}
+		for opOr(p.tok) {
+			rhs := p.parseAnd() // using parseAnd here gives the correct precedence behavior
+			if next, ok := rhs.(*DisjunctiveLicenseSet); ok {
+				s.Members = append(s.Members, next.Members...)
+			} else if rhs != nil {
+				s.Members = append(s.Members, rhs)
+			} // if rhs == nil, already reported an error
+		}
+		if len(s.Members) > 1 {
+			out = s
+		}
+	}
+	return out
+}
+
+// parseAnd handles: expr ("AND" expr)*; flattens consecutive & nested AND operands into a single ConjunctiveLicenseSet.
+func (p *licenseParser) parseAnd() AnyLicenseInfo {
+	out := p.parseLicense()
+	if out == nil {
+		return nil // already noted the error; continue trying to parse
+	}
+	if opAnd(p.tok) {
+		s, _ := out.(*ConjunctiveLicenseSet)
+		if s == nil {
+			s = &ConjunctiveLicenseSet{}
+			s.Members = append(s.Members, out)
+		}
+		for opAnd(p.tok) {
+			rhs := p.parseAnd()
+			if next, ok := rhs.(*ConjunctiveLicenseSet); ok {
+				s.Members = append(s.Members, next.Members...)
+			} else if rhs != nil {
+				s.Members = append(s.Members, rhs)
+			} // if rhs == nil, already reported an error
+		}
+		if len(s.Members) > 1 {
+			out = s
+		}
+	}
+	return out
+}
+
+// parseLicense handles: ("(" expr ")")? | license (+)? ("WITH" exception)?
+func (p *licenseParser) parseLicense() AnyLicenseInfo {
+	p.next()
+	if p.tok == "(" {
+		lic := p.parseOr()
+		if p.tok == ")" {
+			p.next()
+		} else if len(p.errs) == 0 {
+			p.err("unclosed parenthesis")
+		}
+		return lic
+	}
+	lic := makeLicense(p.tok)
+	if lic == nil {
+		p.err("unexpected token")
+		if p.pos < len(p.in) {
+			return p.parseLicense()
+		}
+		return nil
+	}
+	p.next()
+	if p.tok == "+" {
+		if p.pos > 2 && isWhitespace(p.in[p.pos-2]) { // whitespace is not allowed per spec
+			p.err("illegal whitespace before +")
+		}
+		if l, ok := lic.(AnyLicense); ok {
+			lic = &OrLaterOperator{SubjectLicense: l}
+		} else {
+			p.err("invalid license used with + operator: %v", lic)
+		}
+		p.next()
+	}
+	if opWith(p.tok) {
+		p.next()
+		addition := makeAddition(p.tok)
+		if addition == nil {
+			p.err("unable to parse addition")
+			return lic
+		}
+		if l, ok := lic.(AnyExtendableLicense); ok {
+			lic = &WithAdditionOperator{
+				SubjectAddition:          addition,
+				SubjectExtendableLicense: l,
+			}
+		} else {
+			p.err("invalid license used with WITH addition operator: %v", lic)
+		}
+		p.next()
+	}
+	return lic
+}
+
+// makeLicense creates the appropriate license type based on the identifier:
+// NONE and NOASSERTION return appropriate values
+// LicenseRef-* and DocumentRef-* identifiers produce CustomLicense, all others produce ListedLicense.
+func makeLicense(ident string) AnyLicenseInfo {
+	switch {
+	case strings.EqualFold(ident, "NONE"):
+		return IndividualLicensingInfo_NoneLicense
+	case strings.EqualFold(ident, "NOASSERTION"):
+		return IndividualLicensingInfo_NoAssertionLicense
+	case strings.HasPrefix(ident, "LicenseRef-") || strings.HasPrefix(ident, "DocumentRef-"):
+		return &CustomLicense{ID: ident}
+	case invalidIdentifier(ident):
+		return nil // operators are not allowed as licenses, e.g. "MIT OR OR", or other malformed expression
+	}
+	// it's possible we should set the ID to ID: fmt.Sprintf("https://spdx.org/licenses/%s", ident) but for now
+	// we do not set the license ID to avoid a user editing shared objects and unexpectedly affecting an entire graph
+	return &ListedLicense{Name: ident}
+}
+
+// makeAddition creates the license addition based on the identifier:
+// AdditionRef-*, LicenseRef-*, and DocumentRef-* identifiers produce CustomLicenseAddition, all others produce ListedLicenseException.
+func makeAddition(ident string) AnyLicenseAddition {
+	switch {
+	case strings.HasPrefix(ident, "AdditionRef-") || strings.HasPrefix(ident, "LicenseRef-") || strings.HasPrefix(ident, "DocumentRef-"):
+		return &CustomLicenseAddition{ID: ident}
+	case invalidIdentifier(ident):
+		return nil
+	}
+	return &ListedLicenseException{Name: ident}
+}
+
+func opOr(tok string) bool {
+	return strings.EqualFold(tok, "or")
+}
+
+func opAnd(tok string) bool {
+	return strings.EqualFold(tok, "and")
+}
+
+func opWith(tok string) bool {
+	return strings.EqualFold(tok, "with")
+}
+
+func invalidIdentifier(tok string) bool {
+	return tok == "" || opOr(tok) || opAnd(tok) || opWith(tok) || tok == "(" || tok == ")" || tok == "+"
 }
 
 func isWhitespace(c byte) bool {
 	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v'
 }
 
-// peekKeyword checks if the next non-whitespace token is exactly the given keyword,
-// ensuring it is not part of a longer identifier.
-func (p *licenseParser) peekKeyword(keyword string) bool {
-	p.skipWhitespace()
-	end := p.pos + len(keyword)
-	if end > len(p.input) {
-		return false
-	}
-	if !strings.EqualFold(p.input[p.pos:end], keyword) {
-		return false
-	}
-	if end < len(p.input) && isIdentChar(p.input[end]) {
-		return false
-	}
-	return true
+type ParseError struct {
+	Position int
+	Token    string
+	Message  string
 }
 
-func (p *licenseParser) consumeKeyword(keyword string) {
-	p.skipWhitespace()
-	p.pos += len(keyword)
+type ParseErrors struct {
+	Expression string
+	Errors     []ParseError
 }
 
-// scanIdent reads an SPDX identifier: [a-zA-Z0-9.-]+
-// Also handles the DocumentRef-xxx:LicenseRef-xxx compound form.
-func (p *licenseParser) scanIdent() string {
-	p.skipWhitespace()
-	start := p.pos
-	for p.pos < len(p.input) && isIdentChar(p.input[p.pos]) {
-		p.pos++
+// collectErrs returns nil if there are no errors or a ParseErrors struct
+func collectErrs(p *licenseParser) error {
+	if len(p.errs) == 0 {
+		return nil
 	}
-	if p.pos == start {
-		return ""
+	return ParseErrors{
+		Expression: p.in,
+		Errors:     p.errs,
 	}
-	ident := p.input[start:p.pos]
-	// Handle DocumentRef-xxx:LicenseRef-xxx
-	if strings.HasPrefix(ident, "DocumentRef-") && p.pos < len(p.input) && p.input[p.pos] == ':' {
-		p.pos++ // consume ':'
-		for p.pos < len(p.input) && isIdentChar(p.input[p.pos]) {
-			p.pos++
-		}
-		ident = p.input[start:p.pos]
-	}
-	return ident
 }
 
-func isIdentChar(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.'
-}
-
-// makeLicense creates the appropriate license type based on the identifier prefix.
-// LicenseRef-* and DocumentRef-* identifiers produce CustomLicense, all others produce ListedLicense.
-func makeLicense(ident string) AnyLicense {
-	if strings.HasPrefix(ident, "LicenseRef-") || strings.HasPrefix(ident, "DocumentRef-") {
-		return &CustomLicense{ID: ident}
+// Error renders all parse errors against the full expression, with a caret
+// line under each error pointing at the offending token:
+//
+//	MIT OR (BLAH AND) OR OR
+//	                ^ unexpected token: )
+func (p ParseErrors) Error() string {
+	var b strings.Builder
+	b.WriteString(p.Expression)
+	for _, e := range p.Errors {
+		b.WriteByte('\n')
+		b.WriteString(strings.Repeat(" ", e.Position))
+		b.WriteString("^ ")
+		b.WriteString(e.Message)
+		b.WriteString(": ")
+		b.WriteString(e.Token)
 	}
-	return &ListedLicense{Name: ident}
-}
-
-// makeAddition creates the appropriate license addition type based on the identifier prefix.
-// AdditionRef-*, LicenseRef-*, and DocumentRef-* identifiers produce CustomLicenseAddition,
-// all others produce ListedLicenseException.
-func makeAddition(ident string) AnyLicenseAddition {
-	if strings.HasPrefix(ident, "AdditionRef-") || strings.HasPrefix(ident, "LicenseRef-") || strings.HasPrefix(ident, "DocumentRef-") {
-		return &CustomLicenseAddition{ID: ident}
-	}
-	return &ListedLicenseException{Name: ident}
+	return b.String()
 }

--- a/spdx/v3/v3_0/license_parser.go
+++ b/spdx/v3/v3_0/license_parser.go
@@ -2,8 +2,14 @@ package v3_0
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
+
+// licenseIdentifierChars matches the characters allowed in an SPDX license
+// identifier token: idstring characters (ALPHA / DIGIT / "-" / ".") plus ":"
+// used to separate the DocumentRef portion of an external reference.
+var licenseIdentifierChars = regexp.MustCompile(`^[A-Za-z0-9.:-]+$`)
 
 // ParseLicenseExpression parses an SPDX license expression string into the corresponding model types.
 // It handles AND, OR, WITH operators, the + (or-later) suffix, LicenseRef and DocumentRef references, and
@@ -199,16 +205,21 @@ func makeLicense(ident string) AnyLicenseInfo {
 	switch {
 	case strings.EqualFold(ident, "NONE"):
 		return IndividualLicensingInfo_NoneLicense
-	case strings.EqualFold(ident, "NOASSERTION"):
+	case strings.EqualFold(ident, NOASSERTION):
 		return IndividualLicensingInfo_NoAssertionLicense
 	case strings.HasPrefix(ident, "LicenseRef-") || strings.HasPrefix(ident, "DocumentRef-"):
-		return &CustomLicense{ID: ident}
+		return &CustomLicense{
+			ID: ident,
+		}
 	case invalidIdentifier(ident):
 		return nil // operators are not allowed as licenses, e.g. "MIT OR OR", or other malformed expression
 	}
 	// it's possible we should set the ID to ID: fmt.Sprintf("https://spdx.org/licenses/%s", ident) but for now
 	// we do not set the license ID to avoid a user editing shared objects and unexpectedly affecting an entire graph
-	return &ListedLicense{Name: ident}
+	// These will not have all the required information such as license Text
+	return &ListedLicense{
+		Name: ident,
+	}
 }
 
 // makeAddition creates the license addition based on the identifier:
@@ -216,11 +227,15 @@ func makeLicense(ident string) AnyLicenseInfo {
 func makeAddition(ident string) AnyLicenseAddition {
 	switch {
 	case strings.HasPrefix(ident, "AdditionRef-") || strings.HasPrefix(ident, "LicenseRef-") || strings.HasPrefix(ident, "DocumentRef-"):
-		return &CustomLicenseAddition{ID: ident}
+		return &CustomLicenseAddition{
+			ID: ident,
+		}
 	case invalidIdentifier(ident):
 		return nil
 	}
-	return &ListedLicenseException{Name: ident}
+	return &ListedLicenseException{
+		AdditionText: ident,
+	}
 }
 
 func opOr(tok string) bool {
@@ -236,7 +251,7 @@ func opWith(tok string) bool {
 }
 
 func invalidIdentifier(tok string) bool {
-	return tok == "" || opOr(tok) || opAnd(tok) || opWith(tok) || tok == "(" || tok == ")" || tok == "+"
+	return opOr(tok) || opAnd(tok) || opWith(tok) || !licenseIdentifierChars.MatchString(tok)
 }
 
 func isWhitespace(c byte) bool {

--- a/spdx/v3/v3_0/license_parser.go
+++ b/spdx/v3/v3_0/license_parser.go
@@ -1,0 +1,234 @@
+package v3_0
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseLicenseExpression parses an SPDX license expression string into the
+// corresponding model types. It handles AND, OR, WITH operators, the + (or-later)
+// suffix, LicenseRef and DocumentRef references, and parenthesized sub-expressions.
+//
+// Operator precedence (lowest to highest): OR, AND, WITH, + (or-later)
+//
+// Examples:
+//   - "MIT" → *ListedLicense
+//   - "MIT OR Apache-2.0" → *DisjunctiveLicenseSet
+//   - "MIT AND Apache-2.0" → *ConjunctiveLicenseSet
+//   - "GPL-2.0-only WITH Classpath-exception-2.0" → *WithAdditionOperator
+//   - "GPL-2.0-only+" → *OrLaterOperator wrapping *ListedLicense
+//   - "LicenseRef-custom" → *CustomLicense
+//   - "DocumentRef-ext:LicenseRef-custom" → *CustomLicense
+func ParseLicenseExpression(expression string) (AnyLicenseInfo, error) {
+	p := &licenseParser{input: strings.TrimSpace(expression)}
+	if len(p.input) == 0 {
+		return nil, fmt.Errorf("empty license expression")
+	}
+	result, err := p.parseOr()
+	if err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+	if p.pos < len(p.input) {
+		return nil, fmt.Errorf("unexpected token at position %d: %q", p.pos, p.remaining())
+	}
+	return result, nil
+}
+
+type licenseParser struct {
+	input string
+	pos   int
+}
+
+func (p *licenseParser) remaining() string {
+	if p.pos >= len(p.input) {
+		return ""
+	}
+	return p.input[p.pos:]
+}
+
+// parseOr handles: and-expr ("OR" and-expr)*
+// Flattens consecutive OR operands into a single DisjunctiveLicenseSet.
+func (p *licenseParser) parseOr() (AnyLicenseInfo, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+
+	members := LicenseInfoList{left}
+	for p.peekKeyword("OR") {
+		p.consumeKeyword("OR")
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		members = append(members, right)
+	}
+
+	if len(members) == 1 {
+		return left, nil
+	}
+	return &DisjunctiveLicenseSet{Members: members}, nil
+}
+
+// parseAnd handles: with-expr ("AND" with-expr)*
+// Flattens consecutive AND operands into a single ConjunctiveLicenseSet.
+func (p *licenseParser) parseAnd() (AnyLicenseInfo, error) {
+	left, err := p.parseWith()
+	if err != nil {
+		return nil, err
+	}
+
+	members := LicenseInfoList{left}
+	for p.peekKeyword("AND") {
+		p.consumeKeyword("AND")
+		right, err := p.parseWith()
+		if err != nil {
+			return nil, err
+		}
+		members = append(members, right)
+	}
+
+	if len(members) == 1 {
+		return left, nil
+	}
+	return &ConjunctiveLicenseSet{Members: members}, nil
+}
+
+// parseWith handles: simple-expr ("WITH" exception-id)?
+func (p *licenseParser) parseWith() (AnyLicenseInfo, error) {
+	license, err := p.parseSimple()
+	if err != nil {
+		return nil, err
+	}
+
+	if !p.peekKeyword("WITH") {
+		return license, nil
+	}
+	p.consumeKeyword("WITH")
+
+	extendable, ok := license.(AnyExtendableLicense)
+	if !ok {
+		return nil, fmt.Errorf("WITH operator requires a simple license or or-later expression, got %T", license)
+	}
+
+	exceptionID := p.scanIdent()
+	if exceptionID == "" {
+		return nil, fmt.Errorf("expected license exception identifier after WITH at position %d", p.pos)
+	}
+
+	return &WithAdditionOperator{
+		SubjectExtendableLicense: extendable,
+		SubjectAddition:          makeAddition(exceptionID),
+	}, nil
+}
+
+// parseSimple handles: "(" expression ")" | license-id "+"? | license-ref
+func (p *licenseParser) parseSimple() (AnyLicenseInfo, error) {
+	p.skipWhitespace()
+
+	if p.pos >= len(p.input) {
+		return nil, fmt.Errorf("unexpected end of expression")
+	}
+
+	if p.input[p.pos] == '(' {
+		p.pos++
+		expr, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		p.skipWhitespace()
+		if p.pos >= len(p.input) || p.input[p.pos] != ')' {
+			return nil, fmt.Errorf("expected ')' at position %d", p.pos)
+		}
+		p.pos++
+		return expr, nil
+	}
+
+	ident := p.scanIdent()
+	if ident == "" {
+		return nil, fmt.Errorf("expected license identifier at position %d, got %q", p.pos, p.remaining())
+	}
+
+	// Check for or-later (+) suffix
+	if p.pos < len(p.input) && p.input[p.pos] == '+' {
+		p.pos++
+		return &OrLaterOperator{SubjectLicense: makeLicense(ident)}, nil
+	}
+
+	return makeLicense(ident), nil
+}
+
+func (p *licenseParser) skipWhitespace() {
+	for p.pos < len(p.input) && p.input[p.pos] == ' ' {
+		p.pos++
+	}
+}
+
+// peekKeyword checks if the next non-whitespace token is exactly the given keyword,
+// ensuring it is not part of a longer identifier.
+func (p *licenseParser) peekKeyword(keyword string) bool {
+	p.skipWhitespace()
+	end := p.pos + len(keyword)
+	if end > len(p.input) {
+		return false
+	}
+	if !strings.EqualFold(p.input[p.pos:end], keyword) {
+		return false
+	}
+	if end < len(p.input) && isIdentChar(p.input[end]) {
+		return false
+	}
+	return true
+}
+
+func (p *licenseParser) consumeKeyword(keyword string) {
+	p.skipWhitespace()
+	p.pos += len(keyword)
+}
+
+// scanIdent reads an SPDX identifier: [a-zA-Z0-9.-]+
+// Also handles the DocumentRef-xxx:LicenseRef-xxx compound form.
+func (p *licenseParser) scanIdent() string {
+	p.skipWhitespace()
+	start := p.pos
+	for p.pos < len(p.input) && isIdentChar(p.input[p.pos]) {
+		p.pos++
+	}
+	if p.pos == start {
+		return ""
+	}
+	ident := p.input[start:p.pos]
+	// Handle DocumentRef-xxx:LicenseRef-xxx
+	if strings.HasPrefix(ident, "DocumentRef-") && p.pos < len(p.input) && p.input[p.pos] == ':' {
+		p.pos++ // consume ':'
+		for p.pos < len(p.input) && isIdentChar(p.input[p.pos]) {
+			p.pos++
+		}
+		ident = p.input[start:p.pos]
+	}
+	return ident
+}
+
+func isIdentChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.'
+}
+
+// makeLicense creates the appropriate license type based on the identifier prefix.
+// LicenseRef-* and DocumentRef-* identifiers produce CustomLicense, all others produce ListedLicense.
+func makeLicense(ident string) AnyLicense {
+	if strings.HasPrefix(ident, "LicenseRef-") || strings.HasPrefix(ident, "DocumentRef-") {
+		return &CustomLicense{ID: ident}
+	}
+	return &ListedLicense{Name: ident}
+}
+
+// makeAddition creates the appropriate license addition type based on the identifier prefix.
+// AdditionRef-*, LicenseRef-*, and DocumentRef-* identifiers produce CustomLicenseAddition,
+// all others produce ListedLicenseException.
+func makeAddition(ident string) AnyLicenseAddition {
+	if strings.HasPrefix(ident, "AdditionRef-") || strings.HasPrefix(ident, "LicenseRef-") || strings.HasPrefix(ident, "DocumentRef-") {
+		return &CustomLicenseAddition{ID: ident}
+	}
+	return &ListedLicenseException{Name: ident}
+}

--- a/spdx/v3/v3_0/license_parser_test.go
+++ b/spdx/v3/v3_0/license_parser_test.go
@@ -1,0 +1,274 @@
+package v3_0
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestParseLicenseExpression(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		want       AnyLicenseInfo
+		wantErr    bool
+	}{
+		{
+			name:       "simple license",
+			expression: "MIT",
+			want:       &ListedLicense{Name: "MIT"},
+		},
+		{
+			name:       "license with dots",
+			expression: "Apache-2.0",
+			want:       &ListedLicense{Name: "Apache-2.0"},
+		},
+		{
+			name:       "LicenseRef",
+			expression: "LicenseRef-custom-1.0",
+			want:       &CustomLicense{ID: "LicenseRef-custom-1.0"},
+		},
+		{
+			name:       "DocumentRef",
+			expression: "DocumentRef-ext:LicenseRef-custom",
+			want:       &CustomLicense{ID: "DocumentRef-ext:LicenseRef-custom"},
+		},
+		{
+			name:       "or later",
+			expression: "GPL-2.0-only+",
+			want: &OrLaterOperator{
+				SubjectLicense: &ListedLicense{Name: "GPL-2.0-only"},
+			},
+		},
+		{
+			name:       "OR",
+			expression: "MIT OR Apache-2.0",
+			want: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&ListedLicense{Name: "Apache-2.0"},
+				},
+			},
+		},
+		{
+			name:       "AND",
+			expression: "MIT AND Apache-2.0",
+			want: &ConjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&ListedLicense{Name: "Apache-2.0"},
+				},
+			},
+		},
+		{
+			name:       "WITH",
+			expression: "GPL-2.0-only WITH Classpath-exception-2.0",
+			want: &WithAdditionOperator{
+				SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
+				SubjectAddition:          &ListedLicenseException{Name: "Classpath-exception-2.0"},
+			},
+		},
+		{
+			name:       "WITH custom addition",
+			expression: "MIT WITH AdditionRef-my-exception",
+			want: &WithAdditionOperator{
+				SubjectExtendableLicense: &ListedLicense{Name: "MIT"},
+				SubjectAddition:          &CustomLicenseAddition{ID: "AdditionRef-my-exception"},
+			},
+		},
+		{
+			name:       "or later with exception",
+			expression: "GPL-2.0-only+ WITH Classpath-exception-2.0",
+			want: &WithAdditionOperator{
+				SubjectExtendableLicense: &OrLaterOperator{
+					SubjectLicense: &ListedLicense{Name: "GPL-2.0-only"},
+				},
+				SubjectAddition: &ListedLicenseException{Name: "Classpath-exception-2.0"},
+			},
+		},
+		{
+			name:       "flattened OR",
+			expression: "MIT OR Apache-2.0 OR BSD-3-Clause",
+			want: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&ListedLicense{Name: "Apache-2.0"},
+					&ListedLicense{Name: "BSD-3-Clause"},
+				},
+			},
+		},
+		{
+			name:       "flattened AND",
+			expression: "MIT AND Apache-2.0 AND BSD-3-Clause",
+			want: &ConjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&ListedLicense{Name: "Apache-2.0"},
+					&ListedLicense{Name: "BSD-3-Clause"},
+				},
+			},
+		},
+		{
+			name:       "AND precedence over OR",
+			expression: "MIT OR Apache-2.0 AND BSD-3-Clause",
+			want: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&ConjunctiveLicenseSet{
+						Members: LicenseInfoList{
+							&ListedLicense{Name: "Apache-2.0"},
+							&ListedLicense{Name: "BSD-3-Clause"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "parentheses",
+			expression: "(MIT OR Apache-2.0) AND BSD-3-Clause",
+			want: &ConjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&DisjunctiveLicenseSet{
+						Members: LicenseInfoList{
+							&ListedLicense{Name: "MIT"},
+							&ListedLicense{Name: "Apache-2.0"},
+						},
+					},
+					&ListedLicense{Name: "BSD-3-Clause"},
+				},
+			},
+		},
+		{
+			name:       "complex nested parentheses",
+			expression: "(MIT or (Apache-2.0 or LicenseRef-MIT-modified)) and GPL-2.0-only",
+			want: &ConjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&DisjunctiveLicenseSet{
+						Members: LicenseInfoList{
+							&ListedLicense{Name: "MIT"},
+							&DisjunctiveLicenseSet{
+								Members: LicenseInfoList{
+									&ListedLicense{Name: "Apache-2.0"},
+									&CustomLicense{ID: "LicenseRef-MIT-modified"},
+								},
+							},
+						},
+					},
+					&ListedLicense{Name: "GPL-2.0-only"},
+				},
+			},
+		},
+		{
+			name:       "complex expression",
+			expression: "MIT AND (GPL-2.0-only WITH Classpath-exception-2.0 OR Apache-2.0) AND LicenseRef-custom",
+			want: &ConjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&DisjunctiveLicenseSet{
+						Members: LicenseInfoList{
+							&WithAdditionOperator{
+								SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
+								SubjectAddition:          &ListedLicenseException{Name: "Classpath-exception-2.0"},
+							},
+							&ListedLicense{Name: "Apache-2.0"},
+						},
+					},
+					&CustomLicense{ID: "LicenseRef-custom"},
+				},
+			},
+		},
+		{
+			name:       "extra whitespace",
+			expression: "  MIT   OR   Apache-2.0  ",
+			want: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&ListedLicense{Name: "Apache-2.0"},
+				},
+			},
+		},
+		// error cases
+		{
+			name:       "empty",
+			expression: "",
+			wantErr:    true,
+		},
+		{
+			name:       "just whitespace",
+			expression: "   ",
+			wantErr:    true,
+		},
+		{
+			name:       "unclosed paren",
+			expression: "(MIT",
+			wantErr:    true,
+		},
+		{
+			name:       "unexpected close paren",
+			expression: "MIT)",
+			wantErr:    true,
+		},
+		{
+			name:       "missing operand after OR",
+			expression: "MIT OR",
+			wantErr:    true,
+		},
+		{
+			name:       "missing operand after AND",
+			expression: "MIT AND",
+			wantErr:    true,
+		},
+		{
+			name:       "missing exception after WITH",
+			expression: "MIT WITH",
+			wantErr:    true,
+		},
+		{
+			name:       "double operator",
+			expression: "MIT OR OR Apache-2.0",
+			wantErr:    true,
+		},
+		{
+			name:       "leading operator",
+			expression: "OR MIT",
+			wantErr:    true,
+		},
+		{
+			name:       "trailing plus on group",
+			expression: "(MIT OR Apache-2.0)+",
+			wantErr:    true,
+		},
+	}
+
+	opts := cmp.Options{
+		cmpopts.IgnoreUnexported(
+			ListedLicense{},
+			CustomLicense{},
+			OrLaterOperator{},
+			DisjunctiveLicenseSet{},
+			ConjunctiveLicenseSet{},
+			WithAdditionOperator{},
+			ListedLicenseException{},
+			CustomLicenseAddition{},
+		),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseLicenseExpression(tt.expression)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q, got nil", tt.expression)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if d := cmp.Diff(tt.want, got, opts...); d != "" {
+				t.Errorf("ParseLicenseExpression(%q) mismatch (-want +got):\n%s", tt.expression, d)
+			}
+		})
+	}
+}

--- a/spdx/v3/v3_0/license_parser_test.go
+++ b/spdx/v3/v3_0/license_parser_test.go
@@ -1,10 +1,10 @@
 package v3_0
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,7 +13,7 @@ func TestParseLicenseExpression(t *testing.T) {
 		name       string
 		expression string
 		want       AnyLicenseInfo
-		wantErr    bool
+		wantErr    string
 	}{
 		{
 			name:       "simple license",
@@ -156,6 +156,21 @@ func TestParseLicenseExpression(t *testing.T) {
 			},
 		},
 		{
+			name:       "AND precedence over OR 2",
+			expression: "MIT AND Apache-2.0 OR BSD-3-Clause",
+			want: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ConjunctiveLicenseSet{
+						Members: LicenseInfoList{
+							&ListedLicense{Name: "MIT"},
+							&ListedLicense{Name: "Apache-2.0"},
+						},
+					},
+					&ListedLicense{Name: "BSD-3-Clause"},
+				},
+			},
+		},
+		{
 			name:       "parentheses",
 			expression: "(MIT OR Apache-2.0) AND BSD-3-Clause",
 			want: &ConjunctiveLicenseSet{
@@ -171,14 +186,26 @@ func TestParseLicenseExpression(t *testing.T) {
 			},
 		},
 		{
+			name:       "flatten nested parentheses",
+			expression: "(MIT or (Apache-2.0 or LicenseRef-MIT-modified)) or GPL-2.0-only",
+			want: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&ListedLicense{Name: "Apache-2.0"},
+					&CustomLicense{ID: "LicenseRef-MIT-modified"},
+					&ListedLicense{Name: "GPL-2.0-only"},
+				},
+			},
+		},
+		{
 			name:       "complex nested parentheses",
-			expression: "(MIT or (Apache-2.0 or LicenseRef-MIT-modified)) and GPL-2.0-only",
+			expression: "(MIT or (Apache-2.0 and LicenseRef-MIT-modified)) and GPL-2.0-only",
 			want: &ConjunctiveLicenseSet{
 				Members: LicenseInfoList{
 					&DisjunctiveLicenseSet{
 						Members: LicenseInfoList{
 							&ListedLicense{Name: "MIT"},
-							&DisjunctiveLicenseSet{
+							&ConjunctiveLicenseSet{
 								Members: LicenseInfoList{
 									&ListedLicense{Name: "Apache-2.0"},
 									&CustomLicense{ID: "LicenseRef-MIT-modified"},
@@ -265,8 +292,32 @@ func TestParseLicenseExpression(t *testing.T) {
 			},
 		},
 		{
-			// WITH binds tighter than OR, so the explicit grouping matches the
-			// default precedence.
+			name:       "WITH not grouped",
+			expression: "MIT OR GPL-2.0-only WITH Classpath-exception-2.0",
+			want: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&WithAdditionOperator{
+						SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
+						SubjectAddition:          &ListedLicenseException{Name: "Classpath-exception-2.0"},
+					},
+				},
+			},
+		},
+		{
+			name:       "WITH not grouped 2",
+			expression: "GPL-2.0-only WITH Classpath-exception-2.0 OR MIT",
+			want: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&WithAdditionOperator{
+						SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
+						SubjectAddition:          &ListedLicenseException{Name: "Classpath-exception-2.0"},
+					},
+					&ListedLicense{Name: "MIT"},
+				},
+			},
+		},
+		{
 			name:       "WITH inside paren-grouped OR",
 			expression: "MIT OR (GPL-2.0-only WITH Classpath-exception-2.0)",
 			want: &DisjunctiveLicenseSet{
@@ -283,102 +334,125 @@ func TestParseLicenseExpression(t *testing.T) {
 		{
 			name:       "empty",
 			expression: "",
-			wantErr:    true,
+			wantErr:    "empty",
 		},
 		{
 			name:       "just whitespace",
 			expression: "   ",
-			wantErr:    true,
+			wantErr:    "empty",
 		},
 		{
 			name:       "unclosed paren",
 			expression: "(MIT",
-			wantErr:    true,
+			wantErr:    "unclosed parenthesis",
 		},
 		{
 			name:       "unexpected close paren",
 			expression: "MIT)",
-			wantErr:    true,
+			wantErr:    "unexpected",
 		},
 		{
 			name:       "missing operand after OR",
 			expression: "MIT OR",
-			wantErr:    true,
+			wantErr:    "OR",
 		},
 		{
 			name:       "missing operand after AND",
 			expression: "MIT AND",
-			wantErr:    true,
+			wantErr:    "AND",
 		},
 		{
 			name:       "missing exception after WITH",
 			expression: "MIT WITH",
-			wantErr:    true,
+			wantErr:    "WITH",
 		},
 		{
 			name:       "double operator",
 			expression: "MIT OR OR Apache-2.0",
-			wantErr:    true,
+			wantErr:    "OR",
 		},
 		{
 			name:       "leading operator",
 			expression: "OR MIT",
-			wantErr:    true,
+			wantErr:    "OR",
+			want:       &ListedLicense{Name: "MIT"},
 		},
 		{
 			name:       "trailing plus on group",
 			expression: "(MIT OR Apache-2.0)+",
-			wantErr:    true,
+			wantErr:    "+",
 		},
 		{
 			// the exception side of WITH is a bare identifier; it cannot be parenthesized.
 			name:       "parenthesized exception",
 			expression: "MIT WITH (Classpath-exception-2.0)",
-			wantErr:    true,
+			wantErr:    "WITH",
 		},
 		{
 			// + is not allowed on the exception side; the trailing + is left as an
 			// unexpected token.
 			name:       "or-later suffix on exception",
 			expression: "MIT WITH GPL-2.0-only+",
-			wantErr:    true,
+			wantErr:    "+",
 		},
 		{
 			// WITH requires an extendable license; a license set is not extendable,
 			// so this fails the AnyExtendableLicense type assertion.
 			name:       "WITH applied to a license set",
 			expression: "(MIT OR Apache-2.0) WITH Classpath-exception-2.0",
-			wantErr:    true,
+			wantErr:    "WITH",
 		},
 		{
 			// a space before + detaches it from the identifier, leaving it as an
 			// unexpected trailing token.
 			name:       "space before or-later suffix",
 			expression: "MIT +",
-			wantErr:    true,
+			wantErr:    "whitespace",
 		},
 		{
 			name:       "empty parens",
 			expression: "()",
-			wantErr:    true,
+			wantErr:    "unexpected token",
+		},
+		{
+			name:       "empty parens after valid license",
+			expression: "MIT OR ()",
+			wantErr:    "unexpected token",
 		},
 		{
 			name:       "empty parens with whitespace",
 			expression: "( )",
-			wantErr:    true,
+			wantErr:    "unexpected token",
+		},
+		{
+			name:       "empty parens before license",
+			expression: "( ) OR MIT",
+			wantErr:    "unexpected token",
+			want:       &ListedLicense{Name: "MIT"},
+		},
+		{
+			name:       "no operators",
+			expression: "MIT GPL",
+			wantErr:    "unexpected trailing",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ParseLicenseExpression(tt.expression)
-			if tt.wantErr {
-				require.Errorf(t, err, "expected error for input %q, got nil", tt.expression)
-				return
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				// ensure we don't have cascading errors
+				require.Truef(t, len(strings.Split(err.Error(), "^")) < 3,
+					"expected error to avoid cascading but got %q", err.Error(),
+				)
+			} else {
+				require.NoError(t, err)
 			}
-			require.NoError(t, err)
-			d := cmp.Diff(tt.want, got, diffOpts()...)
-			require.Empty(t, d, "ParseLicenseExpression(%q) mismatch (-want +got):\n%s", tt.expression, d)
+			if tt.want != nil {
+				d := cmp.Diff(tt.want, got, diffOpts()...)
+				require.Empty(t, d, "ParseLicenseExpression(%q) mismatch (-want +got):\n%s", tt.expression, d)
+			}
 		})
 	}
 }
@@ -447,20 +521,6 @@ func TestConvert23LicenseExpressionResolvesNestedRefs(t *testing.T) {
 		},
 	}
 
-	opts := cmp.Options{
-		cmpopts.IgnoreUnexported(
-			ListedLicense{},
-			CustomLicense{},
-			OrLaterOperator{},
-			DisjunctiveLicenseSet{},
-			ConjunctiveLicenseSet{},
-			WithAdditionOperator{},
-			ListedLicenseException{},
-			CustomLicenseAddition{},
-			IndividualLicensingInfo{},
-		),
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &documentConverter{
@@ -470,7 +530,7 @@ func TestConvert23LicenseExpressionResolvesNestedRefs(t *testing.T) {
 				},
 			}
 			got := c.convert23licenseExpression(tt.expression)
-			d := cmp.Diff(tt.want, got, opts...)
+			d := cmp.Diff(tt.want, got, diffOpts()...)
 			require.Emptyf(t, d, "convert23licenseExpression(%q) mismatch (-want +got):\n%s", tt.expression, d)
 		})
 	}

--- a/spdx/v3/v3_0/license_parser_test.go
+++ b/spdx/v3/v3_0/license_parser_test.go
@@ -272,3 +272,96 @@ func TestParseLicenseExpression(t *testing.T) {
 		})
 	}
 }
+
+func TestConvert23LicenseExpressionResolvesNestedRefs(t *testing.T) {
+	// custom licenses registered by convert23license, as populated when the
+	// document's OtherLicenses are converted.
+	custom1 := &CustomLicense{ID: "LicenseRef-custom-1", Name: "Custom One", Text: "custom one text"}
+	custom2 := &CustomLicense{ID: "LicenseRef-custom-2", Name: "Custom Two", Text: "custom two text"}
+
+	tests := []struct {
+		name       string
+		expression string
+		want       AnyLicenseInfo
+	}{
+		{
+			name:       "ref nested in conjunctive and disjunctive sets",
+			expression: "MIT AND (Apache-2.0 OR LicenseRef-custom-1)",
+			want: &ConjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&DisjunctiveLicenseSet{
+						Members: LicenseInfoList{
+							&ListedLicense{Name: "Apache-2.0"},
+							custom1,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "multiple refs nested at different depths",
+			expression: "LicenseRef-custom-1 OR (MIT AND LicenseRef-custom-2)",
+			want: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					custom1,
+					&ConjunctiveLicenseSet{
+						Members: LicenseInfoList{
+							&ListedLicense{Name: "MIT"},
+							custom2,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "ref nested in or-later operator",
+			expression: "LicenseRef-custom-1+",
+			want: &OrLaterOperator{
+				SubjectLicense: custom1,
+			},
+		},
+		{
+			// the subject license is resolved; the addition is left untouched.
+			name:       "ref nested in with-addition operator",
+			expression: "LicenseRef-custom-1 WITH AdditionRef-custom",
+			want: &WithAdditionOperator{
+				SubjectExtendableLicense: custom1,
+				SubjectAddition:          &CustomLicenseAddition{ID: "AdditionRef-custom"},
+			},
+		},
+		{
+			name:       "unregistered ref left as placeholder",
+			expression: "LicenseRef-unknown",
+			want:       &CustomLicense{ID: "LicenseRef-unknown"},
+		},
+	}
+
+	opts := cmp.Options{
+		cmpopts.IgnoreUnexported(
+			ListedLicense{},
+			CustomLicense{},
+			OrLaterOperator{},
+			DisjunctiveLicenseSet{},
+			ConjunctiveLicenseSet{},
+			WithAdditionOperator{},
+			ListedLicenseException{},
+			CustomLicenseAddition{},
+		),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &documentConverter{
+				idMap: map[string]any{
+					custom1.ID: custom1,
+					custom2.ID: custom2,
+				},
+			}
+			got := c.convert23licenseExpression(tt.expression)
+			if d := cmp.Diff(tt.want, got, opts...); d != "" {
+				t.Errorf("convert23licenseExpression(%q) mismatch (-want +got):\n%s", tt.expression, d)
+			}
+		})
+	}
+}

--- a/spdx/v3/v3_0/license_parser_test.go
+++ b/spdx/v3/v3_0/license_parser_test.go
@@ -97,7 +97,7 @@ func TestParseLicenseExpression(t *testing.T) {
 			expression: "GPL-2.0-only WITH Classpath-exception-2.0",
 			want: &WithAdditionOperator{
 				SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
-				SubjectAddition:          &ListedLicenseException{Name: "Classpath-exception-2.0"},
+				SubjectAddition:          &ListedLicenseException{AdditionText: "Classpath-exception-2.0"},
 			},
 		},
 		{
@@ -115,7 +115,7 @@ func TestParseLicenseExpression(t *testing.T) {
 				SubjectExtendableLicense: &OrLaterOperator{
 					SubjectLicense: &ListedLicense{Name: "GPL-2.0-only"},
 				},
-				SubjectAddition: &ListedLicenseException{Name: "Classpath-exception-2.0"},
+				SubjectAddition: &ListedLicenseException{AdditionText: "Classpath-exception-2.0"},
 			},
 		},
 		{
@@ -227,7 +227,7 @@ func TestParseLicenseExpression(t *testing.T) {
 						Members: LicenseInfoList{
 							&WithAdditionOperator{
 								SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
-								SubjectAddition:          &ListedLicenseException{Name: "Classpath-exception-2.0"},
+								SubjectAddition:          &ListedLicenseException{AdditionText: "Classpath-exception-2.0"},
 							},
 							&ListedLicense{Name: "Apache-2.0"},
 						},
@@ -299,7 +299,7 @@ func TestParseLicenseExpression(t *testing.T) {
 					&ListedLicense{Name: "MIT"},
 					&WithAdditionOperator{
 						SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
-						SubjectAddition:          &ListedLicenseException{Name: "Classpath-exception-2.0"},
+						SubjectAddition:          &ListedLicenseException{AdditionText: "Classpath-exception-2.0"},
 					},
 				},
 			},
@@ -311,7 +311,7 @@ func TestParseLicenseExpression(t *testing.T) {
 				Members: LicenseInfoList{
 					&WithAdditionOperator{
 						SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
-						SubjectAddition:          &ListedLicenseException{Name: "Classpath-exception-2.0"},
+						SubjectAddition:          &ListedLicenseException{AdditionText: "Classpath-exception-2.0"},
 					},
 					&ListedLicense{Name: "MIT"},
 				},
@@ -325,7 +325,7 @@ func TestParseLicenseExpression(t *testing.T) {
 					&ListedLicense{Name: "MIT"},
 					&WithAdditionOperator{
 						SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
-						SubjectAddition:          &ListedLicenseException{Name: "Classpath-exception-2.0"},
+						SubjectAddition:          &ListedLicenseException{AdditionText: "Classpath-exception-2.0"},
 					},
 				},
 			},
@@ -523,11 +523,10 @@ func TestConvert23LicenseExpressionResolvesNestedRefs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &documentConverter{
-				idMap: map[string]any{
-					custom1.ID: custom1,
-					custom2.ID: custom2,
-				},
+			c := newDocumentConverter(&Document{})
+			c.idMap = map[string]any{
+				custom1.ID: custom1,
+				custom2.ID: custom2,
 			}
 			got := c.convert23licenseExpression(tt.expression)
 			d := cmp.Diff(tt.want, got, diffOpts()...)

--- a/spdx/v3/v3_0/license_parser_test.go
+++ b/spdx/v3/v3_0/license_parser_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseLicenseExpression(t *testing.T) {
@@ -228,6 +229,56 @@ func TestParseLicenseExpression(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "or-later combined with conjunction and grouped or-later",
+			expression: "MIT+ AND Apache-2.0+ and (MIT OR GPL-2.0-only+) AND BSD-3-Clause",
+			want: &ConjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&OrLaterOperator{SubjectLicense: &ListedLicense{Name: "MIT"}},
+					&OrLaterOperator{SubjectLicense: &ListedLicense{Name: "Apache-2.0"}},
+					&DisjunctiveLicenseSet{
+						Members: LicenseInfoList{
+							&ListedLicense{Name: "MIT"},
+							&OrLaterOperator{SubjectLicense: &ListedLicense{Name: "GPL-2.0-only"}},
+						},
+					},
+					&ListedLicense{Name: "BSD-3-Clause"},
+				},
+			},
+		},
+		{
+			// makeAddition's AdditionRef- prefix handling on the addition side,
+			// with a LicenseRef as the extendable subject.
+			name:       "WITH on a LicenseRef with AdditionRef",
+			expression: "LicenseRef-MyLic WITH AdditionRef-MyExc",
+			want: &WithAdditionOperator{
+				SubjectExtendableLicense: &CustomLicense{ID: "LicenseRef-MyLic"},
+				SubjectAddition:          &CustomLicenseAddition{ID: "AdditionRef-MyExc"},
+			},
+		},
+		{
+			// the colon-aware ident scanner cooperates with the + suffix.
+			name:       "DocumentRef with or-later suffix",
+			expression: "DocumentRef-ext:LicenseRef-foo+",
+			want: &OrLaterOperator{
+				SubjectLicense: &CustomLicense{ID: "DocumentRef-ext:LicenseRef-foo"},
+			},
+		},
+		{
+			// WITH binds tighter than OR, so the explicit grouping matches the
+			// default precedence.
+			name:       "WITH inside paren-grouped OR",
+			expression: "MIT OR (GPL-2.0-only WITH Classpath-exception-2.0)",
+			want: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&WithAdditionOperator{
+						SubjectExtendableLicense: &ListedLicense{Name: "GPL-2.0-only"},
+						SubjectAddition:          &ListedLicenseException{Name: "Classpath-exception-2.0"},
+					},
+				},
+			},
+		},
 		// error cases
 		{
 			name:       "empty",
@@ -279,23 +330,55 @@ func TestParseLicenseExpression(t *testing.T) {
 			expression: "(MIT OR Apache-2.0)+",
 			wantErr:    true,
 		},
+		{
+			// the exception side of WITH is a bare identifier; it cannot be parenthesized.
+			name:       "parenthesized exception",
+			expression: "MIT WITH (Classpath-exception-2.0)",
+			wantErr:    true,
+		},
+		{
+			// + is not allowed on the exception side; the trailing + is left as an
+			// unexpected token.
+			name:       "or-later suffix on exception",
+			expression: "MIT WITH GPL-2.0-only+",
+			wantErr:    true,
+		},
+		{
+			// WITH requires an extendable license; a license set is not extendable,
+			// so this fails the AnyExtendableLicense type assertion.
+			name:       "WITH applied to a license set",
+			expression: "(MIT OR Apache-2.0) WITH Classpath-exception-2.0",
+			wantErr:    true,
+		},
+		{
+			// a space before + detaches it from the identifier, leaving it as an
+			// unexpected trailing token.
+			name:       "space before or-later suffix",
+			expression: "MIT +",
+			wantErr:    true,
+		},
+		{
+			name:       "empty parens",
+			expression: "()",
+			wantErr:    true,
+		},
+		{
+			name:       "empty parens with whitespace",
+			expression: "( )",
+			wantErr:    true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ParseLicenseExpression(tt.expression)
 			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error for input %q, got nil", tt.expression)
-				}
+				require.Errorf(t, err, "expected error for input %q, got nil", tt.expression)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if d := cmp.Diff(tt.want, got, diffOpts()...); d != "" {
-				t.Errorf("ParseLicenseExpression(%q) mismatch (-want +got):\n%s", tt.expression, d)
-			}
+			require.NoError(t, err)
+			d := cmp.Diff(tt.want, got, diffOpts()...)
+			require.Empty(t, d, "ParseLicenseExpression(%q) mismatch (-want +got):\n%s", tt.expression, d)
 		})
 	}
 }
@@ -387,9 +470,8 @@ func TestConvert23LicenseExpressionResolvesNestedRefs(t *testing.T) {
 				},
 			}
 			got := c.convert23licenseExpression(tt.expression)
-			if d := cmp.Diff(tt.want, got, opts...); d != "" {
-				t.Errorf("convert23licenseExpression(%q) mismatch (-want +got):\n%s", tt.expression, d)
-			}
+			d := cmp.Diff(tt.want, got, opts...)
+			require.Emptyf(t, d, "convert23licenseExpression(%q) mismatch (-want +got):\n%s", tt.expression, d)
 		})
 	}
 }

--- a/spdx/v3/v3_0/license_parser_test.go
+++ b/spdx/v3/v3_0/license_parser_test.go
@@ -35,6 +35,36 @@ func TestParseLicenseExpression(t *testing.T) {
 			want:       &CustomLicense{ID: "DocumentRef-ext:LicenseRef-custom"},
 		},
 		{
+			name:       "NONE",
+			expression: "NONE",
+			want:       IndividualLicensingInfo_NoneLicense,
+		},
+		{
+			name:       "NOASSERTION",
+			expression: "NOASSERTION",
+			want:       IndividualLicensingInfo_NoAssertionLicense,
+		},
+		{
+			name:       "NONE within expression",
+			expression: "MIT OR NONE",
+			want: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					IndividualLicensingInfo_NoneLicense,
+				},
+			},
+		},
+		{
+			name:       "NOASSERTION within expression",
+			expression: "MIT AND NOASSERTION",
+			want: &ConjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					IndividualLicensingInfo_NoAssertionLicense,
+				},
+			},
+		},
+		{
 			name:       "or later",
 			expression: "GPL-2.0-only+",
 			want: &OrLaterOperator{
@@ -188,6 +218,16 @@ func TestParseLicenseExpression(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "tabs and newlines",
+			expression: "\tMIT\n\tOR\r\n\tApache-2.0\t",
+			want: &DisjunctiveLicenseSet{
+				Members: LicenseInfoList{
+					&ListedLicense{Name: "MIT"},
+					&ListedLicense{Name: "Apache-2.0"},
+				},
+			},
+		},
 		// error cases
 		{
 			name:       "empty",
@@ -241,19 +281,6 @@ func TestParseLicenseExpression(t *testing.T) {
 		},
 	}
 
-	opts := cmp.Options{
-		cmpopts.IgnoreUnexported(
-			ListedLicense{},
-			CustomLicense{},
-			OrLaterOperator{},
-			DisjunctiveLicenseSet{},
-			ConjunctiveLicenseSet{},
-			WithAdditionOperator{},
-			ListedLicenseException{},
-			CustomLicenseAddition{},
-		),
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ParseLicenseExpression(tt.expression)
@@ -266,7 +293,7 @@ func TestParseLicenseExpression(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if d := cmp.Diff(tt.want, got, opts...); d != "" {
+			if d := cmp.Diff(tt.want, got, diffOpts()...); d != "" {
 				t.Errorf("ParseLicenseExpression(%q) mismatch (-want +got):\n%s", tt.expression, d)
 			}
 		})
@@ -347,6 +374,7 @@ func TestConvert23LicenseExpressionResolvesNestedRefs(t *testing.T) {
 			WithAdditionOperator{},
 			ListedLicenseException{},
 			CustomLicenseAddition{},
+			IndividualLicensingInfo{},
 		),
 	}
 

--- a/spdx/v3/v3_0/spdx.go
+++ b/spdx/v3/v3_0/spdx.go
@@ -101,11 +101,6 @@ func (d *Document) Validate(setCreationInfo bool) error {
 	return ld.ValidateGraph(d.SpdxDocument)
 }
 
-//func (d *Document) Append(e ...AnyElement) {
-//	d.SpdxDocument.Elements = append(d.SpdxDocument.Elements, e...)
-//	d.SpdxDocument.RootElements = append(d.SpdxDocument.RootElements, e...)
-//}
-
 // ToJSON first processes the document by:
 //   - setting each Element's CreationInfo property to the SpdxDocument's CreationInfo if nil
 //   - collecting all element references to the top-level Elements slice
@@ -116,8 +111,10 @@ func (d *Document) ToJSON(writer io.Writer) error {
 	// all Elements need to have creationInfo set...
 	d.setCreationInfo(d.SpdxDocument.CreationInfo, &d.SpdxDocument)
 
-	// ensure the Elements are in the root Element list
-	d.ensureAllDocumentElements()
+	// The Elements list should not be serialized - the graph of the SpdxDocument includes all other properties, such as RootElements
+	elements := d.Elements
+	defer func() { d.Elements = elements }()
+	d.Elements = nil
 
 	if d.LDContext == nil {
 		d.LDContext = context()
@@ -195,34 +192,38 @@ func (d *Document) FromJSON(reader io.Reader) error {
 	for _, e := range graph {
 		if doc, ok := e.(*SpdxDocument); ok {
 			d.SpdxDocument = *doc
+
+			var allElements []AnyElement
+			for _, o := range graph {
+				// collect all graph elements except SpdxDocument itself
+				if el, ok := o.(AnyElement); ok && el != doc {
+					allElements = append(allElements, el)
+				}
+			}
+			d.Elements = allElements
+
 			return nil
 		}
 	}
 	return fmt.Errorf("no SPDX document found")
 }
 
-func (d *Document) ensureAllDocumentElements() {
-	all := map[reflect.Value]struct{}{}
-	for _, e := range d.Elements {
-		v := reflect.ValueOf(e)
-		if v.Kind() != reflect.Pointer {
-			panic(fmt.Sprintf("non-pointer type in elements: %#v", v))
-		}
-		all[v] = struct{}{}
-	}
-	all[reflect.ValueOf(d.SpdxDocument)] = struct{}{}
-	_ = ld.VisitObjectGraph(d.SpdxDocument, func(path []any, value reflect.Value) error {
+// all elements in the Document should be available in the SpdxDocument.Elements proeprty --
+// on JSON LD deserialization, move all elements from @graph to the Elements property
+func collectAllElements(d *SpdxDocument) map[reflect.Value]AnyElement {
+	all := map[reflect.Value]AnyElement{}
+	all[reflect.ValueOf(d)] = d
+	_ = ld.VisitObjectGraph(d, func(path []any, value reflect.Value) error {
 		if value.Kind() == reflect.Pointer {
-			if _, ok := all[value]; ok {
-				return nil
-			}
-			if e, ok := value.Interface().(AnyElement); ok {
-				all[value] = struct{}{}
-				d.Elements = append(d.Elements, e)
+			if _, ok := all[value]; !ok {
+				if e, ok := value.Interface().(AnyElement); ok {
+					all[value] = e
+				}
 			}
 		}
 		return nil
 	})
+	return all
 }
 
 var _ interface {

--- a/spdx/v3/v3_0/spdx.go
+++ b/spdx/v3/v3_0/spdx.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -111,6 +113,14 @@ func (d *Document) ToJSON(writer io.Writer) error {
 	// all Elements need to have creationInfo set...
 	d.setCreationInfo(d.SpdxDocument.CreationInfo, &d.SpdxDocument)
 
+	// all element collections need to have all contained elements in the Elements property
+	for _, e := range collectAllElements(&d.SpdxDocument) {
+		if collection, ok := e.(AnyElementCollection); ok {
+			// collect all unique elements in the collection graph and set in the elements property
+			collection.SetElements(slices.Collect(maps.Values(collectAllElements(collection))))
+		}
+	}
+
 	// The Elements list should not be serialized - the graph of the SpdxDocument includes all other properties, such as RootElements
 	elements := d.Elements
 	defer func() { d.Elements = elements }()
@@ -208,11 +218,11 @@ func (d *Document) FromJSON(reader io.Reader) error {
 	return fmt.Errorf("no SPDX document found")
 }
 
-// all elements in the Document should be available in the SpdxDocument.Elements proeprty --
-// on JSON LD deserialization, move all elements from @graph to the Elements property
-func collectAllElements(d *SpdxDocument) map[reflect.Value]AnyElement {
+// collectAllElements collects all elements referenced by the element collection, except the collection itself
+func collectAllElements(d AnyElementCollection) map[reflect.Value]AnyElement {
 	all := map[reflect.Value]AnyElement{}
-	all[reflect.ValueOf(d)] = d
+	v := reflect.ValueOf(d)
+	all[v] = d
 	_ = ld.VisitObjectGraph(d, func(path []any, value reflect.Value) error {
 		if value.Kind() == reflect.Pointer {
 			if _, ok := all[value]; !ok {
@@ -223,6 +233,7 @@ func collectAllElements(d *SpdxDocument) map[reflect.Value]AnyElement {
 		}
 		return nil
 	})
+	delete(all, v)
 	return all
 }
 

--- a/spdx/v3/v3_0/spdx.go
+++ b/spdx/v3/v3_0/spdx.go
@@ -5,9 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
-	"reflect"
-	"slices"
 	"strings"
 	"time"
 
@@ -15,12 +12,13 @@ import (
 	"github.com/spdx/tools-golang/spdx/v3/internal/ld"
 )
 
-/*
-SPDX 3 models and serialization code is generated from internal/generate/main.go
-To regenerate all models, run: make generate
-*/
+// SPDX 3 model and serialization code is generated from internal/generate/main.go
+// To regenerate all models, run: make generate
 
-const Version = "3.0.1" // TODO is there a way to ascertain this version from generated code programmatically?
+const (
+	Version     = "3.0.1" // TODO is there a way to ascertain this version from generated code programmatically?
+	NOASSERTION = "NOASSERTION"
+)
 
 type Document struct {
 	SpdxDocument
@@ -95,31 +93,45 @@ func conformanceFrom(conformance ProfileIdentifierType) []ProfileIdentifierType 
 	return out
 }
 
-func (d *Document) Validate(setCreationInfo bool) error {
-	if setCreationInfo {
-		// all Elements need to have creationInfo set...
-		d.setCreationInfo(d.SpdxDocument.CreationInfo, &d.SpdxDocument)
+// Validate will validate the full SPDX document, optionally applying the same pre-processing that ToJSON performs to fill
+// in missing CreationInfo and other data
+func (d *Document) Validate(preProcess bool) error {
+	if preProcess {
+		// do all
+		_ = d.ToJSON(io.Discard)
 	}
 	return ld.ValidateGraph(d.SpdxDocument)
 }
 
 // ToJSON first processes the document by:
 //   - setting each Element's CreationInfo property to the SpdxDocument's CreationInfo if nil
-//   - collecting all element references to the top-level Elements slice
+//   - collecting every ElementCollection's object graph Element references to its Elements slice
+//   - filling known required fields with NOASSERTION or similar left empty by conversion from 2.3
 //
 // ... and after this initial processing, outputs the document as compact JSON LD,
 // including accounting for empty IDs by outputting blank node spdxId values
 func (d *Document) ToJSON(writer io.Writer) error {
-	// all Elements need to have creationInfo set...
-	d.setCreationInfo(d.SpdxDocument.CreationInfo, &d.SpdxDocument)
-
 	// all element collections need to have all contained elements in the Elements property
-	for _, e := range collectAllElements(&d.SpdxDocument) {
-		if collection, ok := e.(AnyElementCollection); ok {
-			// collect all unique elements in the collection graph and set in the elements property
-			collection.SetElements(slices.Collect(maps.Values(collectAllElements(collection))))
+	_ = ld.VisitObjectGraph(&d.SpdxDocument, func(path []any, e AnyElement) error {
+		// all elements need to have creationInfo set
+		if e.GetCreationInfo() == nil {
+			e.SetCreationInfo(d.CreationInfo)
 		}
-	}
+		switch e := e.(type) {
+		case AnyElementCollection:
+			// collect all unique elements in the collection graph and set in the Elements property
+			e.SetElements(collectAllElements(e))
+		case AnyLicense:
+			// licenses are frequently missing required fields: during 2.3 conversion we have to convert license expressions to a full object graph,
+			// not LicenseExpression because this is broken in 3.0 and only fixed in 3.1, which is not released. In 3.0 it cannot support
+			// CustomLicenses, which many expressions have, so we must use the expanded licensing model to properly capture this, but these do not
+			// have _text_, so we help users by filling these with NOASSERTION
+			if e.GetText() == "" {
+				e.SetText(NOASSERTION)
+			}
+		}
+		return nil
+	})
 
 	// The Elements list should not be serialized - the graph of the SpdxDocument includes all other properties, such as RootElements
 	elements := d.Elements
@@ -176,21 +188,6 @@ func (d *Document) ToJSON(writer io.Writer) error {
 	return internal.ToJSON("https://spdx.org/rdf/3.0.1/spdx-context.jsonld", d.LDContext, &d.SpdxDocument, internal.PrefixedIdGenerator(documentPrefix, namespaceMap), writer)
 }
 
-func (d *Document) setCreationInfo(creationInfo AnyCreationInfo, doc *SpdxDocument) {
-	if creationInfo == nil {
-		return
-	}
-	creationInfoInterfaceType := reflect.TypeOf((*AnyCreationInfo)(nil)).Elem()
-	ci := reflect.ValueOf(creationInfo)
-	_ = ld.VisitObjectGraph(doc, func(path []any, value reflect.Value) error {
-		t := value.Type()
-		if t == creationInfoInterfaceType && value.IsNil() {
-			value.Set(ci)
-		}
-		return nil
-	})
-}
-
 func (d *Document) FromJSON(reader io.Reader) error {
 	if d.LDContext == nil {
 		d.LDContext = context()
@@ -218,37 +215,7 @@ func (d *Document) FromJSON(reader io.Reader) error {
 	return fmt.Errorf("no SPDX document found")
 }
 
-// collectAllElements collects all elements referenced by the element collection, except the collection itself
-func collectAllElements(d AnyElementCollection) map[reflect.Value]AnyElement {
-	all := map[reflect.Value]AnyElement{}
-	v := reflect.ValueOf(d)
-	all[v] = d
-	_ = ld.VisitObjectGraph(d, func(path []any, value reflect.Value) error {
-		if value.Kind() == reflect.Pointer {
-			if _, ok := all[value]; !ok {
-				if e, ok := value.Interface().(AnyElement); ok {
-					all[value] = e
-				}
-			}
-		}
-		return nil
-	})
-	delete(all, v)
-	return all
-}
-
 var _ interface {
 	json.Marshaler
 	json.Unmarshaler
 } = (*Document)(nil)
-
-func notNil[T any, ListType ~[]T](values ListType) ListType {
-	var out ListType
-	for _, v := range values {
-		if isNil(v) {
-			continue
-		}
-		out = append(out, v)
-	}
-	return out
-}

--- a/spdx/v3/v3_0/spdx_serialization_test.go
+++ b/spdx/v3/v3_0/spdx_serialization_test.go
@@ -112,9 +112,7 @@ func Test_spdxExportImportExport(t *testing.T) {
 			}
 		}
 	}
-	if len(pkgs) != 2 {
-		t.Error("wrong packages returned")
-	}
+	require.Len(t, pkgs, 2)
 }
 
 func Test_stringSlice(t *testing.T) {
@@ -181,9 +179,7 @@ func encodeDecode[T AnyElement](t *testing.T, obj T) T {
 	}
 
 	diff := cmp.Diff(obj, got, diffOpts()...)
-	if diff != "" {
-		t.Fatal(diff)
-	}
+	require.Empty(t, diff)
 
 	return got
 }

--- a/spdx/v3/v3_0/spdx_test.go
+++ b/spdx/v3/v3_0/spdx_test.go
@@ -177,12 +177,6 @@ func Test_writer(t *testing.T) {
 	d2 := newTestDocument()
 	err = d2.FromJSON(&buf)
 	require.NoError(t, err)
-	// these would (correctly) cause a failure, to validate unexported and time fields are being properly checked:
-	//d2.RootElements.Packages().Views()[1].PrimaryPurpose = spdx.SoftwarePurpose_Archive
-	//_ = spdx.As(d2.CreationInfo, func(info *spdx.CreationInfo) error {
-	//	info.Created = info.Created.Add(time.Hour)
-	//	return nil
-	//})
 	diff := cmp.Diff(d.SpdxDocument, d2.SpdxDocument, diffOpts()...)
 	require.Empty(t, diff)
 }

--- a/spdx/v3/v3_0/spdx_test.go
+++ b/spdx/v3/v3_0/spdx_test.go
@@ -184,9 +184,7 @@ func Test_writer(t *testing.T) {
 	//	return nil
 	//})
 	diff := cmp.Diff(d.SpdxDocument, d2.SpdxDocument, diffOpts()...)
-	if diff != "" {
-		t.Fatal(diff)
-	}
+	require.Empty(t, diff)
 }
 
 func diffOpts() []cmp.Option {
@@ -382,9 +380,7 @@ func Test_exportImportExport(t *testing.T) {
 
 	buf := bytes.Buffer{}
 	err := doc.ToJSON(&buf)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	json1 := buf.String()
 
@@ -392,14 +388,11 @@ func Test_exportImportExport(t *testing.T) {
 
 	newDoc := newTestDocument()
 	err = newDoc.FromJSON(strings.NewReader(json1))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	// compare original to parsed -- this includes Element lists, etc.
-	if diff := cmp.Diff(doc, newDoc, diffOpts()...); diff != "" {
-		t.Errorf(diff)
-	}
+	diff := cmp.Diff(doc, newDoc, diffOpts()...)
+	require.Empty(t, diff)
 
 	// some basic usage:
 
@@ -417,9 +410,7 @@ func Test_exportImportExport(t *testing.T) {
 			}
 		}
 	}
-	if len(pkgs) != 2 {
-		t.Error("wrong packages returned")
-	}
+	require.Len(t, pkgs, 2)
 }
 
 func Test_aiProfile(t *testing.T) {
@@ -455,9 +446,7 @@ func Test_aiProfile(t *testing.T) {
 
 	buf := bytes.Buffer{}
 	err := doc.ToJSON(&buf)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	json1 := buf.String()
 
@@ -465,13 +454,10 @@ func Test_aiProfile(t *testing.T) {
 
 	newDoc := newTestDocument()
 	err = newDoc.FromJSON(strings.NewReader(json1))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
-	if diff := cmp.Diff(doc, newDoc, diffOpts()...); diff != "" {
-		t.Errorf(diff)
-	}
+	diff := cmp.Diff(doc, newDoc, diffOpts()...)
+	require.Empty(t, diff)
 }
 
 func newTestDocument() *spdx.Document {

--- a/spdx/v3/v3_0/spdx_test.go
+++ b/spdx/v3/v3_0/spdx_test.go
@@ -298,7 +298,7 @@ func Test_reader2(t *testing.T) {
 	  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
 	  "@graph": [
 		{ "type": "SpdxDocument",
-		  "element": [ "https://spdx.org/rdf/3.0.1/terms/Core/SpdxOrganization" ]
+		  "rootElement": [ "https://spdx.org/rdf/3.0.1/terms/Core/SpdxOrganization" ]
 		}
 	  ]
 	}`
@@ -306,9 +306,9 @@ func Test_reader2(t *testing.T) {
 	d := newTestDocument()
 	err := d.FromJSON(strings.NewReader(contents))
 	require.NoError(t, err)
-	require.Len(t, d.Elements, 1)
+	require.Len(t, d.RootElements, 1)
 	spdxOrgID, _ := ld.GetID(spdx.Organization_SpdxOrganization)
-	gotID, _ := ld.GetID(d.Elements[0])
+	gotID, _ := ld.GetID(d.RootElements[0])
 	require.Equal(t, spdxOrgID, gotID)
 }
 

--- a/spdx/v3/v3_0/spdx_test.go
+++ b/spdx/v3/v3_0/spdx_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pmezard/go-difflib/difflib"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spdx/tools-golang/spdx/v3/internal/ld"
@@ -239,6 +238,7 @@ func diffOpts() []cmp.Option {
 			spdx.AnnotationType{},
 			spdx.ProfileIdentifierType{},
 			spdx.ExternalIRI{},
+			spdx.EnergyUnitType{},
 		),
 	)
 	return out
@@ -396,27 +396,9 @@ func Test_exportImportExport(t *testing.T) {
 		t.Error(err)
 	}
 
-	// re-serialize
-
-	buf.Reset()
-	err = newDoc.ToJSON(&buf)
-	if err != nil {
-		t.Error(err)
-	}
-	json2 := buf.String()
-
-	// compare original to parsed and re-encoded
-
-	diff := difflib.UnifiedDiff{
-		A:        difflib.SplitLines(json1),
-		B:        difflib.SplitLines(json2),
-		FromFile: "Original",
-		ToFile:   "Current",
-		Context:  3,
-	}
-	text, _ := difflib.GetUnifiedDiffString(diff)
-	if text != "" {
-		t.Errorf("mismatch (-want +got):\n%s", text)
+	// compare original to parsed -- this includes Element lists, etc.
+	if diff := cmp.Diff(doc, newDoc, diffOpts()...); diff != "" {
+		t.Errorf(diff)
 	}
 
 	// some basic usage:
@@ -481,34 +463,14 @@ func Test_aiProfile(t *testing.T) {
 
 	// deserialize to a new document
 
-	doc = newTestDocument()
-	//doc.RootElements.Append(&spdx.Agent{})
-	err = doc.FromJSON(strings.NewReader(json1))
+	newDoc := newTestDocument()
+	err = newDoc.FromJSON(strings.NewReader(json1))
 	if err != nil {
 		t.Error(err)
 	}
 
-	// re-serialize
-
-	buf.Reset()
-	err = doc.ToJSON(&buf)
-	if err != nil {
-		t.Error(err)
-	}
-	json2 := buf.String()
-
-	// compare original to parsed and re-encoded
-
-	diff := difflib.UnifiedDiff{
-		A:        difflib.SplitLines(json1),
-		B:        difflib.SplitLines(json2),
-		FromFile: "Original",
-		ToFile:   "Current",
-		Context:  3,
-	}
-	text, _ := difflib.GetUnifiedDiffString(diff)
-	if text != "" {
-		t.Errorf("mismatch (-want +got):\n%s", text)
+	if diff := cmp.Diff(doc, newDoc, diffOpts()...); diff != "" {
+		t.Errorf(diff)
 	}
 }
 

--- a/spdx/v3/v3_0/util.go
+++ b/spdx/v3/v3_0/util.go
@@ -1,0 +1,56 @@
+package v3_0
+
+import "github.com/spdx/tools-golang/spdx/v3/internal/ld"
+
+// collectAllElements collects all elements referenced by the element collection, except the collection itself
+func collectAllElements(d AnyElementCollection) []AnyElement {
+	all := make(map[AnyElement]struct{}, 1024)
+	_ = ld.VisitObjectGraph(d, func(path []any, elem AnyElement) error {
+		if _, ok := all[elem]; !ok {
+			if elem == d {
+				return nil
+			}
+			all[elem] = struct{}{}
+		}
+		return nil
+	})
+	return mapKeys(all)
+}
+
+func mapKeys[T comparable, V any](all map[T]V) []T {
+	out := make([]T, len(all))
+	i := 0
+	nilCount := 0
+	for e := range all {
+		if isNil(e) {
+			nilCount++
+			continue
+		}
+		out[i] = e
+		i++
+	}
+	if nilCount > 0 {
+		return out[0 : len(out)-nilCount]
+	}
+	return out
+}
+
+func notNil[T any, ListType ~[]T](values ListType) ListType {
+	var out ListType
+	for i, v := range values {
+		if isNil(v) {
+			if out == nil {
+				out = make(ListType, i, len(values)-1)
+				copy(out, values[0:i])
+			}
+			continue
+		}
+		if out != nil {
+			out = append(out, v)
+		}
+	}
+	if out == nil {
+		return values
+	}
+	return out
+}

--- a/spdx/v3/v3_0/util_test.go
+++ b/spdx/v3/v3_0/util_test.go
@@ -1,0 +1,116 @@
+package v3_0
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_collectAllElements(t *testing.T) {
+	pkg := &Package{Name: "my-pkg"}
+	file := &File{Name: "main.go"}
+	rel := &Relationship{
+		From: pkg,
+		Type: RelationshipType_Contains,
+		To:   ElementList{file},
+	}
+
+	// a sub-collection nested within the SBOM, with its own element
+	bundlePkg := &Package{Name: "bundled-pkg"}
+	bundle := &Bundle{
+		RootElements: ElementList{bundlePkg},
+	}
+
+	sbom := &SBOM{
+		RootElements: ElementList{pkg, file, rel, bundle},
+	}
+
+	doc := &Document{
+		SpdxDocument: SpdxDocument{
+			RootElements: ElementList{sbom},
+		},
+	}
+
+	got := collectAllElements(&doc.SpdxDocument)
+
+	// everything reachable from the document graph, except the document collection itself
+	require.ElementsMatch(t, []AnyElement{sbom, pkg, file, rel, bundle, bundlePkg}, got)
+}
+
+func Test_mapKeys(t *testing.T) {
+	p1 := &Package{Name: "p1"}
+	p2 := &Package{Name: "p2"}
+
+	tests := []struct {
+		name string
+		in   map[any]struct{}
+		want []any
+	}{
+		{
+			name: "empty map",
+			in:   map[any]struct{}{},
+			want: []any{},
+		},
+		{
+			name: "string keys",
+			in:   map[any]struct{}{"a": {}, "b": {}, "c": {}},
+			want: []any{"a", "b", "c"},
+		},
+		{
+			name: "zero-value key is dropped",
+			in:   map[any]struct{}{"a": {}, "": {}, "b": {}},
+			want: []any{"a", "b"},
+		},
+		{
+			name: "nil pointer key is dropped",
+			in:   map[any]struct{}{p1: {}, (*Package)(nil): {}, p2: {}},
+			want: []any{p1, p2},
+		},
+		{
+			name: "all keys dropped",
+			in:   map[any]struct{}{"": {}, (*Package)(nil): {}},
+			want: []any{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapKeys(tt.in)
+			// map iteration order is not deterministic
+			require.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func Test_notNil(t *testing.T) {
+	p1 := &Package{Name: "p1"}
+	p2 := &Package{Name: "p2"}
+
+	t.Run("nil slice", func(t *testing.T) {
+		require.Nil(t, notNil[*Package, []*Package](nil))
+	})
+
+	t.Run("no nils returns input unchanged", func(t *testing.T) {
+		in := []*Package{p1, p2}
+		require.Equal(t, in, notNil(in))
+	})
+
+	t.Run("drops nil pointers, preserves order", func(t *testing.T) {
+		in := []*Package{p1, nil, p2}
+		require.Equal(t, []*Package{p1, p2}, notNil(in))
+	})
+
+	t.Run("drops leading nil", func(t *testing.T) {
+		in := []*Package{nil, p1, p2}
+		require.Equal(t, []*Package{p1, p2}, notNil(in))
+	})
+
+	t.Run("zero values treated as nil", func(t *testing.T) {
+		in := []string{"a", "", "b"}
+		require.Equal(t, []string{"a", "b"}, notNil(in))
+	})
+
+	t.Run("all nil yields empty", func(t *testing.T) {
+		in := []*Package{nil, nil}
+		require.Empty(t, notNil(in))
+	})
+}


### PR DESCRIPTION
This PR primarily corrects an issue where all licenses were converted from 2.3 to 3.0 as SimpleLicenses. Now, complex licenses are converted to the conjunctive/disjunctive license structures.

While working on this, I noticed tests were erroneously passing due to not comparing the `Elements` list. After discussion with implementors, it seems that Elements are where all elements should go which are not the direct subject of a collection and this should contain _all elements_ in collection's object graph. As an example, an SpdxDocument has Elements and RootElements, an SBOM would typically be the sole entry in the RootElements, the SBOM RootElements has a root package, say a package which represents the container. Relationships are added to the Elements list and this ends up being the only way to reference related packages and other related information. In addition to that, the Elements properties would contain the container package -- all the way up the object graph to the SpdxDocument.Element property. Now, any ElementCollection automatically has it's Elements collection flattened and deduplicated during serialization. These Element lists are also tested as part of the diffing process.