### PR TITLE
fix: update code for go-struct-converter release 0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version: '1.26'
       - name: Run tests
         run: make test
       - name: Send coverage report to coveralls

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.23'
       - name: Run tests
         run: make test
       - name: Send coverage report to coveralls

--- a/convert/chain.go
+++ b/convert/chain.go
@@ -13,7 +13,13 @@ import (
 	"github.com/spdx/tools-golang/spdx/v2/v2_3"
 )
 
-var DocumentChain = converter.NewFuncChain(v2_2.V2_1toV2_2, v2_3.V2_2toV2_3)
+func DocumentChain() converter.FuncChain {
+	return converter.NewFuncChain(
+		v2_2.From_v2_1, v2_2.To_v2_1,
+		v2_3.From_v2_2, v2_3.To_v2_2,
+		// for future v3.x to v3.y conversions, see funcChain.AutoPackageConverter()
+	)
+}
 
 // Document converts from one document to another document
 // For example, converting a document to the latest version could be done like:
@@ -30,5 +36,5 @@ func Document(from common.AnyDocument, to common.AnyDocument) error {
 		reflect.ValueOf(to).Elem().Set(reflect.ValueOf(from))
 		return nil
 	}
-	return DocumentChain.Convert(from, to)
+	return DocumentChain().Convert(from, to)
 }

--- a/convert/chain.go
+++ b/convert/chain.go
@@ -9,16 +9,11 @@ import (
 	converter "github.com/anchore/go-struct-converter"
 
 	"github.com/spdx/tools-golang/spdx/common"
-	"github.com/spdx/tools-golang/spdx/v2/v2_1"
 	"github.com/spdx/tools-golang/spdx/v2/v2_2"
 	"github.com/spdx/tools-golang/spdx/v2/v2_3"
 )
 
-var DocumentChain = converter.NewChain(
-	v2_1.Document{},
-	v2_2.Document{},
-	v2_3.Document{},
-)
+var DocumentChain = converter.NewFuncChain(v2_2.V2_1toV2_2, v2_3.V2_2toV2_3)
 
 // Document converts from one document to another document
 // For example, converting a document to the latest version could be done like:

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/spdx/tools-golang
 
-go 1.22
+go 1.26.4
 
 require (
-	github.com/anchore/go-struct-converter v0.1.0
+	github.com/anchore/go-struct-converter v0.2.1
 	github.com/google/go-cmp v0.7.0
-	github.com/spdx/gordf v0.0.0-20201111095634-7098f93598fb
+	github.com/spdx/gordf v0.0.0-20250128162952-000978ccd6fb
 	github.com/stretchr/testify v1.11.1
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spdx/tools-golang
 
-go 1.26.4
+go 1.23.0
 
 require (
 	github.com/anchore/go-struct-converter v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,13 @@
-github.com/anchore/go-struct-converter v0.1.0 h1:2rDRssAl6mgKBSLNiVCMADgZRhoqtw9dedlWa0OhD30=
-github.com/anchore/go-struct-converter v0.1.0/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
+github.com/anchore/go-struct-converter v0.2.1 h1:wdz5Oqi+bXXxvY667+NOwnncIOI1rp6QRORa5ERmFNk=
+github.com/anchore/go-struct-converter v0.2.1/go.mod h1:cDBA5vhcR62nXWo8QH9/Kk2807o65ISaHPNPX66L+Uw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/spdx/gordf v0.0.0-20201111095634-7098f93598fb h1:bLo8hvc8XFm9J47r690TUKBzcjSWdJDxmjXJZ+/f92U=
-github.com/spdx/gordf v0.0.0-20201111095634-7098f93598fb/go.mod h1:uKWaldnbMnjsSAXRurWqqrdyZen1R7kxl8TkmWk2OyM=
+github.com/spdx/gordf v0.0.0-20250128162952-000978ccd6fb h1:7G2Czq97VORM5xNRrD8tSQdhoXPRs8s+Otlc7st9TS0=
+github.com/spdx/gordf v0.0.0-20250128162952-000978ccd6fb/go.mod h1:uKWaldnbMnjsSAXRurWqqrdyZen1R7kxl8TkmWk2OyM=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=

--- a/spdx/v2/v2_1/document.go
+++ b/spdx/v2/v2_1/document.go
@@ -4,8 +4,6 @@
 package v2_1
 
 import (
-	converter "github.com/anchore/go-struct-converter"
-
 	"github.com/spdx/tools-golang/spdx/v2/common"
 )
 
@@ -70,10 +68,3 @@ type Document struct {
 	// DEPRECATED in version 2.0 of spec
 	Reviews []*Review `json:"-"`
 }
-
-func (d *Document) ConvertFrom(_ interface{}) error {
-	d.SPDXVersion = Version
-	return nil
-}
-
-var _ converter.ConvertFrom = (*Document)(nil)

--- a/spdx/v2/v2_2/document.go
+++ b/spdx/v2/v2_2/document.go
@@ -73,6 +73,14 @@ type Document struct {
 	Reviews []*Review `json:"-"`
 }
 
+func From_v2_1(_ v2_1.Document, d *Document) {
+	d.SPDXVersion = Version
+}
+
+func To_v2_1(_ Document, d *v2_1.Document) {
+	d.SPDXVersion = v2_1.Version
+}
+
 func (d *Document) UnmarshalJSON(b []byte) error {
 	type doc Document
 	type extras struct {
@@ -164,8 +172,3 @@ func (d *Document) UnmarshalJSON(b []byte) error {
 }
 
 var _ json.Unmarshaler = (*Document)(nil)
-
-func V2_1toV2_2(from v2_1.Document, to *Document) error {
-	to.SPDXVersion = Version
-	return nil
-}

--- a/spdx/v2/v2_2/document.go
+++ b/spdx/v2/v2_2/document.go
@@ -7,9 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	converter "github.com/anchore/go-struct-converter"
-
 	"github.com/spdx/tools-golang/spdx/v2/common"
+	"github.com/spdx/tools-golang/spdx/v2/v2_1"
 )
 
 const Version = "SPDX-2.2"
@@ -73,13 +72,6 @@ type Document struct {
 	// DEPRECATED in version 2.0 of spec
 	Reviews []*Review `json:"-"`
 }
-
-func (d *Document) ConvertFrom(_ interface{}) error {
-	d.SPDXVersion = Version
-	return nil
-}
-
-var _ converter.ConvertFrom = (*Document)(nil)
 
 func (d *Document) UnmarshalJSON(b []byte) error {
 	type doc Document
@@ -172,3 +164,8 @@ func (d *Document) UnmarshalJSON(b []byte) error {
 }
 
 var _ json.Unmarshaler = (*Document)(nil)
+
+func V2_1toV2_2(from v2_1.Document, to *Document) error {
+	to.SPDXVersion = Version
+	return nil
+}

--- a/spdx/v2/v2_2/example/example.go
+++ b/spdx/v2/v2_2/example/example.go
@@ -12,7 +12,7 @@ import (
 // Copy provides a deep copy of the example
 func Copy() spdx.Document {
 	out := spdx.Document{}
-	err := converter.Convert(example, &out)
+	err := converter.Clone(example, &out)
 	if err != nil {
 		panic(fmt.Errorf("unable to convert example doc: %w", err))
 	}

--- a/spdx/v2/v2_3/document.go
+++ b/spdx/v2/v2_3/document.go
@@ -7,9 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	converter "github.com/anchore/go-struct-converter"
-
 	"github.com/spdx/tools-golang/spdx/v2/common"
+	"github.com/spdx/tools-golang/spdx/v2/v2_2"
 )
 
 const Version = "SPDX-2.3"
@@ -72,13 +71,6 @@ type Document struct {
 	// DEPRECATED in version 2.0 of spec
 	Reviews []*Review `json:"-" yaml:"-"`
 }
-
-func (d *Document) ConvertFrom(_ interface{}) error {
-	d.SPDXVersion = Version
-	return nil
-}
-
-var _ converter.ConvertFrom = (*Document)(nil)
 
 func (d *Document) UnmarshalJSON(b []byte) error {
 	type doc Document
@@ -172,3 +164,8 @@ func (d *Document) UnmarshalJSON(b []byte) error {
 }
 
 var _ json.Unmarshaler = (*Document)(nil)
+
+func V2_2toV2_3(from v2_2.Document, to *Document) error {
+	to.SPDXVersion = Version
+	return nil
+}

--- a/spdx/v2/v2_3/document.go
+++ b/spdx/v2/v2_3/document.go
@@ -72,6 +72,14 @@ type Document struct {
 	Reviews []*Review `json:"-" yaml:"-"`
 }
 
+func From_v2_2(_ v2_2.Document, d *Document) {
+	d.SPDXVersion = Version
+}
+
+func To_v2_2(_ Document, d *v2_2.Document) {
+	d.SPDXVersion = v2_2.Version
+}
+
 func (d *Document) UnmarshalJSON(b []byte) error {
 	type doc Document
 	type extras struct {
@@ -164,8 +172,3 @@ func (d *Document) UnmarshalJSON(b []byte) error {
 }
 
 var _ json.Unmarshaler = (*Document)(nil)
-
-func V2_2toV2_3(from v2_2.Document, to *Document) error {
-	to.SPDXVersion = Version
-	return nil
-}

--- a/spdx/v2/v2_3/example/example.go
+++ b/spdx/v2/v2_3/example/example.go
@@ -12,7 +12,7 @@ import (
 // Copy provides a deep copy of the example
 func Copy() spdx.Document {
 	out := spdx.Document{}
-	err := converter.Convert(example, &out)
+	err := converter.Clone(example, &out)
 	if err != nil {
 		panic(fmt.Errorf("unable to convert example doc: %w", err))
 	}


### PR DESCRIPTION
## Describe your changes

This PR updates the code to adapt to the backward incompatible changes that came with relase [0.2.1](https://github.com/anchore/go-struct-converter/releases/tag/v0.2.1) from https://github.com/anchore/go-struct-converter/

## Tickets and links

Fixes #288
