### PR TITLE
Guard against a nil *Package when reading JSON

### DIFF
--- a/json/reader_test.go
+++ b/json/reader_test.go
@@ -28,3 +28,30 @@ func TestRead(t *testing.T) {
 		})
 	}
 }
+
+// TestReadNullPackage makes sure a document with a null entry in the packages
+// array doesn't panic. The custom unmarshaller walks d.Packages to build
+// hasFiles relationships, and a null element decodes to a nil *Package that
+// used to be dereferenced. This mirrors the null-relationships handling added
+// for #238.
+func TestReadNullPackage(t *testing.T) {
+	fixtures := []string{
+		"test_fixtures/spdx2_2_null_package.json",
+		"test_fixtures/spdx2_3_null_package.json",
+	}
+
+	for _, filename := range fixtures {
+		t.Run(filename, func(t *testing.T) {
+			file, err := os.Open(filename)
+			if err != nil {
+				t.Fatalf("error opening %s: %v", filename, err)
+			}
+			defer file.Close()
+
+			// Read must return cleanly here; before the nil guard it panicked.
+			if _, err = Read(file); err != nil {
+				t.Errorf("error reading %s: %v", filename, err)
+			}
+		})
+	}
+}

--- a/json/test_fixtures/spdx2_2_null_package.json
+++ b/json/test_fixtures/spdx2_2_null_package.json
@@ -1,0 +1,12 @@
+{
+  "SPDXID" : "SPDXRef-DOCUMENT",
+  "spdxVersion" : "SPDX-2.2",
+  "creationInfo" : {
+    "created" : "2023-07-18T12:27:48Z",
+    "creators" : [ "Tool: spdx-tools" ]
+  },
+  "name" : "null-package-doc",
+  "dataLicense" : "CC0-1.0",
+  "documentNamespace" : "test",
+  "packages" : [ null ]
+}

--- a/json/test_fixtures/spdx2_3_null_package.json
+++ b/json/test_fixtures/spdx2_3_null_package.json
@@ -1,0 +1,12 @@
+{
+  "SPDXID" : "SPDXRef-DOCUMENT",
+  "spdxVersion" : "SPDX-2.3",
+  "creationInfo" : {
+    "created" : "2023-07-18T12:27:48Z",
+    "creators" : [ "Tool: spdx-tools" ]
+  },
+  "name" : "null-package-doc",
+  "dataLicense" : "CC0-1.0",
+  "documentNamespace" : "test",
+  "packages" : [ null ]
+}

--- a/spdx/v2/v2_2/document.go
+++ b/spdx/v2/v2_2/document.go
@@ -151,6 +151,9 @@ func (d *Document) UnmarshalJSON(b []byte) error {
 
 	// build relationships for package hasFiles field
 	for _, p := range d.Packages {
+		if p == nil {
+			continue
+		}
 		for _, f := range p.hasFiles {
 			r := &Relationship{
 				RefA: common.DocElementID{

--- a/spdx/v2/v2_3/document.go
+++ b/spdx/v2/v2_3/document.go
@@ -151,6 +151,9 @@ func (d *Document) UnmarshalJSON(b []byte) error {
 	// build relationships for package hasFiles field
 	// build relationships for package hasFiles field
 	for _, p := range d.Packages {
+		if p == nil {
+			continue
+		}
 		for _, f := range p.hasFiles {
 			r := &Relationship{
 				RefA: common.DocElementID{


### PR DESCRIPTION
Reading a JSON document that has a null element in its packages array trips a nil-pointer panic rather than returning cleanly. A document like `{"packages":[null]}` decodes that element to a nil `*Package`, and the custom `Document` unmarshaller then walks `d.Packages` to build the hasFiles relationships and dereferences it.

Quick repro (panics on main): feed a minimal SPDX-2.3 or SPDX-2.2 doc whose `packages` is `[ null ]` through `json.Read`.

The reader already does the equivalent thing for relationships (the null-relationships strip added for #238), so this just extends the same idea to packages: skip nil entries in the hasFiles loop. I applied it to both v2_2 and v2_3 since they share the pattern, and added a fixture plus a test in the json package that asserts `Read` comes back without an error (it panicked before the guard).

`go test ./...` passes.