### PR TITLE
[EXP] Prototype: SPDX 3.0 → 2.3 backward conversion (packages, IDs, relationships, lossy handling)

### DIFF
--- a/spdx/v3/v3_0/convert_to_v23.go
+++ b/spdx/v3/v3_0/convert_to_v23.go
@@ -1,49 +1,185 @@
 package v3_0
 
 import (
-	"github.com/spdx/tools-golang/spdx/v2/common" 
-	"github.com/spdx/tools-golang/spdx/v2/v2_3"
 	"fmt"
+
+	"github.com/spdx/tools-golang/spdx/v2/common"
+	"github.com/spdx/tools-golang/spdx/v2/v2_3"
 )
 
-//we want conversion from v3.0 -> v2.3 for name specifically v3.GetName -> v2PackageName
+// ==============================
+// Conversion Context
+// ==============================
 
-// Extract Name from v3 package and place it in v2 package
+type ConversionContext struct {
+	idMap    map[string]common.ElementID
+	Counter  int
+	Warnings []string
+}
+
+func StartConversion() *ConversionContext {
+	return &ConversionContext{
+		idMap: make(map[string]common.ElementID),
+	}
+}
+
+// ==============================
+// Relationship Mapping
+// ==============================
+
+type RelationshipMapping struct {
+	V2Type  string
+	Reverse bool
+	ToField string
+}
+
+var relMap = map[string]RelationshipMapping{
+	// keys must match rel.Type.GetID()
+	"https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/dependsOn": {
+		V2Type: string(common.TypeRelationshipDependsOn),
+	},
+	"https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/contains": {
+		V2Type: string(common.TypeRelationshipContains),
+	},
+	// placeholder for N:1
+	"https://spdx.org/rdf/3.0.1/terms/Software/hasConcludedLicense": {
+		ToField: "PackageLicenseConcluded",
+	},
+}
+
+// ==============================
+// Package Conversion
+// ==============================
+
 func ConvertPackageNameToV23(p AnyPackage) *v2_3.Package {
 	if p == nil {
 		return nil
 	}
-	name := p.GetName()
+
 	return &v2_3.Package{
-		PackageName: name,
+		PackageName: p.GetName(),
 	}
 }
 
