### PR TITLE
chore(maintainers): remove swinslow at his request

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,5 @@
 # spdx/tools-golang project maintainers
 #
 # GitHub ID, Name, Affiliation, Email address
-swinslow, Steve Winslow, NA, steve@swinslow.net
 RishabhBhatnagar, Rishabh Bhatnagar, media.net, bhatnagarrishabh4@gmail.com
 lumjjb, Brandon Lum, Google, lumjjb@gmail.com


### PR DESCRIPTION
Fixes #285

@swinslow asked in #285 to be taken off the `MAINTAINERS` file:

> The `MAINTAINERS` file still lists me as a maintainer. I should probably be removed from the file, as
> in all honesty I haven't contributed to maintaining the project for quite some time.

This PR does exactly that and nothing else.

Adding people in his place is deliberately left out — he mentioned @kzantow as a possible addition, but
who joins the file is the project's call, not something a drive-by PR should decide. Happy to amend this
PR with any names you want added, in one commit, if that is easier than a separate one.

AI-assisted (LLM used for drafting); the change is a single line and is mine.