-//Extract V3ID -> Check mapping -> Generate NewID -> StoreMapping -> Assign To v2
-
-func ConvertPackageToV23(p AnyPackage, idMap map[string]common.ElementID, idx int) *v2_3.Package {
-	if p == nil {
+func ConvertPackageToV23(p AnyPackage, ctx *ConversionContext) *v2_3.Package {
+	if p == nil || ctx == nil {
 		return nil
 	}
 
 	v3ID := p.GetID()
 
-	// Check if already mapped
-	if existing, ok := idMap[v3ID]; ok {
+	if v3ID == "" {
+		ctx.Warnings = append(ctx.Warnings, "package missing ID")
+		return nil
+	}
+
+	if existing, ok := ctx.idMap[v3ID]; ok {
 		return &v2_3.Package{
 			PackageName:           p.GetName(),
 			PackageSPDXIdentifier: existing,
 		}
 	}
 
-	// Generate new SPDX ID
-	spdxID := fmt.Sprintf("SPDXRef-Package-%d", idx+1)
+	ctx.Counter++
+	spdxID := fmt.Sprintf("SPDXRef-Package-%d", ctx.Counter)
 
-	// Store mapping
-	idMap[v3ID] = common.ElementID(spdxID)
+	ctx.idMap[v3ID] = common.ElementID(spdxID)
 
 	return &v2_3.Package{
 		PackageName:           p.GetName(),
 		PackageSPDXIdentifier: common.ElementID(spdxID),
+	}
+}
+
+// ==============================
+// Relationship Conversion
+// ==============================
+
+func ConvertRelationshipToV23(rel *Relationship, ctx *ConversionContext) []*v2_3.Relationship {
+	if rel == nil || ctx == nil {
+		return nil
+	}
+
+	typeID := rel.Type.GetID()
+
+	mapping, ok := relMap[typeID]
+	if !ok {
+		ctx.Warnings = append(ctx.Warnings, "unsupported relationship: "+typeID)
+		return nil
+	}
+
+	fromID := rel.From.GetID()
+	if fromID == "" {
+		ctx.Warnings = append(ctx.Warnings, "relationship source missing ID")
+		return nil
+	}
+
+	v2From, ok := ctx.idMap[fromID]
+	if !ok {
+		ctx.Warnings = append(ctx.Warnings, "missing ID mapping for source: "+fromID)
+		return nil
+	}
+
+	var results []*v2_3.Relationship
+
+	for _, to := range rel.To {
+		toID := to.GetID()
+
+		if toID == "" {
+			ctx.Warnings = append(ctx.Warnings, "relationship target missing ID")
+			continue
+		}
+
+		v2To, ok := ctx.idMap[toID]
+		if !ok {
+			ctx.Warnings = append(ctx.Warnings, "missing ID mapping for target: "+toID)
+			continue
+		}
+
+		// N:1 placeholder
+		if mapping.ToField != "" {
+			ctx.Warnings = append(ctx.Warnings, "field mapping not implemented: "+typeID)
+			continue
+		}
+
+		src := v2From
+		dst := v2To
+
+		if mapping.Reverse {
+			src, dst = dst, src
+		}
+
+		results = append(results, &v2_3.Relationship{
+			RefA: common.DocElementID{
+				ElementRefID: src,
+			},
+			RefB: common.DocElementID{
+				ElementRefID: dst,
+			},
+			Relationship: mapping.V2Type,
+		})
+	}
+
+	return results
+}
+
+// ==============================
+// Warnings → Annotations
+// ==============================
+
+func ApplyWarningsAsAnnotations(doc *v2_3.Document, ctx *ConversionContext) {
+	if doc == nil || ctx == nil {
+		return
+	}
+
+	for _, w := range ctx.Warnings {
+		doc.Annotations = append(doc.Annotations, &v2_3.Annotation{
+			Annotator: common.Annotator{
+				Annotator:     "SPDX-Converter",
+				AnnotatorType: "Tool",
+			},
+			AnnotationType:    "OTHER",
+			AnnotationComment: "LOSSY: " + w,
+		})
 	}
 }

--- a/spdx/v3/v3_0/convert_to_v23.go
+++ b/spdx/v3/v3_0/convert_to_v23.go
@@ -1,0 +1,49 @@
+package v3_0
+
+import (
+	"github.com/spdx/tools-golang/spdx/v2/common" 
+	"github.com/spdx/tools-golang/spdx/v2/v2_3"
+	"fmt"
+)
+
+//we want conversion from v3.0 -> v2.3 for name specifically v3.GetName -> v2PackageName
+
+// Extract Name from v3 package and place it in v2 package
+func ConvertPackageNameToV23(p AnyPackage) *v2_3.Package {
+	if p == nil {
+		return nil
+	}
+	name := p.GetName()
+	return &v2_3.Package{
+		PackageName: name,
+	}
+}
+
+//Extract V3ID -> Check mapping -> Generate NewID -> StoreMapping -> Assign To v2
+
+func ConvertPackageToV23(p AnyPackage, idMap map[string]common.ElementID, idx int) *v2_3.Package {
+	if p == nil {
+		return nil
+	}
+
+	v3ID := p.GetID()
+
+	// Check if already mapped
+	if existing, ok := idMap[v3ID]; ok {
+		return &v2_3.Package{
+			PackageName:           p.GetName(),
+			PackageSPDXIdentifier: existing,
+		}
+	}
+
+	// Generate new SPDX ID
+	spdxID := fmt.Sprintf("SPDXRef-Package-%d", idx+1)
+
+	// Store mapping
+	idMap[v3ID] = common.ElementID(spdxID)
+
+	return &v2_3.Package{
+		PackageName:           p.GetName(),
+		PackageSPDXIdentifier: common.ElementID(spdxID),
+	}
+}

--- a/spdx/v3/v3_0/convert_to_v23_test.go
+++ b/spdx/v3/v3_0/convert_to_v23_test.go
@@ -1,0 +1,82 @@
+package v3_0
+
+import (
+	"testing"
+	"github.com/spdx/tools-golang/spdx/v2/common"
+)
+
+func TestConvertPackageNameToV23(t *testing.T) {
+
+	t.Run("basic name mapping", func(t *testing.T) {
+		pkg := &AIPackage{
+			ID:   "pkg-1",
+			Name: "example1",
+		}
+
+		result := ConvertPackageNameToV23(pkg)
+
+		if result == nil {
+			t.Fatalf("expected non-nil result")
+		}
+
+		if result.PackageName != "example1" {
+			t.Fatalf("expected 'example1', got '%s'", result.PackageName)
+		}
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		result := ConvertPackageNameToV23(nil)
+
+		if result != nil {
+			t.Fatalf("expected nil result for nil input")
+		}
+	})
+}
+
+func TestConvertV3ElementIDtoV2ElementID(t *testing.T) {
+
+	t.Run("basic ID mapping", func(t *testing.T) {
+		idMap := make(map[string]common.ElementID)
+
+		pkg := &AIPackage{
+			ID:   "pkg-1",
+			Name: "example",
+		}
+
+		result := ConvertPackageToV23(pkg, idMap, 0)
+
+		if result.PackageSPDXIdentifier != "SPDXRef-Package-1" {
+			t.Fatalf("expected SPDXRef-Package-1, got %s", result.PackageSPDXIdentifier)
+		}
+	})
+
+	t.Run("reuse existing ID mapping", func(t *testing.T) {
+		idMap := make(map[string]common.ElementID)
+
+		pkg := &AIPackage{
+			ID:   "pkg-1",
+			Name: "example",
+		}
+
+		first := ConvertPackageToV23(pkg, idMap, 0)
+		second := ConvertPackageToV23(pkg, idMap, 1)
+
+		if first.PackageSPDXIdentifier != second.PackageSPDXIdentifier {
+			t.Fatalf("expected same SPDXID, got %s and %s", first.PackageSPDXIdentifier, second.PackageSPDXIdentifier)
+		}
+	})
+
+	t.Run("multiple packages get unique IDs", func(t *testing.T) {
+		idMap := make(map[string]common.ElementID)
+
+		pkg1 := &AIPackage{ID: "pkg-1", Name: "one"}
+		pkg2 := &AIPackage{ID: "pkg-2", Name: "two"}
+
+		res1 := ConvertPackageToV23(pkg1, idMap, 0)
+		res2 := ConvertPackageToV23(pkg2, idMap, 1)
+
+		if res1.PackageSPDXIdentifier == res2.PackageSPDXIdentifier {
+			t.Fatalf("expected different SPDXIDs, got %s", res1.PackageSPDXIdentifier)
+		}
+	})
+}

--- a/spdx/v3/v3_0/convert_to_v23_test.go
+++ b/spdx/v3/v3_0/convert_to_v23_test.go
@@ -2,6 +2,7 @@ package v3_0
 
 import (
 	"testing"
+
 	"github.com/spdx/tools-golang/spdx/v2/common"
 )
 
@@ -33,33 +34,37 @@ func TestConvertPackageNameToV23(t *testing.T) {
 	})
 }
 
-func TestConvertV3ElementIDtoV2ElementID(t *testing.T) {
+func TestConvertPackageToV23(t *testing.T) {
 
 	t.Run("basic ID mapping", func(t *testing.T) {
-		idMap := make(map[string]common.ElementID)
+		ctx := StartConversion()
 
 		pkg := &AIPackage{
 			ID:   "pkg-1",
 			Name: "example",
 		}
 
-		result := ConvertPackageToV23(pkg, idMap, 0)
+		result := ConvertPackageToV23(pkg, ctx)
 
-		if result.PackageSPDXIdentifier != "SPDXRef-Package-1" {
+		if result == nil {
+			t.Fatalf("expected non-nil result")
+		}
+
+		if result.PackageSPDXIdentifier != common.ElementID("SPDXRef-Package-1") {
 			t.Fatalf("expected SPDXRef-Package-1, got %s", result.PackageSPDXIdentifier)
 		}
 	})
 
 	t.Run("reuse existing ID mapping", func(t *testing.T) {
-		idMap := make(map[string]common.ElementID)
+		ctx := StartConversion()
 
 		pkg := &AIPackage{
 			ID:   "pkg-1",
 			Name: "example",
 		}
 
-		first := ConvertPackageToV23(pkg, idMap, 0)
-		second := ConvertPackageToV23(pkg, idMap, 1)
+		first := ConvertPackageToV23(pkg, ctx)
+		second := ConvertPackageToV23(pkg, ctx)
 
 		if first.PackageSPDXIdentifier != second.PackageSPDXIdentifier {
 			t.Fatalf("expected same SPDXID, got %s and %s", first.PackageSPDXIdentifier, second.PackageSPDXIdentifier)
@@ -67,16 +72,35 @@ func TestConvertV3ElementIDtoV2ElementID(t *testing.T) {
 	})
 
 	t.Run("multiple packages get unique IDs", func(t *testing.T) {
-		idMap := make(map[string]common.ElementID)
+		ctx := StartConversion()
 
 		pkg1 := &AIPackage{ID: "pkg-1", Name: "one"}
 		pkg2 := &AIPackage{ID: "pkg-2", Name: "two"}
 
-		res1 := ConvertPackageToV23(pkg1, idMap, 0)
-		res2 := ConvertPackageToV23(pkg2, idMap, 1)
+		res1 := ConvertPackageToV23(pkg1, ctx)
+		res2 := ConvertPackageToV23(pkg2, ctx)
 
 		if res1.PackageSPDXIdentifier == res2.PackageSPDXIdentifier {
 			t.Fatalf("expected different SPDXIDs, got %s", res1.PackageSPDXIdentifier)
+		}
+	})
+
+	t.Run("missing ID should return nil", func(t *testing.T) {
+		ctx := StartConversion()
+
+		pkg := &AIPackage{
+			ID:   "",
+			Name: "invalid",
+		}
+
+		result := ConvertPackageToV23(pkg, ctx)
+
+		if result != nil {
+			t.Fatalf("expected nil for missing ID")
+		}
+
+		if len(ctx.Warnings) == 0 {
+			t.Fatalf("expected warning for missing ID")
 		}
 	})
 }


### PR DESCRIPTION
part of : #237

## Overview

This PR introduces an experimental prototype for SPDX 3.0 → 2.3 backward conversion within tools-golang.

The goal is not a complete transformation, but to explore a **controlled, lossy conversion strategy** between:

- SPDX 3.0 (graph-based model)
- SPDX 2.3 (document-based model)

This is intended as a **design exploration** and foundation for further discussion, not a final implementation.



## Motivation

SPDX 3.0 introduces a graph-based and modular model, while many existing tools and ecosystems still rely on SPDX 2.3.

A backward conversion layer enables:

- interoperability with legacy tooling
- gradual adoption of SPDX 3.0
- continued support for existing SBOM workflows

However, due to model differences:

> **a lossless transformation is not possible**

This PR explores a **controlled loss approach** instead.

---

## Key Design Decisions

### 1. ConversionContext (stateful conversion engine)

A shared `ConversionContext` is introduced to manage:

- `idMap`: mapping v3 element IDs → v2 SPDX IDs
- deterministic ID generation
- collection of warnings for lossy cases

**Why:**
SPDX 3.0 elements are graph nodes with reusable identities, while SPDX 2.3 requires document-scoped identifiers.  
A consistent mapping layer is required to preserve referential integrity.

---

### 2. Deterministic ID Mapping

Each v3 element is mapped to a stable v2 SPDX identifier:
